### PR TITLE
Implement and test genocide!(model::ABM, f::Function)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Ali Vahdati", "George Datseris"]
-version = "2.3.0"
+version = "2.4.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -26,7 +26,7 @@ end
 
 """
     genocide!(model::ABM, f::Function)
-Kills all agents where the function `f(agent)` returns `true`.
+Kill all agents where the function `f(agent)` returns `true`.
 """
 function genocide!(model::ABM, f::Function)
     for (k, v) in model.agents

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -25,6 +25,18 @@ function genocide!(model::ABM, n::Int)
 end
 
 """
+    genocide!(model::ABM, f::Function)
+Kills all agents where the function `f(agent)` returns `true`.
+"""
+function genocide!(model::ABM, f::Function)
+    for (k, v) in model.agents
+        if f(v)
+            kill_agent!(v, model)
+        end
+    end
+end
+
+"""
     sample!(model::ABM, n [, weight]; kwargs...)
 
 Replace the agents of the `model` with a random sample of the current agents with


### PR DESCRIPTION
This adds unit tests for the `genocide!` functions in the API, and implements the requested additional `genocide!(model::ABM, f::Function)`, which closes #134.

I've attempted to keep to the style of similar methods and tests as much as practicable.

For the moment we just throw a `TypeError` if `f` doesn't return `Bool`. Fairly certain that's OK based on other unit tests in the project, but could be easily changed.