### PR TITLE
add pretty printing for abm and space

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -48,7 +48,7 @@ end
 
 function Base.show(io::IO, abm::ABM{A}) where {A}
     s = "AgentBasedModel with $(nagents(abm)) agents of type $A"
-    s*= "\n space: $(nameof(typeof(abm.space))) with $(nv(abm)) nodes"
+    s*= "\n space: $(nameof(typeof(abm.space))) with $(nv(abm)) nodes and $(ne(abm)) edges"
     s*= "\n scheduler: $(nameof(abm.scheduler))"
     print(io, s)
     if abm.properties ≠ nothing

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -36,6 +36,7 @@ and the `space` (from [`Space`](@ref)).
 Optionally provide a `scheduler` that creates the order with which agents
 are activated in the model, and `properties` (a dictionary of key-type `Symbol`)
 for additional model-level properties.
+This is accessed as `model.properties` for later use.
 """
 function AgentBasedModel(
         ::Type{A}, space::S;
@@ -43,6 +44,16 @@ function AgentBasedModel(
         ) where {A<:AbstractAgent, S<:AbstractSpace, F, P}
     agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
+end
+
+function Base.show(io::IO, abm::ABM{A}) where {A}
+    s = "AgentBasedModel with $(nagents(abm)) agents of type $A"
+    s*= "\n space: $(nameof(typeof(abm.space))) with $(nv(abm)) nodes"
+    s*= "\n scheduler: $(nameof(abm.scheduler))"
+    print(io, s)
+    if abm.properties ≠ nothing
+        print(io, "\n properties: ", abm.properties)
+    end
 end
 
 

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -7,6 +7,8 @@ id2agent, NodeIterator, node_neighbors, gridsize
 #######################################################################################
 LightGraphs.nv(space::AbstractSpace) = LightGraphs.nv(space.graph)
 LightGraphs.ne(space::AbstractSpace) = LightGraphs.ne(space.graph)
+LightGraphs.nv(abm::ABM) = LightGraphs.nv(abm.space.graph)
+LightGraphs.ne(abm::ABM) = LightGraphs.ne(abm.space.graph)
 gridsize(model::ABM) = LightGraphs.nv(model.space.graph)
 
 struct GraphSpace{G} <: AbstractSpace
@@ -17,6 +19,10 @@ struct GridSpace{G, D, I<:Integer} <: AbstractSpace
   graph::G # Graph
   agent_positions::Vector{Vector{Int}}
   dimensions::NTuple{D, I}
+end
+function Base.show(io::IO, abm::AbstractSpace)
+    s = "$(nameof(typeof(abm))) with $(nv(abm)) nodes and $(ne(abm)) edges"
+    print(io, s)
 end
 
 Space(m::ABM) = m.space


### PR DESCRIPTION
Now we have:
```
julia> schelling
AgentBasedModel with 0 agents of type SchellingAgent
 space: GridSpace with 100 nodes
 scheduler: as_added
 properties: Dict(:min_to_be_happy=>3)

julia> schelling.space
GridSpace with 100 nodes and 342 edges
```

Closes #55