### PR TITLE
Restructure output

### DIFF
--- a/src/simulations/data_collector.jl
+++ b/src/simulations/data_collector.jl
@@ -80,11 +80,12 @@ function data_collecter_raw(model::ABM, properties::Array{Symbol}; step=1)
     begin
       dd[!, :id] = sort(collect(keys(model.agents)))
     end
-    fieldname = Symbol(join([string(fn), step], "_"))
+    fieldname = fn
     begin
       dd[!, fieldname] = temparray
     end
   end
+  dd[!, :step] = [step for i in 1:size(dd, 1)]
   return dd
 end
 
@@ -123,7 +124,7 @@ end
 
 function data_collector(model::ABM, properties::Array{Symbol}, when::AbstractArray{T}, step::Integer, df::DataFrame) where T<:Integer
   d = data_collecter_raw(model, properties, step=step)
-  df = join(df, d, on=:id, kind=:outer)
+  df = vcat(df, d) #join(df, d, on=:id, kind=:outer)
   return df
 end
 

--- a/test/CA_test.jl
+++ b/test/CA_test.jl
@@ -3,17 +3,19 @@
   using Agents.CA1D
   rules = Dict("111"=>"0", "110"=>"0", "101"=>"0", "100"=>"1", "011"=>"0",
   "010"=>"1", "001"=>"1", "000"=>"0")  # rule 22
-  model = CA1D.build_model(rules=rules, ncols=101)
+  ncols = 101
+  model = CA1D.build_model(rules=rules, ncols=ncols)
   model.agents[51].status="1"
   runs = 10
   data = CA1D.ca_run(model, runs);
-  @test size(data) == (101, 23)
+  @test size(data) == (ncols*(runs+1), 4)
 end
 
 @testset "Cellular automata 2D" begin
   using Agents.CA2D
   rules = (2,3,3)
-  model = CA2D.build_model(rules=rules, dims=(100, 10), Moore=true)
+  dims=(100, 10)
+  model = CA2D.build_model(rules=rules, dims=dims, Moore=true)
   for i in 1:nv(model)
     if rand() < 0.1
       model.agents[i].status="1"
@@ -21,5 +23,5 @@ end
   end
   runs = 2
   data = CA2D.ca_run(model, runs);
-  @test size(data) == (1000, 7)
+  @test size(data) == ((dims[1]*dims[2])*(runs+1), 4)
 end

--- a/test/boltzmann_test.jl
+++ b/test/boltzmann_test.jl
@@ -24,13 +24,13 @@ end
 @testset "Model tests" begin
 
   numagents = 20
-  steps = 10
+  n = 10
   model = boltzmann_model(numagents=numagents)
   agent_properties = [:wealth]
-  data = step!(model, Boltzmann_step!, steps, agent_properties, when=1:steps)
-  @test size(data) == (numagents, steps+2)
+  data = step!(model, Boltzmann_step!, n, agent_properties, when=1:n)
+  @test size(data) == (numagents*(n+1), length(agent_properties)+2)
 
   nreps = 3
-  data = step!(model, Boltzmann_step!, steps, agent_properties, when=1:steps, replicates=nreps)
+  data = step!(model, Boltzmann_step!, n, agent_properties, when=1:n, replicates=nreps)
   @test length(data) == nreps
 end

--- a/test/data_collector_test.jl
+++ b/test/data_collector_test.jl
@@ -10,5 +10,5 @@ Random.seed!(223)
   agent_properties = [:status]
   forest = model_initiation(f=0.05, d=0.8, p=0.01, griddims=(20, 20), seed=2);
   data = step!(forest, dummystep, forest_step!, 10, agent_properties, when=when);
-  @test size(data) == (347, 12)
+  @test size(data) == (993, 3)
 end

--- a/test/schelling_test.jl
+++ b/test/schelling_test.jl
@@ -63,6 +63,6 @@ end
   when = 1:5
   data = step!(model, agent_step!, 2, agent_properties, when=when)
 
-  @test data[1, :pos_0] == 363
-  @test data[1, :pos_1] == 393
+  @test data[1, :pos] == 363
+  @test data[end, :pos] == 341
 end

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -92,6 +92,17 @@ end
   @test vertex2coord(18, (2,3,3)) == (2,3,3)
 end
 
+mutable struct Agent1 <: AbstractAgent
+  id::Int 
+  pos::Tuple{Int,Int}
+end
+
+mutable struct Agent2 <: AbstractAgent
+  id::Int 
+  pos::Tuple{Int,Int}
+  p::Int
+end
+
 @testset "Agent-Space interactions" begin
 
   model = model_initiation(f=0.1, d=0.8, p=0.1, griddims=(20, 20), seed=2)  # forest fire model
@@ -114,21 +125,12 @@ end
   @test agent.id in model.space.agent_positions[coord2vertex((2,9), model)]
   @test agent.id in model.space.agent_positions[coord2vertex(new_pos, model)]
 
-  mutable struct Agent1 <: AbstractAgent
-    id::Int 
-    pos::Tuple{Int,Int}
-  end
   model1 = ABM(Agent1, Space((3,3)))
   add_agent!(1, model1)
   @test model1.agents[1].pos == (1, 1)
   add_agent!((2,1), model1)
   @test model1.agents[2].pos == (2, 1)
   
-  mutable struct Agent2 <: AbstractAgent
-    id::Int 
-    pos::Tuple{Int,Int}
-    p::Int
-  end
   model2 = ABM(Agent2, Space((3,3)))
   add_agent!(1, model2, 3)
   @test model2.agents[1].pos == (1,1)


### PR DESCRIPTION
This PR changes the output structure when collecting raw data.
Currently, when we collect raw data from a model at different steps, the output data frame creates a new column for each step. But a more standard structure is to add a `step` column. This way the output is easier to parse and understand.

Current output for the Schelling model looks like this:

```
370×19 DataFrames.DataFrame. Omitted printing of 11 columns
│ Row │ id     │ pos_0  │ mood_0 │ group_0 │ pos_1  │ mood_1 │ group_1 │ pos_2  │
│     │ Int64⍰ │ Int64⍰ │ Bool⍰  │ Int64⍰  │ Int64⍰ │ Bool⍰  │ Int64⍰  │ Int64⍰ │
├─────┼────────┼────────┼────────┼─────────┼────────┼────────┼─────────┼────────┤
│ 1   │ 1      │ 5      │ 0      │ 2       │ 393    │ 0      │ 2       │ 140    │
│ 2   │ 2      │ 368    │ 0      │ 2       │ 368    │ 1      │ 2       │ 368    │
│ 3   │ 3      │ 367    │ 0      │ 1       │ 367    │ 1      │ 1       │ 367    │
│ 4   │ 4      │ 360    │ 0      │ 1       │ 361    │ 0      │ 1       │ 361    │
│ 5   │ 5      │ 333    │ 0      │ 1       │ 333    │ 1      │ 1       │ 333    │
│ 6   │ 6      │ 192    │ 0      │ 1       │ 192    │ 1      │ 1       │ 192    │
│ 7   │ 7      │ 391    │ 0      │ 2       │ 391    │ 1      │ 2       │ 391    │
│ 8   │ 8      │ 232    │ 0      │ 1       │ 232    │ 1      │ 1       │ 232    │
```

And the output from this PR looks like this:

```
2220×5 DataFrames.DataFrame
│ Row  │ id    │ pos   │ mood │ group │ step  │
│      │ Int64 │ Int64 │ Bool │ Int64 │ Int64 │
├──────┼───────┼───────┼──────┼───────┼───────┤
│ 1    │ 1     │ 292   │ 0    │ 2     │ 0     │
│ 2    │ 2     │ 385   │ 0    │ 2     │ 0     │
│ 3    │ 3     │ 118   │ 0    │ 1     │ 0     │
⋮
│ 2217 │ 367   │ 4     │ 1    │ 2     │ 5     │
│ 2218 │ 368   │ 169   │ 1    │ 1     │ 5     │
│ 2219 │ 369   │ 393   │ 1    │ 2     │ 5     │
│ 2220 │ 370   │ 45    │ 1    │ 1     │ 5     │
```