### PR TITLE
Change type of model.agents to Dict

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -188,11 +188,13 @@ function agent_step!(agent, model)
     return
 end
 ```
+
 For the purpose of this implementation of Schelling's segregation model, we only need an agent step function.
 
 For defining `agent_step!` we used some of the built-in functions of Agents.jl, such as [`node_neighbors`](@ref) that returns the neighboring nodes of the node on which the agent resides, [`get_node_contents`](@ref) that returns the IDs of the agents on a given node, and [`move_agent_single!`](@ref) which moves agents to random empty nodes on the grid. A full list of built-in functions and their explanations are available [Built-in functions](@ref) page.
 
 ### Running the model
+
 ```@example schelling
 # Instantiate the model with 370 agents on a 20 by 20 grid.
 model = instantiate()

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -36,7 +36,7 @@ function forest_step!(forest)
     if length(forest.space.agent_positions[node]) == 0  # the cell is empty, maybe a tree grows here?
       p = rand()
       if p <= forest.properties[:p]
-        bigest_id = maximum([a.id for a in values(forest.agents)])
+        bigest_id = maximum(keys(forest.agents))
         treeid = bigest_id +1
         tree = Tree(treeid, (1,1), true)
         add_agent!(tree, node, forest)

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -36,7 +36,8 @@ function forest_step!(forest)
     if length(forest.space.agent_positions[node]) == 0  # the cell is empty, maybe a tree grows here?
       p = rand()
       if p <= forest.properties[:p]
-        treeid = forest.agents[end].id +1
+        bigest_id = maximum([a.id for a in values(forest.agents)])
+        treeid = bigest_id +1
         tree = Tree(treeid, (1,1), true)
         add_agent!(tree, node, forest)
       end

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -15,7 +15,7 @@ function kill_agent!(agent::AbstractAgent, model::ABM)
    # remove from the space
   splice!(agent_positions(model)[agentnode],
           findfirst(a->a==agent.id, agent_positions(model)[agentnode]))
-  splice!(model.agents, findfirst(a->a==agent, model.agents))  # remove from the model
+  delete!(model.agents, agent.id)
 end
 
 """
@@ -87,7 +87,7 @@ end
 
 function add_agent!(agent::AbstractAgent, pos::Integer, model::ABM)
   push!(model.space.agent_positions[pos], agent.id)
-  push!(model.agents, agent)
+  model.agents[agent.id] = agent
   # update agent position
   if typeof(agent.pos) <: Integer
     agent.pos = pos

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -57,8 +57,8 @@ nagents(model::ABM) = length(model.agents)
 Activate agents at each step in the same order as they have been added to the model.
 """
 function as_added(model::ABM)
-  agent_ids = [i.id for i in values(model.agents)]
-  return sortperm(agent_ids)
+  agent_ids = sort(collect(keys(model.agents)))
+  return agent_ids
 end
 
 """
@@ -66,7 +66,7 @@ end
 Activate agents once per step in a random order.
 """
 function random_activation(model::ABM)
-  order = shuffle([i.id for i in values(model.agents)])
+  order = shuffle(collect(keys(model.agents)))
 end
 
 """

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -20,7 +20,7 @@ for example variable quantities like "status" or other "counters".
 abstract type AbstractAgent end
 
 struct AgentBasedModel{A<:AbstractAgent, S<:AbstractSpace, F, P}
-    agents::Vector{A}
+    agents::Dict{Int,A}
     space::S
     scheduler::F
     properties::P
@@ -41,7 +41,7 @@ function AgentBasedModel(
         ::Type{A}, space::S;
         scheduler::F = as_added, properties::P = nothing
         ) where {A<:AbstractAgent, S<:AbstractSpace, F, P}
-    agents = A[]
+    agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
 end
 
@@ -57,7 +57,7 @@ nagents(model::ABM) = length(model.agents)
 Activate agents at each step in the same order as they have been added to the model.
 """
 function as_added(model::ABM)
-  agent_ids = [i.id for i in model.agents]
+  agent_ids = [i.id for i in values(model.agents)]
   return sortperm(agent_ids)
 end
 
@@ -66,7 +66,7 @@ end
 Activate agents once per step in a random order.
 """
 function random_activation(model::ABM)
-  order = shuffle(1:length(model.agents))
+  order = shuffle([i.id for i in values(model.agents)])
 end
 
 """

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -335,8 +335,7 @@ end
 Return an agent given its ID.
 """
 function id2agent(id::Integer, model::ABM)
-  agent_index = findfirst(a-> a.id==id, model.agents)
-  return model.agents[agent_index]
+  return model.agents[id]
 end
 
 """

--- a/src/simulations/data_collector.jl
+++ b/src/simulations/data_collector.jl
@@ -78,7 +78,7 @@ function data_collecter_raw(model::ABM, properties::Array{Symbol}; step=1)
       temparray = [getproperty(model.agents[i], fn) for i in agent_ids]
     end
     begin
-      dd[!, :id] = [i.id for i in values(model.agents)]
+      dd[!, :id] = sort(collect(keys(model.agents)))
     end
     fieldname = Symbol(join([string(fn), step], "_"))
     begin

--- a/src/simulations/data_collector.jl
+++ b/src/simulations/data_collector.jl
@@ -24,19 +24,24 @@ function data_collecter_aggregate(model::ABM, field_aggregator::Dict; step=1)
   end
   output = Array{Any}(undef, ncols)
   output[1] = step
-  agentslen = nagents(model)
+  agent_ids = keys(model.agents)
   counter = 2
+  rand_agent_id = 0
+  for aa in agent_ids
+    rand_agent_id = aa 
+    break
+  end
   for (fn, aggs) in field_aggregator
-    if fn == :pos && typeof(model.agents[1].pos) <: Tuple
-      temparray = [coord2vertex(model.agents[i], model) for i in 1:agentslen]
+    if fn == :pos && typeof(model.agents[rand_agent_id].pos) <: Tuple
+      temparray = [coord2vertex(model.agents[i], model) for i in agent_ids]
     elseif fn == :agent
-      temparray = model.agents
+      temparray = values(model.agents)
     elseif fn == :model
       temparray = model
-    elseif typeof(getproperty(model.agents[1], fn)) <: AbstractArray
-      temparray = [mean(getproperty(model.agents[i], fn)) for i in 1:agentslen]
+    elseif typeof(getproperty(model.agents[rand_agent_id], fn)) <: AbstractArray
+      temparray = [mean(getproperty(model.agents[i], fn)) for i in agent_ids]
     else
-      temparray = [getproperty(model.agents[i], fn) for i in 1:agentslen]
+      temparray = [getproperty(model.agents[i], fn) for i in agent_ids]
     end
     for agg in aggs
       output[counter] = agg(temparray)
@@ -56,17 +61,24 @@ If  an agent field returns an array, the mean of those arrays will be recorded.
 """
 function data_collecter_raw(model::ABM, properties::Array{Symbol}; step=1)
   dd = DataFrame()
+  agent_ids = keys(model.agents)
+  counter = 2
+  rand_agent_id = 0
+  for aa in agent_ids
+    rand_agent_id = aa 
+    break
+  end
   agentslen = nagents(model)
   for fn in properties
-    if fn == :pos  && typeof(model.agents[1].pos) <: Tuple
-      temparray = [coord2vertex(model.agents[i], model) for i in 1:agentslen]
-    elseif typeof(getproperty(model.agents[1], fn)) <: AbstractArray
-      temparray = [mean(getproperty(model.agents[i], fn)) for i in 1:agentslen]
+    if fn == :pos  && typeof(model.agents[rand_agent_id].pos) <: Tuple
+      temparray = [coord2vertex(model.agents[i], model) for i in agent_ids]
+    elseif typeof(getproperty(model.agents[rand_agent_id], fn)) <: AbstractArray
+      temparray = [mean(getproperty(model.agents[i], fn)) for i in agent_ids]
     else
-      temparray = [getproperty(model.agents[i], fn) for i in 1:agentslen]
+      temparray = [getproperty(model.agents[i], fn) for i in agent_ids]
     end
     begin
-      dd[!, :id] = [i.id for i in model.agents]
+      dd[!, :id] = [i.id for i in values(model.agents)]
     end
     fieldname = Symbol(join([string(fn), step], "_"))
     begin

--- a/test/benchmark/benchmark.jl
+++ b/test/benchmark/benchmark.jl
@@ -17,8 +17,8 @@ a = @benchmark id2agent(250, model) setup=(model = model_initiation(f=0.1, d=0.8
 display(a)
 
 println("\nkill_agent!")
-a = @benchmark kill_agent!(model.agents[250], model) setup=(model = model_initiation(f=0.1, d=0.8, p=0.1, griddims=(100, 50), seed=2))
-display(a)
+a = @benchmarkable kill_agent!(model.agents[250], model) setup=(model = model_initiation(f=0.1, d=0.8, p=0.1, griddims=(100, 50), seed=2))
+display(run(a))
 
 println("\nSchelling model")
 include("../schelling_defs.jl")

--- a/test/forest_fire_defs.jl
+++ b/test/forest_fire_defs.jl
@@ -30,7 +30,8 @@ function forest_step!(forest)
     if length(forest.space.agent_positions[node]) == 0  # the cell is empty, maybe a tree grows here?
       p = rand()
       if p <= forest.properties[:p]
-        treeid = forest.agents[end].id +1
+        bigest_id = maximum([a.id for a in values(forest.agents)])
+        treeid = bigest_id +1
         tree = Tree(treeid, (1,1), true)
         add_agent!(tree, node, forest)
       end

--- a/test/forest_fire_defs.jl
+++ b/test/forest_fire_defs.jl
@@ -30,7 +30,7 @@ function forest_step!(forest)
     if length(forest.space.agent_positions[node]) == 0  # the cell is empty, maybe a tree grows here?
       p = rand()
       if p <= forest.properties[:p]
-        bigest_id = maximum([a.id for a in values(forest.agents)])
+        bigest_id =  maximum(keys(forest.agents))
         treeid = bigest_id +1
         tree = Tree(treeid, (1,1), true)
         add_agent!(tree, node, forest)

--- a/test/schelling_defs.jl
+++ b/test/schelling_defs.jl
@@ -56,4 +56,4 @@ function agent_step!(agent, model)
   # return
 end
 
-happyperc(model) = count(x -> x.mood == true, model.agents)/nagents(model)
+happyperc(model) = count(x -> x.mood == true, values(model.agents))/nagents(model)

--- a/test/schelling_test.jl
+++ b/test/schelling_test.jl
@@ -6,6 +6,6 @@
   when = 1:5
   data = step!(model, agent_step!, 2, agent_properties, when=when)
 
-  @test data[1, :pos_1] == 261
-  @test data[1, :pos_2] == 378
+  @test data[1, :pos_1] == 363
+  @test data[1, :pos_2] == 393
 end

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -1,4 +1,4 @@
-
+using Random
 Random.seed!(209)
 
 @testset "0D grids" begin
@@ -116,12 +116,12 @@ end
 
   @test agent.id in get_node_contents(agent, model)
 
-  ii = model.agents[end].id
-  @test id2agent(ii, model) == model.agents[end]
+  ii = model.agents[length(model.agents)]
+  @test id2agent(ii.id, model) == model.agents[ii.id]
 
   agent = model.agents[1]
   agent_pos = coord2vertex(agent.pos, model)
   kill_agent!(agent, model)
-  @test_throws ArgumentError id2agent(1, model) 
+  @test_throws KeyError id2agent(1, model) 
   @test !in(1, Agents.agent_positions(model)[agent_pos])
 end

--- a/test/try_new_api.jl
+++ b/test/try_new_api.jl
@@ -35,38 +35,36 @@ model = instantiate()
 function agent_step!(agent, model)
     agent.mood == true && return # do nothing if already happy
     minhappy = model.properties[:min_to_be_happy]
-    while agent.mood == false
-        neighbor_cells = node_neighbors(agent, model)
-        count_neighbors_same_group = 0
-        # For each neighbor, get group and compare to current agent's group
-        # and increment count_neighbors_same_group as appropriately.
-        for neighbor_cell in neighbor_cells
-            node_contents = get_node_contents(neighbor_cell, model)
-            # Skip iteration if the node is empty.
-            length(node_contents) == 0 && continue
-            # Otherwise, get the first agent in the node...
-            agent_id = node_contents[1]
-            # ...and increment count_neighbors_same_group if the neighbor's group is
-            # the same.
-            neighbor_agent_group = model.agents[agent_id].group
-            if neighbor_agent_group == agent.group
-                count_neighbors_same_group += 1
-            end
+    neighbor_cells = node_neighbors(agent, model)
+    count_neighbors_same_group = 0
+    # For each neighbor, get group and compare to current agent's group
+    # and increment count_neighbors_same_group as appropriately.
+    for neighbor_cell in neighbor_cells
+        node_contents = get_node_contents(neighbor_cell, model)
+        # Skip iteration if the node is empty.
+        length(node_contents) == 0 && continue
+        # Otherwise, get the first agent in the node...
+        agent_id = node_contents[1]
+        # ...and increment count_neighbors_same_group if the neighbor's group is
+        # the same.
+        neighbor_agent_group = model.agents[agent_id].group
+        if neighbor_agent_group == agent.group
+            count_neighbors_same_group += 1
         end
+    end
 
-        # After counting the neighbors, decide whether or not to move the agent.
-        # If count_neighbors_same_group is at least the min_to_be_happy, set the
-        # mood to true. Otherwise, move the agent to a random node.
-        if count_neighbors_same_group ≥ minhappy
-            agent.mood = true
-        else
-            move_agent_single!(agent, model)
-        end
+    # After counting the neighbors, decide whether or not to move the agent.
+    # If count_neighbors_same_group is at least the min_to_be_happy, set the
+    # mood to true. Otherwise, move the agent to a random node.
+    if count_neighbors_same_group ≥ minhappy
+        agent.mood = true
+    else
+        move_agent_single!(agent, model)
     end
     return
 end
 
-happyperc(model) = count(x -> x.mood == true, model.agents)/nagents(model)
+happyperc(model) = count(x -> x.mood == true, values(model.agents))/nagents(model)
 
 step!(model, agent_step!)  # Run the model one step...
 happyperc(model)


### PR DESCRIPTION
This PR stores agents in a dictionary `id=>agent` instead of an array. It has biggest impact on the `id2agent` function, which is commonly used in agent-space interactions. Other operations are also slightly faster now.