### PR TITLE
Add Codecov upload to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,5 @@ jobs:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
-      after_success: skip
+      after_success:
+        - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,14 @@ notifications:
 
 jobs:
   include:
+    - stage: "Tests"
+      julia: 1.3
+      os: linux
+      script:
+        - julia --code-coverage test/runtests.jl
+      after_success:
+        - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+
     - stage: "Documentation"
       julia: 1.3
       os: linux
@@ -31,5 +39,3 @@ jobs:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
-      after_success:
-        - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,4 @@ jobs:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ notifications:
 
 jobs:
   include:
-    - stage: "Tests"
+    - stage: "Coverage"
       julia: 1.3
       os: linux
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
       julia: 1.3
       os: linux
       script:
-        - julia --code-coverage test/runtests.jl
+        - julia --project --color=yes --check-bounds=yes -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.test( ; coverage=true)';
       after_success:
         - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaDynamics.github.io/Agents.jl/dev)
 [![status](http://joss.theoj.org/papers/11ec21a6bb0a6e9992c07f26a601d580/status.svg)](http://joss.theoj.org/papers/11ec21a6bb0a6e9992c07f26a601d580)
 [![Build Status](https://travis-ci.org/JuliaDynamics/Agents.jl.svg?branch=master)](https://travis-ci.org/JuliaDynamics/Agents.jl)
+[![codecov](https://codecov.io/gh/JuliaDynamics/Agents.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaDynamics/Agents.jl)
 
 Agents.jl is a [Julia](https://julialang.org/) framework for agent-based modeling (ABM). It provides a structure and components for quickly implementing agent-based models, run them in batch, collect data, and visualize them. To that end, it provides the following functionalities:
 


### PR DESCRIPTION
For increasing test coverage (https://github.com/JuliaDynamics/Agents.jl/issues/72), seeing where to increase coverage would be nice.

Same setup as eg. [ODE.jl](https://github.com/JuliaDiffEq/ODE.jl/blob/master/.travis.yml#L27).

This would need an admin to connect the repo to [Codecov](https://codecov.io/). 