### PR TITLE
New storage of agents in the model (and new model type)

### DIFF
--- a/benchmark/forest_fire/forest_fire.jl
+++ b/benchmark/forest_fire/forest_fire.jl
@@ -10,7 +10,7 @@ mutable struct Tree{T<:Integer} <: AbstractAgent
   status::T  # 1 is green, 2 is burning, 3 is burned
 end
 
-mutable struct Forest{T<:AbstractSpace, Y<:AbstractVector, Z<:AbstractFloat} <: AbstractModel
+mutable struct Forest{T<:AbstractSpace, Y<:AbstractVector, Z<:AbstractFloat} <: ABM
   space::T
   agents::Y
   scheduler::Function

--- a/benchmark/forest_fire/run.jl
+++ b/benchmark/forest_fire/run.jl
@@ -9,7 +9,7 @@ nsteps = 100
 when = collect(1:nsteps);
 
 
-function counter(model::AbstractModel)
+function counter(model::ABM)
   on_fire = 0
   green = 0
   burned = 0

--- a/docs/src/boltzmann_example01.md
+++ b/docs/src/boltzmann_example01.md
@@ -17,7 +17,7 @@ Recall that Agents.jl structures simulations in three components: a _model_ comp
 Subtyping the model components in the following way will allow all the built-in functions to work on your defined types:
 
 * The agent type should be a subtype of `AbstractAgent`.
-* The model type should be a subtype of `AbstractModel`.
+* The model type should be a subtype of `ABM`.
 * The space type should be a subtype of `AbstractSpace`.
 
 At first in this example, we will not be using a spatial structure:
@@ -47,7 +47,7 @@ The agent type has to have the `id` field and a `pos` field for position (if a s
 
 ```julia
 "Define the model type."
-mutable struct MyModel{T<:AbstractVector} <: AbstractModel
+mutable struct MyModel{T<:AbstractVector} <: ABM
   "An array of agents."
   agents::T
   "A field for the scheduler function."
@@ -88,7 +88,7 @@ Define the agent step function.
 
 Defines what the agent should do at each step.
 """
-function agent_step!(agent::AbstractAgent, model::AbstractModel)
+function agent_step!(agent::AbstractAgent, model::ABM)
   # If the agent's wealth is zero, then do nothing.
   if agent.wealth == 0
     return
@@ -153,7 +153,7 @@ To that end, we will have to modify the model and agent types as well as write a
 
 ```julia
 "Define the model type."
-mutable struct MyModel{T<:AbstractVector} <: AbstractModel
+mutable struct MyModel{T<:AbstractVector} <: ABM
   "An array of agents."
   agents::T
   "A field for the scheduler function."
@@ -231,7 +231,7 @@ Define the agent step function.
 Defines what the agent should do at each step.
 
 """
-function agent_step!(agent::AbstractAgent, model::AbstractModel)
+function agent_step!(agent::AbstractAgent, model::ABM)
   # If the agent's wealth is zero, then do nothing.
   if agent.wealth == 0
     return

--- a/docs/src/forest_fire.md
+++ b/docs/src/forest_fire.md
@@ -23,7 +23,7 @@ mutable struct Tree{T<:Integer} <: AbstractAgent
   status::Bool  # true is green and false is burning
 end
 
-mutable struct Forest{T<:AbstractSpace, Y<:AbstractVector, Z<:AbstractFloat} <: AbstractModel
+mutable struct Forest{T<:AbstractSpace, Y<:AbstractVector, Z<:AbstractFloat} <: ABM
   space::T
   agents::Y
   scheduler::Function

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -18,7 +18,7 @@ With these, Agents.jl's tools manage the rest of the path to producing and proce
 
 ### The model
 ```@docs
-AbstractModel
+ABM
 ```
 The model type may not necessarily be a mutable type, it depends on your problem.
 ## The space
@@ -94,7 +94,7 @@ We added two more fields for this model, namely a `mood` field which will store 
 
 ### Defining the model type
 ```@example schelling
-mutable struct SchellingModel{S, F} <: AbstractModel
+mutable struct SchellingModel{S, F} <: ABM
   scheduler::F
   space::S
   agents::Vector{SchellingAgent}

--- a/examples/boltzmann_wealth_distribution.jl
+++ b/examples/boltzmann_wealth_distribution.jl
@@ -45,7 +45,7 @@ mutable struct MyAgent{T<:Integer} <: AbstractAgent
 end
 
 "Define the model type."
-mutable struct MyModel{T<:AbstractVector} <: AbstractModel
+mutable struct MyModel{T<:AbstractVector} <: ABM
   "An array of agents."
   agents::T
   "A field for the scheduler function."
@@ -69,7 +69,7 @@ Define the agent step function.
 
 Defines what the agent should do at each step.
 """
-function agent_step!(agent::AbstractAgent, model::AbstractModel)
+function agent_step!(agent::AbstractAgent, model::ABM)
   # If the agent's wealth is zero, then do nothing.
   if agent.wealth == 0
     return

--- a/examples/boltzmann_wealth_distribution_with_grid.jl
+++ b/examples/boltzmann_wealth_distribution_with_grid.jl
@@ -44,7 +44,7 @@ mutable struct MyAgent{T<:Integer} <: AbstractAgent
 end
 
 "Define the model type."
-mutable struct MyModel{A<:AbstractVector, S<:AbstractSpace} <: AbstractModel
+mutable struct MyModel{A<:AbstractVector, S<:AbstractSpace} <: ABM
   "A space dimension."
   space::S
   "An array of agents."
@@ -91,7 +91,7 @@ Define the agent step function.
 Defines what the agent should do at each step.
 
 """
-function agent_step!(agent::AbstractAgent, model::AbstractModel)
+function agent_step!(agent::AbstractAgent, model::ABM)
   # If the agent's wealth is zero, then do nothing.
   if agent.wealth == 0
     return

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -10,7 +10,7 @@ mutable struct Tree{T<:Integer} <: AbstractAgent
   status::Bool  # true is green and false is burning
 end
 
-mutable struct Forest{T<:AbstractSpace, Y<:AbstractVector, Z<:AbstractFloat} <: AbstractModel
+mutable struct Forest{T<:AbstractSpace, Y<:AbstractVector, Z<:AbstractFloat} <: ABM
   space::T
   agents::Y
   scheduler::Function

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -15,9 +15,9 @@ neighborhoods.
 using Agents
 
 # Create the agent, model, and grid types.
-"AbstractModel type for the Schelling Model"
-mutable struct SchellingModel{T<:Integer, Y<:AbstractArray, Z<:AbstractSpace} <: AbstractModel 
-  # Object should always be a subtype of AbstractModel.
+"ABM type for the Schelling Model"
+mutable struct SchellingModel{T<:Integer, Y<:AbstractArray, Z<:AbstractSpace} <: ABM 
+  # Object should always be a subtype of ABM.
   "A field of the model for a space object, always a subtype of AbstractSpace."
   space::Z 
   "A list of agents."

--- a/examples/schelling_distributed.jl
+++ b/examples/schelling_distributed.jl
@@ -17,8 +17,8 @@ addprocs(3)  # Add the number of parallel processing units
   group::T
 end
 
-@everywhere mutable struct SchellingModel{T<:Integer, Y<:AbstractArray, Z<:AbstractSpace} <: AbstractModel  # A model
-	# object should always be a subtype of AbstractModel
+@everywhere mutable struct SchellingModel{T<:Integer, Y<:AbstractArray, Z<:AbstractSpace} <: ABM  # A model
+	# object should always be a subtype of ABM
 	space::Z  # A space object, which is a field
 	# of the model object is always subtype of AbstractSpace
 	agents::Y  # a list of agents

--- a/src/CA1D.jl
+++ b/src/CA1D.jl
@@ -8,7 +8,7 @@ mutable struct Agent{T<:Integer, Y<:AbstractString} <: AbstractAgent
   status::Y
 end
 
-mutable struct Model{T<:AbstractVector, Y<:AbstractDict, X<:AbstractSpace} <: AbstractModel
+mutable struct Model{T<:AbstractVector, Y<:AbstractDict, X<:AbstractSpace} <: ABM
   space::X
   agents::T  #Array{AbstractAgent}
   scheduler::Function
@@ -64,11 +64,11 @@ function ca_step!(model)
 end
 
 # """
-#     ca_run(model::AbstractModel, runs::Integer, filename::String="CA_1D")
+#     ca_run(model::ABM, runs::Integer, filename::String="CA_1D")
 
 # Runs a 1D cellular automaton.
 # """
-# function ca_run(model::AbstractModel, runs::Integer, filename::String="CA_1D")
+# function ca_run(model::ABM, runs::Integer, filename::String="CA_1D")
 #   data = step!(dummystep, CA1D.ca_step!, model, runs, [:pos, :status], collect(1:runs))
 #   visualize_1DCA(data, model, :pos, :status, runs, savename=filename)
 # end

--- a/src/CA2D.jl
+++ b/src/CA2D.jl
@@ -9,7 +9,7 @@ mutable struct Agent{T<:Integer, Y<:AbstractString} <: AbstractAgent
   status::Y
 end
 
-mutable struct Model{T<:AbstractSpace, Y<:AbstractVector, Z<:Tuple} <: AbstractModel
+mutable struct Model{T<:AbstractSpace, Y<:AbstractVector, Z<:Tuple} <: ABM
   space::T
   agents::Y  # Array{AbstractAgent}
   scheduler::Function
@@ -122,11 +122,11 @@ function ca_step!(model)
 end
 
 # """
-#     ca_run(model::AbstractModel, runs::Integer, filename::String="CA_2D")
+#     ca_run(model::ABM, runs::Integer, filename::String="CA_2D")
 
 # Runs a 2D cellular automaton.
 # """
-# function ca_run(model::AbstractModel, runs::Integer, filename::String="CA_2D")
+# function ca_run(model::ABM, runs::Integer, filename::String="CA_2D")
 #   data = step!(dummystep, CA2D.ca_step!, model, runs, [:pos, :status], collect(1:runs))
 #   visualize_2DCA(data, model, :pos, :status, runs, savename=filename)
 # end

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -2,11 +2,11 @@ export move_agent!, add_agent!, add_agent_single!,
 move_agent_single!, kill_agent!
 
 """
-    kill_agent!(agent::AbstractAgent, model::AbstractModel)
+    kill_agent!(agent::AbstractAgent, model::ABM)
 
 Remove an agent from the list of agents and from the space.
 """
-function kill_agent!(agent::AbstractAgent, model::AbstractModel)
+function kill_agent!(agent::AbstractAgent, model::ABM)
   if typeof(agent.pos) <: Tuple
     agentnode = coord2vertex(agent.pos, model)
   else
@@ -19,7 +19,7 @@ function kill_agent!(agent::AbstractAgent, model::AbstractModel)
 end
 
 """
-    move_agent!(agent::AbstractAgent, pos, model::AbstractModel)
+    move_agent!(agent::AbstractAgent, pos, model::ABM)
 
 Add `agentID` to the new position `pos` in the model and remove it from the old position
 (also update the agent to have the new position).
@@ -28,13 +28,13 @@ If `pos` is a tuple, it represents the coordinates of the grid node.
 If `pos` is an integer, it represents the node number in the graph.
 If `pos` is not given, the agent is moved to a random position on the grid.
 """
-function move_agent!(agent::AbstractAgent, pos::Tuple, model::AbstractModel)
+function move_agent!(agent::AbstractAgent, pos::Tuple, model::ABM)
   # node number from x, y, z coordinates
   nodenumber = coord2vertex(pos, model)
   move_agent!(agent, nodenumber, model)
 end
 
-function move_agent!(agent::AbstractAgent, pos::Integer, model::AbstractModel)
+function move_agent!(agent::AbstractAgent, pos::Integer, model::ABM)
   push!(model.space.agent_positions[pos], agent.id)
   # remove agent from old position
   if typeof(agent.pos) <: Tuple
@@ -47,21 +47,21 @@ function move_agent!(agent::AbstractAgent, pos::Integer, model::AbstractModel)
   end
 end
 
-function move_agent!(agent::AbstractAgent, model::AbstractModel)
+function move_agent!(agent::AbstractAgent, model::ABM)
   nodenumber = rand(1:nv(model.space))
   move_agent!(agent, nodenumber, model)
   return agent.pos
 end
 
 """
-    move_agent_single!(agent::AbstractAgent, model::AbstractModel)
+    move_agent_single!(agent::AbstractAgent, model::ABM)
 
 Move agent to a random nodes on the grid while respecting a maximum of one agent
 per node. If there are no empty nodes, the agent wont move.
 
 Return the agent's new position.
 """
-function move_agent_single!(agent::AbstractAgent, model::AbstractModel)
+function move_agent_single!(agent::AbstractAgent, model::ABM)
   # TODO: this inefficient
   empty_cells = [i for i in 1:length(model.space.agent_positions) if length(model.space.agent_positions[i]) == 0]
   if length(empty_cells) > 0
@@ -72,20 +72,20 @@ function move_agent_single!(agent::AbstractAgent, model::AbstractModel)
 end
 
 """
-    add_agent!(agent::AbstractAgent [, pos], model::AbstractModel)
+    add_agent!(agent::AbstractAgent [, pos], model::ABM)
 
 Adds the agent to the `pos` in the space and to the list of agents.
 If `pos` is not given, the agent is added to a random position.
 
 The agent's position is then updated to match `pos`, and is returned
 """
-function add_agent!(agent::AbstractAgent, pos::Tuple, model::AbstractModel)
+function add_agent!(agent::AbstractAgent, pos::Tuple, model::ABM)
   # node number from x, y, z coordinates
   nodenumber = coord2vertex(pos, model)
   add_agent!(agent, nodenumber, model)
 end
 
-function add_agent!(agent::AbstractAgent, pos::Integer, model::AbstractModel)
+function add_agent!(agent::AbstractAgent, pos::Integer, model::ABM)
   push!(model.space.agent_positions[pos], agent.id)
   push!(model.agents, agent)
   # update agent position
@@ -98,21 +98,21 @@ function add_agent!(agent::AbstractAgent, pos::Integer, model::AbstractModel)
   end
 end
 
-function add_agent!(agent::AbstractAgent, model::AbstractModel)
+function add_agent!(agent::AbstractAgent, model::ABM)
   nodenumber = rand(1:nv(model.space))
   add_agent!(agent, nodenumber, model)
   return agent.pos
 end
 
 """
-    add_agent_single!(agent::AbstractAgent, model::AbstractModel)
+    add_agent_single!(agent::AbstractAgent, model::ABM)
 
 Add agent to a random node in the space while respecting a maximum one agent per node.
 This function does not do anything if there are no empty nodes.
 
 Return the agent's new position.
 """
-function add_agent_single!(agent::AbstractAgent, model::AbstractModel)
+function add_agent_single!(agent::AbstractAgent, model::ABM)
   empty_cells = [i for i in 1:length(model.space.agent_positions) if length(model.space.agent_positions[i]) == 0]
   if length(empty_cells) > 0
     random_node = rand(empty_cells)

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -208,6 +208,7 @@ function coord2vertex end
 
 coord2vertex(agent::AbstractAgent, model::ABM) =
 coord2vertex(agent.pos, model.space)
+coord2vertex(pos::Integer, model) = pos
 
 function coord2vertex(coord::Tuple{T, T, T}, dims) where T<: Integer
   if (dims[2] == 1 && dims[3] == 1) ||

--- a/src/simulations/data_collector.jl
+++ b/src/simulations/data_collector.jl
@@ -1,5 +1,5 @@
 """
-    data_collecter_aggregate(model::AbstractModel, field_aggregator::Dict; step=1)
+    data_collecter_aggregate(model::ABM, field_aggregator::Dict; step=1)
 
 `field_aggregator` is a dictionary whose keys are field names of agents (they should be symbols) and whose values are aggregator functions to be applied to those fields. For example, if your agents have a field called `wealth`, and you want to calculate mean and median population wealth, your `field_aggregator` dict will be `Dict(:wealth => [mean, median])`.
 
@@ -11,7 +11,7 @@ To apply a function to the model object, use `:model` as a dictionary key.
 
 Returns two arrays: the first one is the values of applying aggregator functions to the fields, and the second one is a header column for the first array.
 """
-function data_collecter_aggregate(model::AbstractModel, field_aggregator::Dict; step=1)
+function data_collecter_aggregate(model::ABM, field_aggregator::Dict; step=1)
   ncols = 1
   colnames = ["step"]
   for (k,v) in field_aggregator
@@ -45,14 +45,14 @@ function data_collecter_aggregate(model::AbstractModel, field_aggregator::Dict; 
 end
 
 """
-    data_collecter_raw( model::AbstractModel, properties::Array{Symbol})
+    data_collecter_raw( model::ABM, properties::Array{Symbol})
 
 Collects agent properties (fields of the agent object) into a dataframe.
 
 If  an agent field returns an array, the mean of those arrays will be recorded.
 
 """
-function data_collecter_raw(model::AbstractModel, properties::Array{Symbol}; step=1)
+function data_collecter_raw(model::ABM, properties::Array{Symbol}; step=1)
   dd = DataFrame()
   agentslen = nagents(model)
   for fn in properties
@@ -75,20 +75,20 @@ function data_collecter_raw(model::AbstractModel, properties::Array{Symbol}; ste
 end
 
 """
-    data_collector(model::AbstractModel, field_aggregator::Dict, when::AbstractArray{T}, step::Integer [, df::DataFrame]) where T<: Integer
+    data_collector(model::ABM, field_aggregator::Dict, when::AbstractArray{T}, step::Integer [, df::DataFrame]) where T<: Integer
 
 Used in the `step!` function.
 
 Returns a DataFrame of collected data. If `df` is supplied, appends to collected data to it.
 """
-function data_collector(model::AbstractModel, field_aggregator::Dict, when::AbstractArray{T}, step::Integer) where T<: Integer
+function data_collector(model::ABM, field_aggregator::Dict, when::AbstractArray{T}, step::Integer) where T<: Integer
   d, colnames = data_collecter_aggregate(model, field_aggregator, step=step)
   dict = Dict(Symbol(colnames[i]) => d[i] for i in 1:length(d))
   df = DataFrame(dict)
   return df
 end
 
-function data_collector(model::AbstractModel, field_aggregator::Dict, when::AbstractArray{T}, step::Integer, df::DataFrame) where T<:Integer
+function data_collector(model::ABM, field_aggregator::Dict, when::AbstractArray{T}, step::Integer, df::DataFrame) where T<:Integer
   d, colnames = data_collecter_aggregate(model, field_aggregator, step=step)
   dict = Dict(Symbol(colnames[i]) => d[i] for i in 1:length(d))
   push!(df, dict)
@@ -96,18 +96,18 @@ function data_collector(model::AbstractModel, field_aggregator::Dict, when::Abst
 end
 
 """
-    data_collector(model::AbstractModel, properties::Array{Symbol}, when::AbstractArray{T}, step::Integer [, df::DataFrame]) where T<:Integer
+    data_collector(model::ABM, properties::Array{Symbol}, when::AbstractArray{T}, step::Integer [, df::DataFrame]) where T<:Integer
 
 Used in the `step!` function.
 
 Returns a DataFrame of collected data. If `df` is supplied, appends to collected data to it.
 """
-function data_collector(model::AbstractModel, properties::Array{Symbol}, when::AbstractArray{T}, step::Integer) where T<:Integer
+function data_collector(model::ABM, properties::Array{Symbol}, when::AbstractArray{T}, step::Integer) where T<:Integer
   df = data_collecter_raw(model, properties, step=step)
   return df
 end
 
-function data_collector(model::AbstractModel, properties::Array{Symbol}, when::AbstractArray{T}, step::Integer, df::DataFrame) where T<:Integer
+function data_collector(model::ABM, properties::Array{Symbol}, when::AbstractArray{T}, step::Integer, df::DataFrame) where T<:Integer
   d = data_collecter_raw(model, properties, step=step)
   df = join(df, d, on=:id, kind=:outer)
   return df

--- a/src/simulations/parallel.jl
+++ b/src/simulations/parallel.jl
@@ -2,17 +2,17 @@
 """
 A function to be used in `pmap` in `parallel_replicates`. It runs the `step!` function, but has a `dummyvar` parameter that does nothing, but is required for the `pmap` function.
 """
-function parallel_step_dummy!(model::AbstractModel, agent_step!::T, model_step!::T, n::Int, properties, when::AbstractArray{V}, dummyvar) where {T<:Function, V<:Integer}
+function parallel_step_dummy!(model::ABM, agent_step!::T, model_step!::T, n::Int, properties, when::AbstractArray{V}, dummyvar) where {T<:Function, V<:Integer}
   data = step!(deepcopy(model), agent_step!, model_step!, n, properties, when=when);
   return data
 end
 
 """
-    parallel_replicates(agent_step!, model::AbstractModel, n::Integer, agent_properties::Array{Symbol}, when::AbstractArray{Integer}, nreplicates::Integer)
+    parallel_replicates(agent_step!, model::ABM, n::Integer, agent_properties::Array{Symbol}, when::AbstractArray{Integer}, nreplicates::Integer)
 
 Runs `nreplicates` number of simulations in parallel and returns a `DataFrame`.
 """
-function parallel_replicates(model::AbstractModel, agent_step!::V, model_step!::V, n::T, properties::Array{Symbol}; when::AbstractArray{T}, nreplicates::T) where {V<:Function, T<:Integer}
+function parallel_replicates(model::ABM, agent_step!::V, model_step!::V, n::T, properties::Array{Symbol}; when::AbstractArray{T}, nreplicates::T) where {V<:Function, T<:Integer}
   dd = step!(deepcopy(model), agent_step!, model_step!, n, properties, when=when);
   all_data = pmap(j-> parallel_step_dummy!(model, agent_step!, model_step!, n, properties, when, j), 1:nreplicates)
   for d in all_data

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -39,9 +39,9 @@ function step! end
 dummystep(model) = nothing
 dummystep(agent, model) = nothing
 
-step!(model::AbstractModel, agent_step!, n::Int = 1) = step!(model, agent_step!, dummystep, n)
+step!(model::ABM, agent_step!, n::Int = 1) = step!(model, agent_step!, dummystep, n)
 
-function step!(model::AbstractModel, agent_step!, model_step!, n::Int = 1)
+function step!(model::ABM, agent_step!, model_step!, n::Int = 1)
   for i in 1:n
     activation_order = model.scheduler(model)
     for index in activation_order
@@ -55,9 +55,9 @@ end
 # data collection
 #######################################################################################
 
-step!(model::AbstractModel, agent_step!, n::Int, properties; when::AbstractArray{Int}, nreplicates::Int=0) = step!(model, agent_step!, dummystep, n::Int, properties, when=when, nreplicates=nreplicates, parallel=false)
+step!(model::ABM, agent_step!, n::Int, properties; when::AbstractArray{Int}, nreplicates::Int=0) = step!(model, agent_step!, dummystep, n::Int, properties, when=when, nreplicates=nreplicates, parallel=false)
 
-function step!(model::AbstractModel, agent_step!, model_step!, n::Int, properties; when::AbstractArray{Int}, nreplicates::Int=0, parallel::Bool=false)
+function step!(model::ABM, agent_step!, model_step!, n::Int, properties; when::AbstractArray{Int}, nreplicates::Int=0, parallel::Bool=false)
 
   if nreplicates > 0
     if parallel

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -43,9 +43,9 @@ step!(model::ABM, agent_step!, n::Int = 1) = step!(model, agent_step!, dummystep
 
 function step!(model::ABM, agent_step!, model_step!, n::Int = 1)
   for i in 1:n
-    activation_order = model.scheduler(model)
-    for index in activation_order
-      agent_step!(model.agents[index], model)
+    actived_agents = model.scheduler(model)
+    for agent in activated_agents
+      agent_step!(agent, model)
     end
     model_step!(model)
   end

--- a/test/forest_fire_defs.jl
+++ b/test/forest_fire_defs.jl
@@ -5,7 +5,7 @@ mutable struct Tree <: AbstractAgent
   status::Bool  # true is green and false is burning
 end
 
-mutable struct Forest <: AbstractModel
+mutable struct Forest <: ABM
   space::AbstractSpace
   agents::Array{AbstractAgent}
   scheduler::Function

--- a/test/schelling_defs.jl
+++ b/test/schelling_defs.jl
@@ -1,7 +1,7 @@
 # Create the agent, model, and grid types.
-"AbstractModel type for the Schelling Model"
-mutable struct SchellingModel{T<:Integer, Y<:AbstractArray, Z<:AbstractSpace} <: AbstractModel 
-  # Object should always be a subtype of AbstractModel.
+"ABM type for the Schelling Model"
+mutable struct SchellingModel{T<:Integer, Y<:AbstractArray, Z<:AbstractSpace} <: ABM 
+  # Object should always be a subtype of ABM.
   "A field of the model for a space object, always a subtype of AbstractSpace."
   space::Z 
   "A list of agents."


### PR DESCRIPTION
This PR addresses #40 and also addresses the fact that users have to make a `struct` for their model instead of calling a function. 

The main idea in this implementation is already described in #40 where we replace killed agents with `missing`.

---

**TODO before merging:**

- [ ] Update agent_space_interactions
- [x] Update the space creation
- [ ] Add a "renormalization" function that removes all missings
- [ ] Update documentation / tutorials for this
- [ ] Check if the data collection works properly with this (sorry @kavir1698 but only you can do this)
- [ ] Benchmark this with the current `v2.0` branch: it may be that this change introduces regressions. (super step!)

For the benchmarking thing, we have to come up with a smart way to benchmark it, which not only creates and kills agents very frequently, but also cares very much about getting the agents in a specified position (because this is exactly the problem that #40 discusses) . Maybe a modified version of the forest fire will do the trick?