### PR TITLE
Add a scheduler API and improve scheduler documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# v2.1
+* Renamed the old scheduler `as_added` to `by_id`, to reflect reality.
+* Added a scheduler public API.
+* Added two new schedulers: `partial_activation`, `property_activation`.
+
+# v2.0
+Changelog is kept with respect to version 2.0.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Ali Vahdati", "George Datseris"]
-version = "2.0.4"
+version = "2.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -47,6 +47,7 @@ fastest
 by_id
 random_activation
 partial_activation
+property_activation
 ```
 
 ## Utilities

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -40,7 +40,7 @@ nodes
 
 ## Schedulers
 ```@docs
-as_added
+by_id
 random_activation
 partial_activation
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -42,6 +42,7 @@ nodes
 The schedulers of Agents.jl have a very simple interface. All schedulers are functions,
 that take as an input the ABM and return an iterator over agent IDs.
 Notice that this iterator can be a "true" iterator or can be just a standard vector of IDs.
+You can define your own scheduler according to this API and use it when making an [`AgentBasedModel`](@ref).
 ```@docs
 fastest
 by_id

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -39,6 +39,9 @@ nodes
 ```
 
 ## Schedulers
+The schedulers of Agents.jl have a very simple interface. All schedulers are functions,
+that take as an input the ABM and return an iterator over agent IDs.
+Notice that this iterator can be a "true" iterator or can be just a standard vector of IDs.
 ```@docs
 by_id
 random_activation

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,6 +43,7 @@ The schedulers of Agents.jl have a very simple interface. All schedulers are fun
 that take as an input the ABM and return an iterator over agent IDs.
 Notice that this iterator can be a "true" iterator or can be just a standard vector of IDs.
 ```@docs
+fastest
 by_id
 random_activation
 partial_activation

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -121,10 +121,16 @@ We also want to include a property `min_to_be_happy` in our model, and so we hav
 
 ```@example schelling
 properties = Dict(:min_to_be_happy => 3)
-schelling = ABM(SchellingAgent, space; properties = properties)
+schelling = ABM(SchellingAgent, space;
+    scheduler = fastest, properties = properties)
 ```
 
-Here we used the default scheduler (which is also the fastest one).
+Here we used the default scheduler (which is also the fastest one) to create the model. We could instead try to activate the agents according to their property `:group`, so that all agents of group 1 act first. We would then use the scheduler [`property_activation`](@ref) like so:
+```@example schelling
+schelling2 = ABM(SchellingAgent, space;
+    properties = properties, scheduler = partial_activation(:group))
+```
+Notice that `partial_activation` accepts an argument and returns a function, which is why we didn't just give `partial_activation` to `scheduler`.
 
 ### Creating the ABM through a function
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -124,7 +124,7 @@ properties = Dict(:min_to_be_happy => 3)
 schelling = ABM(SchellingAgent, space; properties = properties)
 ```
 
-Here we used the default scheduler.
+Here we used the default scheduler (which is also the fastest one).
 
 ### Creating the ABM through a function
 

--- a/src/CA1D.jl
+++ b/src/CA1D.jl
@@ -17,7 +17,7 @@ function build_model(;rules::Dict, ncols::Integer=101)
   nv=(ncols,1)
   space = Space(nv)
   properties = Dict(:rules => rules)
-  model = ABM(Cell, space; properties = properties, scheduler=as_added)
+  model = ABM(Cell, space; properties = properties, scheduler=by_id)
   for n in 1:ncols
     add_agent!(Cell(n, (n,1), "0"), (n,1), model)
   end

--- a/src/CA2D.jl
+++ b/src/CA2D.jl
@@ -16,7 +16,7 @@ Builds a 2D cellular automaton. `rules` is of type `Tuple{Integer,Integer,Intege
 function build_model(;rules::Tuple, dims=(100,100), Moore=true)
   space = Space(dims, moore=Moore)
   properties = Dict(:rules => rules, :Moore=>Moore)
-  model = ABM(Cell, space; properties = properties, scheduler=as_added)
+  model = ABM(Cell, space; properties = properties, scheduler=by_id)
   nnodes = dims[1]*dims[2]
   for n in 1:nnodes
     add_agent!(Cell(n, vertex2coord(n, dims), "0"), (n,1), model)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -111,11 +111,12 @@ function random_activation(model::ABM)
 end
 
 """
-    partial_activation
-At each step, activate only `activation_prob` percentage of randomly chosen agents.
-`activation_prob` must be a field in the model and between 0 and 1.
+    partial_activation(p)
+At each step, activate only `p` percentage of randomly chosen agents.
 """
-function partial_activation(model::ABM)
-  agentnum = nagents(model)
-  return randsubseq(1:agentnum, model.activation_prob)
+function partial_activation(p::Real)
+    function partial(model)
+        ids = collect(keys(model))
+        return randsubseq(1:agentnum, p)
+    end
 end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -59,7 +59,7 @@ This is accessed as `model.properties` for later use.
 """
 function AgentBasedModel(
         ::Type{A}, space::S = nothing;
-        scheduler::F = dict_keys, properties::P = nothing
+        scheduler::F = fastest, properties::P = nothing
         ) where {A<:AbstractAgent, S<:SpaceType, F, P}
     agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
@@ -128,8 +128,9 @@ function partial_activation(p::Real)
 end
 
 """
-    dict_keys
-Activate all agents once in the order dictated by the agent's container, which
-is arbitrary (and random). This is the fastest possible way to activate all agents.
+    fastest
+Activate all agents once per step in the order dictated by the agent's container, which
+is arbitrary (the keys sequence of a dictionary).
+This is the fastest possible way to activate all agents once per step.
 """
-dict_keys(model) = keys(model)
+fastest(model) = keys(model)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -1,5 +1,5 @@
 export nagents, AbstractAgent, ABM, AgentBasedModel,
-random_activation, as_added, partial_activation, random_agent
+random_activation, by_id, partial_activation, random_agent
 
 abstract type AbstractSpace end
 
@@ -59,7 +59,7 @@ This is accessed as `model.properties` for later use.
 """
 function AgentBasedModel(
         ::Type{A}, space::S = nothing;
-        scheduler::F = as_added, properties::P = nothing
+        scheduler::F = by_id, properties::P = nothing
         ) where {A<:AbstractAgent, S<:SpaceType, F, P}
     agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
@@ -92,13 +92,15 @@ Return the number of agents in the `model`.
 nagents(model::ABM) = length(model.agents)
 
 """
-    as_added(model::ABM)
-Activate agents at each step in the same order as they have been added to the model.
+    by_id(model::ABM)
+Activate agents at each step according to their id.
 """
-function as_added(model::ABM)
+function by_id(model::ABM)
   agent_ids = sort(collect(keys(model.agents)))
   return agent_ids
 end
+
+@deprecate as_added by_id
 
 """
     random_activation(model::ABM)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -59,7 +59,7 @@ This is accessed as `model.properties` for later use.
 """
 function AgentBasedModel(
         ::Type{A}, space::S = nothing;
-        scheduler::F = by_id, properties::P = nothing
+        scheduler::F = dict_keys, properties::P = nothing
         ) where {A<:AbstractAgent, S<:SpaceType, F, P}
     agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
@@ -121,8 +121,15 @@ define `model.properties` so that it is possible to access
 function partial_activation(p::Real)
     function partial(model::ABM{A, S, F, P}) where {A, S, F, P}
         ids = collect(keys(model.agents))
-        ap = P == nothing ? p : get(model.properties, :activation_probability, p)
-        return randsubseq(1:agentnum, ap)
+        ap = P == Nothing ? p : get(model.properties, :activation_probability, p)
+        return randsubseq(ids, ap)
     end
     return partial
 end
+
+"""
+    dict_keys
+Activate all agents once in the order dictated by the agent's container, which
+is arbitrary (and random). This is the fastest possible way to activate all agents.
+"""
+dict_keys(model) = keys(model)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -98,9 +98,9 @@ nagents(model::ABM) = length(model.agents)
 ####################################
 """
     fastest
-Activate all agents once per step in the order dictated by the agent's container, which
-is arbitrary (the keys sequence of a dictionary).
-This is the fastest possible way to activate all agents once per step.
+Activate all agents once per step in the order dictated by the agent's container,
+which is arbitrary (the keys sequence of a dictionary).
+This is the fastest way to activate all agents once per step.
 """
 fastest(model) = keys(model)
 
@@ -118,6 +118,7 @@ end
 """
     random_activation
 Activate agents once per step in a random order.
+Different random ordering is used at each different step.
 """
 function random_activation(model::ABM)
   order = shuffle(collect(keys(model.agents)))
@@ -126,16 +127,11 @@ end
 """
     partial_activation(p)
 At each step, activate only `p` percentage of randomly chosen agents.
-
-If you want the activation probability `p` to be a parameter of your model, simply
-define `model.properties` so that it is possible to access
-`model.properties[:activation_probability]`. This number will be used instead of `p`.
 """
 function partial_activation(p::Real)
     function partial(model::ABM{A, S, F, P}) where {A, S, F, P}
         ids = collect(keys(model.agents))
-        ap = P == Nothing ? p : get(model.properties, :activation_probability, p)
-        return randsubseq(ids, ap)
+        return randsubseq(ids, p)
     end
     return partial
 end
@@ -145,16 +141,11 @@ end
 At each step, activate the agents in an order dictated by their `property`,
 with agents with greater `property` acting first. `property` is a `Symbol`, which
 just dictates which field the agents to compare.
-
-If you want the activation `property` to be a parameter of your model, simply
-define `model.properties` so that it is possible to access
-`model.properties[:activation_property]`, which will be used instead of `property`.
 """
 function property_activation(p::Symbol)
     function by_property(model::ABM{A, S, F, P}) where {A, S, F, P}
-        property = P == Nothing ? p : get(model.properties, :activation_property, p)
         ids = collect(keys(model.agents))
-        properties = [getproperty(model.agents[id], property) for id in ids]
+        properties = [getproperty(model.agents[id], p) for id in ids]
         s = sortperm(properties)
         return ids[s]
     end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -92,7 +92,7 @@ Return the number of agents in the `model`.
 nagents(model::ABM) = length(model.agents)
 
 """
-    by_id(model::ABM)
+    by_id
 Activate agents at each step according to their id.
 """
 function by_id(model::ABM)
@@ -103,7 +103,7 @@ end
 @deprecate as_added by_id
 
 """
-    random_activation(model::ABM)
+    random_activation
 Activate agents once per step in a random order.
 """
 function random_activation(model::ABM)
@@ -111,9 +111,8 @@ function random_activation(model::ABM)
 end
 
 """
-    partial_activation(model::ABM)
-At each step, activate only `activation_prob` number of randomly chosen of individuals
-with a `activation_prob` probability.
+    partial_activation
+At each step, activate only `activation_prob` percentage of randomly chosen agents.
 `activation_prob` must be a field in the model and between 0 and 1.
 """
 function partial_activation(model::ABM)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -113,10 +113,16 @@ end
 """
     partial_activation(p)
 At each step, activate only `p` percentage of randomly chosen agents.
+
+If you want the activation probability `p` to be a parameter of your model, simply
+define `model.properties` so that it is possible to access
+`model.properties[:activation_probability]`. This number will be used instead of `p`.
 """
 function partial_activation(p::Real)
-    function partial(model)
-        ids = collect(keys(model))
-        return randsubseq(1:agentnum, p)
+    function partial(model::ABM{A, S, F, P}) where {A, S, F, P}
+        ids = collect(keys(model.agents))
+        ap = P == nothing ? p : get(model.properties, :activation_probability, p)
+        return randsubseq(1:agentnum, ap)
     end
+    return partial
 end

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -58,11 +58,11 @@ a = model.scheduler(model)
 @test a[1] == 74 # reproducibility test
 
 # by property
-mutable struct Agent2 <: AbstractAgent
+mutable struct Agentw <: AbstractAgent
   id::Int
   w::Float64
 end
-model = ABM(Agent2; scheduler = property_activation(:w))
+model = ABM(Agentw; scheduler = property_activation(:w))
 for i in 1:N; add_agent!(model, rand()/rand()); end
 
 Random.seed!(12)

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -20,3 +20,39 @@ pos1 = model1.space.agent_positions[coord2vertex((1,1), model1)]
 @test length(pos1) == 0
 pos2 = model1.space.agent_positions[coord2vertex((2,2), model1)]
 @test pos2[1] == 1
+
+# %% Scheduler tests
+N = 1000
+mutable struct Agent0 <: AbstractAgent
+  id::Int
+end
+# fastest
+model = ABM(Agent0)
+for i in 1:N; add_agent!(model); end
+@test sort!(collect(keys(model.agents))) == 1:N
+
+# by_id
+model = ABM(Agent0; scheduler = by_id)
+for i in 1:N; add_agent!(model); end
+
+@test sort!(collect(keys(model.agents))) == 1:N
+
+@test model.scheduler(model) == 1:N
+
+using Random
+Random.seed!(12)
+
+# random
+model = ABM(Agent0; scheduler = random_activation)
+for i in 1:N; add_agent!(model); end
+
+@test model.scheduler(model)[1:3] == [913, 522, 637] # reproducibility test
+
+# partial
+Random.seed!(12)
+model = ABM(Agent0; scheduler = partial_activation(0.1))
+for i in 1:N; add_agent!(model); end
+
+a = model.scheduler(model)
+@test length(a) < N
+@test a[1] == 74 # reproducibility test

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -56,3 +56,19 @@ for i in 1:N; add_agent!(model); end
 a = model.scheduler(model)
 @test length(a) < N
 @test a[1] == 74 # reproducibility test
+
+# by property
+mutable struct Agent2 <: AbstractAgent
+  id::Int
+  w::Float64
+end
+model = ABM(Agent2; scheduler = property_activation(:w))
+for i in 1:N; add_agent!(model, rand()/rand()); end
+
+Random.seed!(12)
+a = model.scheduler(model)
+
+ids = collect(keys(model.agents))
+properties = [model.agents[id].w for id in ids]
+
+@test ids[sortperm(properties)] == a


### PR DESCRIPTION
I have changed `as_added`, to `by_id`, because "as added" is a misleading name. Dictionary keys have no sequence and also no memory of which is added first.

I've added scheduler `fastest` and made it the default, which is just the key iterator of the dictionary.

Added basic API tests for schedulers.