### PR TITLE
[WIP] Verbose spaces and Agent constructor guards

### DIFF
--- a/examples/continuous_space.jl
+++ b/examples/continuous_space.jl
@@ -15,7 +15,7 @@ end
 
 function model_initiation(;N=100, speed=0.005, space_resolution=0.001, seed=0)
   Random.seed!(seed)
-  space = Space(2; periodic = true, extend = (1, 1))
+  space = ContinuousSpace(2; periodic = true, extend = (1, 1))
   model = ABM(Agent, space);
 
   ## Add initial individuals

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -39,7 +39,7 @@ end
 # We then make a setup function that initializes the model
 function model_initiation(; f, d, p, griddims, seed = 111)
     Random.seed!(seed)
-    space = Space(griddims, moore = true)
+    space = GridSpace(griddims, moore = true)
     properties = Dict(:f => f, :d => d, :p => p)
     forest = AgentBasedModel(Tree, space; properties=properties)
 

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -25,7 +25,7 @@ mutable struct SchellingAgent <: AbstractAgent
 end
 
 # Notice that the position of this Agent type is a `Tuple{Int,Int}` because
-# we will use a grid `Space`.
+# we will use a `GridSpace`.
 
 # We added two more fields for this model, namely a `mood` field which will
 # store `true` for a happy agent and `false` for an unhappy one, and an `group`
@@ -35,7 +35,7 @@ end
 
 # For this example, we will be using a Moore 2D grid, e.g.
 
-space = Space((10,10), moore = true)
+space = GridSpace((10,10), moore = true)
 
 # ## Creating an ABM
 

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -65,7 +65,7 @@ function model_initiation(;Ns, migration_rates, β_und, β_det, infection_period
   properties =
     @dict(Ns, Is, β_und, β_det, β_det, migration_rates, infection_period,
     infection_period, reinfection_probability, detection_time, C, death_rate)
-  space = Space(complete_digraph(C))
+  space = GraphSpace(complete_digraph(C))
   model = ABM(PoorSoul, space; properties=properties)
 
   ## Add initial individuals

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -80,7 +80,7 @@ mutable struct WealthInSpace <: AbstractAgent
 end
 
 function wealth_model_2D(;dims = (25,25), wealth = 1, M = 1000)
-  space = Space(dims, periodic = true)
+  space = GridSpace(dims, periodic = true)
   model = ABM(WealthInSpace, space; scheduler = random_activation)
   for i in 1:M # add agents in random nodes
       add_agent!(model, wealth)

--- a/src/CA1D.jl
+++ b/src/CA1D.jl
@@ -15,7 +15,7 @@ Builds a 1D cellular automaton. `rules` is a dictionary with this format: `Dict(
 """
 function build_model(;rules::Dict, ncols::Integer=101)
   nv=(ncols,1)
-  space = Space(nv)
+  space = GridSpace(nv)
   properties = Dict(:rules => rules)
   model = ABM(Cell, space; properties = properties, scheduler=by_id)
   for n in 1:ncols

--- a/src/CA2D.jl
+++ b/src/CA2D.jl
@@ -14,7 +14,7 @@ end
 Builds a 2D cellular automaton. `rules` is of type `Tuple{Integer,Integer,Integer}`. The numbers are DSR (Death, Survival, Reproduction). Cells die if the number of their living neighbors are <D, survive if the number of their living neighbors are <=S, come to life if their living neighbors are as many as R. `dims` is the x and y size a grid. `Moore` specifies whether cells should connect to their diagonal neighbors.
 """
 function build_model(;rules::Tuple, dims=(100,100), Moore=true)
-  space = Space(dims, moore=Moore)
+  space = GridSpace(dims, moore=Moore)
   properties = Dict(:rules => rules, :Moore=>Moore)
   model = ABM(Cell, space; properties = properties, scheduler=by_id)
   nnodes = dims[1]*dims[2]

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -66,7 +66,7 @@ Add `agentID` to the new position `pos` in the model
 and remove it from the old position
 (also update the agent to have the new position).
 `pos` must be the appropriate position type depending on the [`Space`](@ref) type,
-e.g. `Int` for `GraphSpace`, `NTuple{<:AbstractFloat}}` for `ContinuousSpace`, etc.
+e.g. `Int` for `GraphSpace`, `NTuple{Int}` for `GridSpace`, `NTuple{<:AbstractFloat}` for `ContinuousSpace`, etc.
 """
 function move_agent!(agent::AbstractAgent, pos::Tuple, model::ABM)
   nodenumber = coord2vertex(pos, model)

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -19,12 +19,8 @@ end
 
 const COORDS = 'a':'z' # letters representing coordinates in database
 
-# TODO: `Space` became overly complicated and there is no reason to use the same
-# name for all spaces anymore. Instead, we should properly use `GraphSpace`,
-# `GridSpace`, `ContinuousSpace`. A depwarning should be added to `Space`.
-
 """
-    Space(D::Int [, update_vel!]; periodic::Bool = false, extend = nothing, metric = "cityblock")
+    ContinuousSpace(D::Int [, update_vel!]; periodic::Bool = false, extend = nothing, metric = "cityblock")
 Create a `ContinuousSpace` of dimensionality `D`.
 In this case, your agent positions (field `pos`) should be of type `NTuple{D, F}`
 where `F <: AbstractFloat`.
@@ -45,7 +41,7 @@ By default no update is done this way.
   (after which periodicity happens. All dimensions start at 0).
 
 """
-function Space(D::Int, update_vel! = defvel;
+function ContinuousSpace(D::Int, update_vel! = defvel;
   periodic = false, extend = nothing, metric = "cityblock")
 
   # TODO: implement using different metrics in space_neighbors
@@ -57,6 +53,8 @@ function Space(D::Int, update_vel! = defvel;
   db, q, q2, q3, q4 = prepare_database(D)
   ContinuousSpace(D, update_vel!, periodic, extend, metric, db, q, q2, q3, q4)
 end
+
+@deprecate Space(D::Int, update_vel!::Function) ContinuousSpace(D::Int, update_vel!::Function)
 
 function prepare_database(D)
   db = SQLite.DB()

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -63,6 +63,23 @@ function AgentBasedModel(
         ::Type{A}, space::S = nothing;
         scheduler::F = fastest, properties::P = nothing
         ) where {A<:AbstractAgent, S<:SpaceType, F, P}
+
+    # Check A for required properties & fields
+    isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
+    any(isequal(:id), fieldnames(A)) || throw(ArgumentError("Agent struct must have an `id` field"))
+    if space != nothing
+        any(isequal(:pos), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
+        # Check `pos` field in A has the correct type
+        pos_type = fieldtype(A, :pos)
+        if typeof(space) <: GridSpace && !(pos_type <: NTuple{D, Integer} where {D})
+            throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Int} when using GridSpace."))
+        elseif typeof(space) <: ContinuousSpace && !(pos_type <: NTuple{D, Float64} where {D})
+            throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
+        elseif typeof(space) <: GraphSpace && !(pos_type <: Integer)
+            throw(ArgumentError("`pos` field in Agent struct must be of type Int when using GraphSpace."))
+        end
+    end
+
     agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
 end

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -1,4 +1,4 @@
-export Space, vertex2coords, coords2vertex, node_neighbors,
+export GraphSpace, GridSpace, Space, vertex2coords, coords2vertex, node_neighbors,
 find_empty_nodes, pick_empty, has_empty_nodes, get_node_contents,
 id2agent, NodeIterator, space_neighbors, nodes, get_node_agents
 export nv, ne
@@ -38,6 +38,7 @@ function Base.show(io::IO, abm::DiscreteSpace)
 end
 
 Space(m::ABM) = m.space
+
 agent_positions(m::ABM) = m.space.agent_positions
 agent_positions(m::DiscreteSpace) = m.agent_positions
 Base.size(s::GridSpace) = s.dimensions
@@ -50,17 +51,19 @@ Base.isempty(node::Integer, model::ABM) =
 length(model.space.agent_positions[node]) == 0
 
 """
-    Space(graph::AbstractGraph) → GraphSpace
+    GraphSpace(graph::AbstractGraph) → GraphSpace
 Create a `GraphSpace` instance that is underlined by an arbitrary graph.
 In this case, your agent positions (field `pos`) must be of type `Integer`.
 """
-function Space(graph::G) where {G<:AbstractGraph}
+function GraphSpace(graph::G) where {G<:AbstractGraph}
   agent_positions = [Int[] for i in 1:LightGraphs.nv(graph)]
   return GraphSpace{G}(graph, agent_positions)
 end
 
+@deprecate Space(graph::G) where {G<:AbstractGraph} GraphSpace(graph::G) where {G<:AbstractGraph}
+
 """
-    Space(dims::NTuple; periodic = false, moore = false) → GridSpace
+    GridSpace(dims::NTuple; periodic = false, moore = false) → GridSpace
 Create a `GridSpace` instance that represents a grid of dimensionality `length(dims)`,
 with each dimension having the size of the corresponding entry of `dims`.
 In this case, your agent positions (field `pos`) must be of type `NTuple{Int}`.
@@ -70,11 +73,13 @@ and if the connections should be of type Moore or not (in the Moore case
 the diagonal connections are also valid. E.g. for a 2D grid, each node has
 8 neighbors).
 """
-function Space(dims::NTuple{D, I}; periodic = false, moore = false) where {D, I}
+function GridSpace(dims::NTuple{D, I}; periodic = false, moore = false) where {D, I}
   graph = _grid(dims..., periodic, moore)
   agent_positions = [Int[] for i in 1:LightGraphs.nv(graph)]
   return GridSpace{typeof(graph), D, I}(graph, agent_positions, dims)
 end
+
+@deprecate Space(dims::NTuple{D, I}) where {D, I} GridSpace(dims::NTuple{D, I}) where {D, I}
 
 # 1d grid
 function _grid(length::Integer, periodic::Bool=false, moore::Bool = false)

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -1,6 +1,28 @@
 using Agents, Test, Random
 
-model1 = ABM(Agent1, Space((3,3)))
+@testset "Model construction" begin
+    mutable struct BadAgent <: AbstractAgent
+        useless::Int
+        pos::Int
+    end
+    struct ImmutableAgent <: AbstractAgent
+        id::Int
+    end
+    # Cannot use ImmutableAgent since it cannot be edited
+    @test_throws ArgumentError ABM(ImmutableAgent)
+    # Cannot use BadAgent since it has no `id`
+    @test_throws ArgumentError ABM(BadAgent)
+    # Cannot use BadAgent in a grid space context since `pos` has an invalid type
+    @test_throws ArgumentError ABM(BadAgent, GridSpace((1,1)))
+    # Cannot use Agent0 in a grid space context since it has no `pos`
+    @test_throws ArgumentError ABM(Agent0, GridSpace((1,1)))
+    # Cannot use Agent3 in a graph space context since `pos` has an invalid type
+    @test_throws ArgumentError ABM(Agent3, GraphSpace(Agents.Graph(1)))
+    # Cannot use Agent3 in a continuous space context since `pos` has an invalid type
+    @test_throws ArgumentError ABM(Agent3, ContinuousSpace(2))
+end
+
+model1 = ABM(Agent1, GridSpace((3,3)))
 
 agent = add_agent!((1,1), model1)
 @test agent.pos == (1, 1)
@@ -78,8 +100,8 @@ properties = [model.agents[id].weight for id in ids]
   sample!(model, 40, :weight)
   @test Agents.nagents(model) == 40
 
-  model2 = ABM(Agent5, Space((10, 10)))
-  for i in 1:20; add_agent!(Agent5(i, i, rand()/rand()), model2); end
+  model2 = ABM(Agent3, GridSpace((10, 10)))
+  for i in 1:20; add_agent_single!(Agent3(i, (1,1), rand()/rand()), model2); end
   allweights = [i.weight for i in values(model2.agents)]
   mean_weights = sum(allweights)/length(allweights)
   sample!(model2, 12, :weight)
@@ -93,7 +115,7 @@ properties = [model.agents[id].weight for id in ids]
 end
 
 @testset "genocide!" begin
-  model = ABM(Agent3, Space((10, 10)))
+  model = ABM(Agent3, GridSpace((10, 10)))
 
   # Testing genocide!(model::ABM)
   for i in 1:20

--- a/test/continuousSpace_tests.jl
+++ b/test/continuousSpace_tests.jl
@@ -1,14 +1,14 @@
 @testset "Continuous space" begin
 
   # Basic model initialization
-  space1 = Space(2; periodic = true, extend = (1, 1))
-  space2 = Space(2; periodic = false, extend = (1, 1))
-  space3 = Space(2; periodic = true, extend = (2, 1))
-  space4 = Space(2; periodic = true, extend = (1, 2))
-  space5 = Space(2; periodic = true, extend = (2, 2))
-  space6 = Space(1; periodic = true, extend = (1,))
-  space7 = Space(3; periodic = true, extend = (1,1,1))
-  space8 = Space(3; periodic = false, extend = (1,1,1))
+  space1 = ContinuousSpace(2; periodic = true, extend = (1, 1))
+  space2 = ContinuousSpace(2; periodic = false, extend = (1, 1))
+  space3 = ContinuousSpace(2; periodic = true, extend = (2, 1))
+  space4 = ContinuousSpace(2; periodic = true, extend = (1, 2))
+  space5 = ContinuousSpace(2; periodic = true, extend = (2, 2))
+  space6 = ContinuousSpace(1; periodic = true, extend = (1,))
+  space7 = ContinuousSpace(3; periodic = true, extend = (1,1,1))
+  space8 = ContinuousSpace(3; periodic = false, extend = (1,1,1))
 
   @test space1.D == 2
   @test space2.D == 2

--- a/test/interaction_tests.jl
+++ b/test/interaction_tests.jl
@@ -9,7 +9,7 @@ end
 function forest_initiation(;f, d, p, griddims, seed)
   Random.seed!(seed)
 
-  space = Space(griddims, moore = true)
+  space = GridSpace(griddims, moore = true)
 
   properties = Dict(:f => f, :d => d, :p => p)
   forest = ABM(Tree, space; properties=properties, scheduler=random_activation)
@@ -85,13 +85,13 @@ end
   @test agent.id in model.space.agent_positions[coord2vertex((2,9), model)]
   @test agent.id in model.space.agent_positions[coord2vertex(new_pos, model)]
 
-  model1 = ABM(Agent1, Space((3,3)))
+  model1 = ABM(Agent1, GridSpace((3,3)))
   add_agent!(1, model1)
   @test model1.agents[1].pos == (1, 1)
   add_agent!((2,1), model1)
   @test model1.agents[2].pos == (2, 1)
 
-  model2 = ABM(Agent4, Space((3,3)))
+  model2 = ABM(Agent4, GridSpace((3,3)))
   add_agent!(1, model2, 3)
   @test model2.agents[1].pos == (1,1)
   @test 1 in model2.space.agent_positions[1]

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -1,15 +1,28 @@
 using Random
 Random.seed!(209)
 
+@testset "Deprecated spaces" begin
+  # GraphSpace
+  @test_deprecated (@test_throws TypeError Space(Agents.Graph(1)))
+  # GridSpace
+  @test_deprecated (@test_throws TypeError Space((5,1)))
+  # ContinuousSpace
+  @test_deprecated Space(5, (a,m)->nothing)
+end
+
+@testset "graphs" begin
+  @test GraphSpace(Agents.Graph(1)).graph == Agents.Graph(1) #TODO: poor test
+end
+
 @testset "0D grids" begin
-  @test Space((1,)).graph == Agents.Graph(1)
+  @test GridSpace((1,)).graph == Agents.Graph(1)
 end
 
 @testset "1D grids" begin
-  a = Space((5,1))
+  a = GridSpace((5,1))
   ae = collect(Agents.LightGraphs.edges(a.graph))
 
-  b = Space((5,1), periodic=true)
+  b = GridSpace((5,1), periodic=true)
   be = collect(Agents.LightGraphs.edges(b.graph))
 
   @test ae == [Agents.LightGraphs.Edge(1,2),Agents.LightGraphs.Edge(2,3), Agents.LightGraphs.Edge(3,4), Agents.LightGraphs.Edge(4,5)]
@@ -17,10 +30,10 @@ end
 end
 
 @testset "2D grids" begin
-  @test Space((2,1)).graph == Agents.Graph(2,1)
+  @test GridSpace((2,1)).graph == Agents.Graph(2,1)
 
-  a = Space((2,3))
-  b = Space((2,3), periodic=true) # 2D grid
+  a = GridSpace((2,3))
+  b = GridSpace((2,3), periodic=true) # 2D grid
 
   @test a.dimensions == (2,3)
   @test b.dimensions == (2,3)
@@ -40,28 +53,28 @@ end
 end
 
 @testset "2D Moore" begin
-  a = Space((3, 3), moore=true)
+  a = GridSpace((3, 3), moore=true)
   @test Agents.nv(a) == 9
   @test Agents.ne(a) == 20
 
-  a = Space((3, 4), moore=true)
+  a = GridSpace((3, 4), moore=true)
   @test Agents.nv(a) == 12
   @test Agents.ne(a) == 29
 
-  b = Space((3, 2), moore=true, periodic=true)
+  b = GridSpace((3, 2), moore=true, periodic=true)
   @test Agents.nv(b) == 6
   @test Agents.ne(b) == 15
 
-  b = Space((3, 3), moore=true, periodic=true)
+  b = GridSpace((3, 3), moore=true, periodic=true)
   @test Agents.nv(b) == 9
   @test Agents.ne(b) == 36
 end
 
 @testset "3D grid" begin
-  g1 = Space((2,3,2))
-  g2 = Space((2,3,3))
-  g3 = Space((2,3,2), periodic=true)
-  g4 = Space((2,3,3), periodic=true)
+  g1 = GridSpace((2,3,2))
+  g2 = GridSpace((2,3,3))
+  g3 = GridSpace((2,3,2), periodic=true)
+  g4 = GridSpace((2,3,3), periodic=true)
   @test Agents.ne(g1) == 20
   @test Agents.ne(g2) == 33
   @test Agents.ne(g3) == 24
@@ -93,7 +106,7 @@ end
 end
 
 @testset "nodes" begin
-  space = Space((3,3))
+  space = GridSpace((3,3))
   model = ABM(Agent1, space)
   for node in nodes(model)
     if rand() > 0.7


### PR DESCRIPTION
Starting the move to a more verbose `Space` layout, I've changed the three current space constructors to have the underlying struct's name, so `GraphSpace`, `GridSpace` & `ContinuousSpace`.

- `Space(model::ABM)` has been left in, since it may be a useful helper (although it doesn't seem to be used currently)
- Test cases are functional
- benchmarks and examples have not completely been updated
- most likely some more documentation to fix
- deprecations are added, although I'm having problems with those macros&mdash;they seem to want to spit a type error at you along with the warning. 

Then, there's a start on the work for #148, for which we now have guards and tests for user implemented `AbstractAgent` subtypes. 

- This is a bit more abstract than I'd like, but it needs to deal with the possibility of composite types. We therefore can't use nice helpers like `hasfield(A, :id)` or `A.mutable`, since they only work on `DataTypes`s. With that being said, the current implementation works across our requirements.

I need a bit of clarification from this point on though.
`vertex2coords` and `coords2vertex` are exposed in `core/space`, but the functions are actually without the pluralisation (`vertex2coord` and `coord2vertex`), so there's a bit of general confusion there.

> underlying network structure

Do you mean the ability to do this?
```julia
space = GridSpace((10,10))
space.graph
```
if that's the case, `node_neighbors(node, model::ABM{A, <:DiscreteSpace} [, r]) → nodes` should probably be changed to something like `agent_neighbors(agent, model::ABM{A, <:DiscreteSpace} [, r]) → agents`?

What other things do you think would make sense for this PR?
 