### PR TITLE
Add agent guards to ABM constructor

### DIFF
--- a/src/CA1D.jl
+++ b/src/CA1D.jl
@@ -2,10 +2,10 @@
 module CA1D
 using Agents
 
-mutable struct Cell{T<:Integer, Y<:AbstractString} <: AbstractAgent
-  id::T
-  pos::Tuple{T, T}
-  status::Y
+mutable struct Cell <: AbstractAgent
+  id::Int
+  pos::Tuple{Int, Int}
+  status::String
 end
 
 """

--- a/src/CA2D.jl
+++ b/src/CA2D.jl
@@ -2,10 +2,10 @@
 module CA2D
 using Agents
 
-mutable struct Cell{T<:Integer, Y<:AbstractString} <: AbstractAgent
-  id::T
-  pos::Tuple{T, T}
-  status::Y
+mutable struct Cell <: AbstractAgent
+  id::Int
+  pos::Tuple{Int, Int}
+  status::String
 end
 
 """

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -109,7 +109,7 @@ function agent_validator(::Type{A}, space::S) where {A<:AbstractAgent, S<:SpaceT
     isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
     (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("First field of Agent struct must be `id`"))
     if space != nothing
-        (any(isequal(:pos), fieldnames(A)) && fieldnames(A)[2] == :pos) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
+        (any(isequal(:pos), fieldnames(A)) && fieldnames(A)[2] == :pos) || throw(ArgumentError("Second field of Agent struct be `pos` when using a space"))
         # Check `pos` field in A has the correct type
         pos_type = fieldtype(A, :pos)
         space_type = typeof(space)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -106,9 +106,9 @@ Checks for mutability and existance and correct types for fields depending on `S
 function agent_validator(::Type{A}, space::S) where {A<:AbstractAgent, S<:SpaceType}
     # Check A for required properties & fields
     isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
-    any(isequal(:id), fieldnames(A)) || throw(ArgumentError("Agent struct must have an `id` field"))
+    (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("Agent struct must have an `id` field"))
     if space != nothing
-        any(isequal(:pos), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
+        (any(isequal(:pos), fieldnames(A)) && fieldnames(A)[2] == :pos) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
         # Check `pos` field in A has the correct type
         pos_type = fieldtype(A, :pos)
         space_type = typeof(space)
@@ -120,11 +120,11 @@ function agent_validator(::Type{A}, space::S) where {A<:AbstractAgent, S<:SpaceT
             # `vel` field in A must be checked alongside `pos`
             any(isequal(:vel), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `vel` field when using ContinuousSpace"))
             vel_type = fieldtype(A, :vel)
-            if !(pos_type <: NTuple{D, Float64} where {D}) && !(vel_type <: NTuple{D, Float64} where {D})
+            if !(pos_type <: NTuple{D, <:AbstractFloat} where {D}) && !(vel_type <: NTuple{D, <:AbstractFloat} where {D})
                 throw(ArgumentError("`pos` and `vel` fields in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
-            elseif !(pos_type <: NTuple{D, Float64} where {D})
+            elseif !(pos_type <: NTuple{D, <:AbstractFloat} where {D})
                 throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
-            elseif !(vel_type <: NTuple{D, Float64} where {D})
+            elseif !(vel_type <: NTuple{D, <:AbstractFloat} where {D})
                 throw(ArgumentError("`vel` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
             end
         end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -107,7 +107,7 @@ function agent_validator(::Type{A}, space::S) where {A<:AbstractAgent, S<:SpaceT
     # Check A for required properties & fields
     isconcretetype(A) || throw(ArgumentError("Agent struct must be a concrete type"))
     isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
-    (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("Agent struct must have an `id` field"))
+    (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("First field of Agent struct must be `id`"))
     if space != nothing
         (any(isequal(:pos), fieldnames(A)) && fieldnames(A)[2] == :pos) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
         # Check `pos` field in A has the correct type

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -78,6 +78,31 @@ function AgentBasedModel(
         ::Type{A}, space::S = nothing;
         scheduler::F = fastest, properties::P = nothing
         ) where {A<:AbstractAgent, S<:SpaceType, F, P}
+    # Check A for required properties & fields
+    isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
+    any(isequal(:id), fieldnames(A)) || throw(ArgumentError("Agent struct must have an `id` field"))
+    if space != nothing
+        any(isequal(:pos), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
+        # Check `pos` field in A has the correct type
+        pos_type = fieldtype(A, :pos)
+        space_type = typeof(space)
+        if space_type <: GraphSpace && !(pos_type <: Integer)
+            throw(ArgumentError("`pos` field in Agent struct must be of type Int when using GraphSpace."))
+        elseif space_type <: GridSpace && !(pos_type <: NTuple{D, Integer} where {D})
+            throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Int} when using GridSpace."))
+        elseif space_type <: ContinuousSpace
+            any(isequal(:vel), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `vel` field when using ContinuousSpace"))
+            vel_type = fieldtype(A, :vel)
+            if !(pos_type <: NTuple{D, Float64} where {D}) && !(vel_type <: NTuple{D, Float64} where {D})
+                throw(ArgumentError("`pos` and `vel` fields in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
+            elseif !(pos_type <: NTuple{D, Float64} where {D})
+                throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
+            elseif !(vel_type <: NTuple{D, Float64} where {D})
+                throw(ArgumentError("`vel` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
+            end
+        end
+    end
+
     agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
 end

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -105,6 +105,7 @@ Checks for mutability and existance and correct types for fields depending on `S
 """
 function agent_validator(::Type{A}, space::S) where {A<:AbstractAgent, S<:SpaceType}
     # Check A for required properties & fields
+    isconcretetype(A) || throw(ArgumentError("Agent struct must be a concrete type"))
     isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
     (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("Agent struct must have an `id` field"))
     if space != nothing

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -78,30 +78,7 @@ function AgentBasedModel(
         ::Type{A}, space::S = nothing;
         scheduler::F = fastest, properties::P = nothing
         ) where {A<:AbstractAgent, S<:SpaceType, F, P}
-    # Check A for required properties & fields
-    isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
-    any(isequal(:id), fieldnames(A)) || throw(ArgumentError("Agent struct must have an `id` field"))
-    if space != nothing
-        any(isequal(:pos), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
-        # Check `pos` field in A has the correct type
-        pos_type = fieldtype(A, :pos)
-        space_type = typeof(space)
-        if space_type <: GraphSpace && !(pos_type <: Integer)
-            throw(ArgumentError("`pos` field in Agent struct must be of type Int when using GraphSpace."))
-        elseif space_type <: GridSpace && !(pos_type <: NTuple{D, Integer} where {D})
-            throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Int} when using GridSpace."))
-        elseif space_type <: ContinuousSpace
-            any(isequal(:vel), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `vel` field when using ContinuousSpace"))
-            vel_type = fieldtype(A, :vel)
-            if !(pos_type <: NTuple{D, Float64} where {D}) && !(vel_type <: NTuple{D, Float64} where {D})
-                throw(ArgumentError("`pos` and `vel` fields in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
-            elseif !(pos_type <: NTuple{D, Float64} where {D})
-                throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
-            elseif !(vel_type <: NTuple{D, Float64} where {D})
-                throw(ArgumentError("`vel` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
-            end
-        end
-    end
+    agent_validator(A, space)
 
     agents = Dict{Int, A}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
@@ -118,6 +95,39 @@ function Base.show(io::IO, abm::ABM{A}) where {A}
     print(io, s)
     if abm.properties ≠ nothing
         print(io, "\n properties: ", abm.properties)
+    end
+end
+
+"""
+    agent_validator(agent, space)
+Validate the user supplied agent (subtype of `AbstractAgent`).
+Checks for mutability and existance and correct types for fields depending on `SpaceType`.
+"""
+function agent_validator(::Type{A}, space::S) where {A<:AbstractAgent, S<:SpaceType}
+    # Check A for required properties & fields
+    isbitstype(A) && throw(ArgumentError("Agent struct must be mutable"))
+    any(isequal(:id), fieldnames(A)) || throw(ArgumentError("Agent struct must have an `id` field"))
+    if space != nothing
+        any(isequal(:pos), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `pos` field when using a space"))
+        # Check `pos` field in A has the correct type
+        pos_type = fieldtype(A, :pos)
+        space_type = typeof(space)
+        if space_type <: GraphSpace && !(pos_type <: Integer)
+            throw(ArgumentError("`pos` field in Agent struct must be of type Int when using GraphSpace."))
+        elseif space_type <: GridSpace && !(pos_type <: NTuple{D, Integer} where {D})
+            throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Int} when using GridSpace."))
+        elseif space_type <: ContinuousSpace
+            # `vel` field in A must be checked alongside `pos`
+            any(isequal(:vel), fieldnames(A)) || throw(ArgumentError("Agent struct must have a `vel` field when using ContinuousSpace"))
+            vel_type = fieldtype(A, :vel)
+            if !(pos_type <: NTuple{D, Float64} where {D}) && !(vel_type <: NTuple{D, Float64} where {D})
+                throw(ArgumentError("`pos` and `vel` fields in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
+            elseif !(pos_type <: NTuple{D, Float64} where {D})
+                throw(ArgumentError("`pos` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
+            elseif !(vel_type <: NTuple{D, Float64} where {D})
+                throw(ArgumentError("`vel` field in Agent struct must be of type NTuple{Float64} when using ContinuousSpace."))
+            end
+        end
     end
 end
 

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -1,19 +1,20 @@
 using Agents, Test, Random
 
+mutable struct BadAgent <: AbstractAgent
+    useless::Int
+    pos::Int
+end
+struct ImmutableAgent <: AbstractAgent
+    id::Int
+end
+mutable struct DiscreteVelocity <: AbstractAgent
+    id::Int
+    pos::NTuple{2, Float64}
+    vel::NTuple{2, Int}
+    diameter::Float64
+end
+
 @testset "Model construction" begin
-    mutable struct BadAgent <: AbstractAgent
-        useless::Int
-        pos::Int
-    end
-    struct ImmutableAgent <: AbstractAgent
-        id::Int
-    end
-    mutable struct DiscreteVelocity <: AbstractAgent
-        id::Int
-        pos::NTuple{2, Float64}
-        vel::NTuple{2, Int}
-        diameter::Float64
-    end
     # Cannot use ImmutableAgent since it cannot be edited
     @test_throws ArgumentError ABM(ImmutableAgent)
     # Cannot use BadAgent since it has no `id` field

--- a/test/interaction_tests.jl
+++ b/test/interaction_tests.jl
@@ -1,7 +1,7 @@
 ### Interactions are tested with the forest fire model
-mutable struct Tree{T<:Integer} <: AbstractAgent
-  id::T
-  pos::Tuple{T, T}
+mutable struct Tree <: AbstractAgent
+  id::Int
+  pos::Tuple{Int, Int}
   status::Bool  # true is green and false is burning
 end
 


### PR DESCRIPTION
Closes #147. Full test of requirements for `AbstractAgent` inside the constructor of `AgentBasedModel`.