### PR TITLE
Better functional termination of model run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Breaking changes
 * Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.
-* The `n::Function` argument of `step!` now takes two arguments.
 * Reworked the public API of `GridSpace` to be simpler: position must be `NTuple{Int}`. As a result `vertex2coord` and stuff no longer exported, since they are obsolete.
 * It is now mandatory to provide a concrete type when initializing an `ABM` (for type stability and performance)
 
@@ -11,6 +10,7 @@
 * new function `space_neighbors`, which works for any space. It always and consistently returns the **IDs** of neighbors irrespectively
   of the spatial structure.
 * `when` of `step!` can now be `true`.
+* `step!` has a keyword `Nmax`, used only when `n::Function`, that terminates the evolution if the model steps more than `Nmax`, regardless of what `n(model)` outputs.
 
 # v2.1
 * Renamed the old scheduler `as_added` to `by_id`, to reflect reality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # v3.0
-* Added `ContinuousSpace` as a space option!!!
+
+## Breaking changes
 * Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.
+* The `n::Function` argument of `step!` now takes two arguments.
+* Reworked the public API of `GridSpace` to be simpler: position must be `NTuple{Int}`. As a result `vertex2coord` and stuff no longer exported, since they are obsolete.
+
+## Additions
+* Added `ContinuousSpace` as a space option!!!
 * new function `space_neighbors`, which works for any space. It always and consistently returns the **IDs** of neighbors irrespectively
   of the spatial structure.
-* Reworked the public API of `GridSpace` to be simpler: position must be `NTuple{Int}`. As a result `vertex2coord` and stuff no longer exported, since they are obsolete.
 
 # v2.1
 * Renamed the old scheduler `as_added` to `by_id`, to reflect reality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 * Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.
 * The `n::Function` argument of `step!` now takes two arguments.
 * Reworked the public API of `GridSpace` to be simpler: position must be `NTuple{Int}`. As a result `vertex2coord` and stuff no longer exported, since they are obsolete.
+* It is now mandatory to provide a concrete type when initializing an `ABM` (for type stability and performance)
 
 ## Additions
 * Added `ContinuousSpace` as a space option!!!
 * new function `space_neighbors`, which works for any space. It always and consistently returns the **IDs** of neighbors irrespectively
   of the spatial structure.
+* `when` of `step!` can now be `true`.
 
 # v2.1
 * Renamed the old scheduler `as_added` to `by_id`, to reflect reality.

--- a/examples/HK.jl
+++ b/examples/HK.jl
@@ -1,12 +1,12 @@
 # # HK (Hegselmann and Krause) opinion dynamics model
 
-# In this example we showcase how to do synchronous updating of Agent properties
-# (also know as [Synchronous update schedule](http://jmckalex.org/compass/syn-and-asynch-expl.html)).
-# In a Synchronous update schedule changes made to an agent are not seen by
-# other agents until the next clock tick — that is,
-# all agents update simultaneously ([Wilensky 2015, p.286](https://mitpress.mit.edu/books/introduction-agent-based-modeling)).
-# We also showand how to terminate the system evolution on demand according to a boolean
-# function (here when some convergence is satisfied).
+# This example showcases
+# * How to do synchronous updating of Agent properties
+#   (also know as [Synchronous update schedule](http://jmckalex.org/compass/syn-and-asynch-expl.html)).
+#   In a Synchronous update schedule changes made to an agent are not seen by
+#   other agents until the next step, see also [Wilensky 2015, p.286](https://mitpress.mit.edu/books/introduction-agent-based-modeling)).
+# * How to terminate the system evolution on demand according to a boolean function.
+# * How to terminate the system evolution according to what happened on the _previous_ step.
 
 # ## Model overview
 
@@ -42,9 +42,11 @@ mutable struct HKAgent <: AbstractAgent
 end
 
 # There is a reason the agent has three fields that are "the same".
-# The `old_opinion` is used for synchronous agent update.
+# The `old_opinion` is used for synchronous agent update, since we require access
+# to a property's value at the start of the step and the end of the step.
 # The `previous_opinion` is the opinion of the agent in the _previous_ step,
-# and is use to terminate model evolution when convergence is reached.
+# since for the model termination we require access to a property's value
+# at the end of the previous step, and the end of the current step.
 
 function hk_model(;numagents = 100, ϵ = 0.2)
     model = ABM(HKAgent, scheduler = fastest,

--- a/examples/HK.jl
+++ b/examples/HK.jl
@@ -101,14 +101,13 @@ end
 # but only until all agents have converged to an opinion. From the documentation of
 # [`step!`](@ref) one can see that instead of specifying the amount of steps we can specify
 # a function instead.
-function terminate(model, s)
+function terminate(model)
     agents = values(model.agents)
     if any(!isapprox(a.previous_opinon, a.new_opinion) for a in agents)
         return false
     else
         return true
     end
-    s > 1000 && error("Run too long, something wrong!")
 end
 
 function model_run(; numagents = 100, ϵ= 0.05)

--- a/src/simulations/data_collector.jl
+++ b/src/simulations/data_collector.jl
@@ -74,7 +74,7 @@ function data_collecter_raw(model::ABM, properties::Array{Symbol}; step=1)
       temparray = [getproperty(model.agents[i], fn) for i in agent_ids]
     end
     begin
-      dd[!, :id] = sort(collect(keys(model.agents)))
+      dd[!, :id] = sort!(collect(keys(model.agents)))
     end
     fieldname = fn
     begin
@@ -124,14 +124,14 @@ function data_collector(model::ABM, properties::Array{Symbol}, step::Integer, df
   return df
 end
 
-collect(s, when::AbstractVector{Int}) = s ∈ when
-collect(s, when::Bool) = when
+add_data(s, when::AbstractVector{Int}) = s ∈ when
+add_data(s, when::Bool) = when
 
 function _step!(model, agent_step!, model_step!, properties, when, n::F, step0, df) where F<:Function
   ss = 1
   while !n(model, ss)
     step!(model, agent_step!, model_step!, 1)
-    if collect(ss, when)
+    if add_data(ss, when)
       df = data_collector(model, properties, ss, df)
     end
     ss += 1
@@ -142,7 +142,7 @@ end
 function _step!(model, agent_step!, model_step!, properties, when, n::Int, step0, df)
   for ss in 1:n
     step!(model, agent_step!, model_step!, 1)
-    if collect(ss, when)
+    if add_data(ss, when)
       df = data_collector(model, properties, ss, df)
     end
   end

--- a/src/simulations/data_collector.jl
+++ b/src/simulations/data_collector.jl
@@ -124,11 +124,14 @@ function data_collector(model::ABM, properties::Array{Symbol}, step::Integer, df
   return df
 end
 
+collect(s, when::AbstractVector{Int}) = s ∈ when
+collect(s, when::Bool) = when
+
 function _step!(model, agent_step!, model_step!, properties, when, n::F, step0, df) where F<:Function
   ss = 1
   while !n(model)
     step!(model, agent_step!, model_step!, 1)
-    if ss in when
+    if collect(ss, when)
       df = data_collector(model, properties, ss, df)
     end
     ss += 1
@@ -139,7 +142,7 @@ end
 function _step!(model, agent_step!, model_step!, properties, when, n::Int, step0, df)
   for ss in 1:n
     step!(model, agent_step!, model_step!, 1)
-    if ss in when
+    if collect(ss, when)
       df = data_collector(model, properties, ss, df)
     end
   end

--- a/src/simulations/data_collector.jl
+++ b/src/simulations/data_collector.jl
@@ -129,7 +129,7 @@ collect(s, when::Bool) = when
 
 function _step!(model, agent_step!, model_step!, properties, when, n::F, step0, df) where F<:Function
   ss = 1
-  while !n(model)
+  while !n(model, ss)
     step!(model, agent_step!, model_step!, 1)
     if collect(ss, when)
       df = data_collector(model, properties, ss, df)

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -9,8 +9,10 @@ agent has acted.
 
     step!(model, agent_step! [, model_step!], n::Function)
 
-`n` can be also be a function that takes as an input the `model` and returns
-`true/false`. Then `step!` runs the model until `n(model)` returns `true`.
+`n` can be also be a function that takes as an input the `model` and current step number `s`
+and returns `true/false`. Then `step!` runs the model until `n(model, s)` returns `true`.
+Having the `s` number as an argument is useful to add a fail-safe to your function
+(in case you don't want to let your model run *too* long).
 
     step!(model, agent_step! [, model_step!], n, properties; kwargs...)
 
@@ -56,7 +58,7 @@ function step! end
 dummystep(model) = nothing
 dummystep(agent, model) = nothing
 
-step!(model::ABM, agent_step!, n::Int = 1) = step!(model, agent_step!, dummystep, n)
+step!(model::ABM, agent_step!, n::Union{Integer, Function} = 1) = step!(model, agent_step!, dummystep, n)
 
 function step!(model::ABM, agent_step!::F, model_step!::G, n::Int = 1) where {F<:Function, G<:Function}
   for i in 1:n
@@ -69,8 +71,10 @@ function step!(model::ABM, agent_step!::F, model_step!::G, n::Int = 1) where {F<
 end
 
 function step!(model::ABM, agent_step!::F, model_step!::G, n::H) where {F<:Function, G<:Function, H<:Function}
-  while !n(model)
+  s = 1
+  while !n(model, s)
     step!(model, agent_step!, model_step!, 1)
+    s+=1
   end
 end
 

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -42,7 +42,8 @@ To apply a function to the list of agents, use `:agent` as a dictionary key.
 To apply a function to the model object, use `:model` as a dictionary key.
 
 ### Keywords
-* `when=1:n` : at which steps `n` to perform the data collection and processing.
+* `when=true` : at which steps `n` to perform the data collection and processing.
+  `true` means at all steps, otherwise you can specify steps explicitly like `1:5:1000`.
 * `replicates` : Optional. Run `replicates` replicates of the simulation. Defaults to 0.
 * `parallel` : Optional. Only when `replicates`>0. Run replicate simulations in parallel. Defaults to `false`.
 * `step0`: Whether to collect data at step zero, before running the model. Defaults to true.
@@ -77,9 +78,9 @@ end
 # data collection
 #######################################################################################
 
-step!(model::ABM, agent_step!, n, properties; parallel::Bool=false, when::AbstractArray{Int}=1:n, replicates::Int=0, step0::Bool=true) = step!(model, agent_step!, dummystep, n, properties, when=when, replicates=replicates, parallel=parallel, step0=step0)
+step!(model::ABM, agent_step!, n, properties; parallel::Bool=false, when=true, replicates::Int=0, step0::Bool=true) = step!(model, agent_step!, dummystep, n, properties, when=when, replicates=replicates, parallel=parallel, step0=step0)
 
-function step!(model::ABM, agent_step!, model_step!, n, properties; when::AbstractArray{Int}=1:n, replicates::Int=0, parallel::Bool=false, step0::Bool=true)
+function step!(model::ABM, agent_step!, model_step!, n, properties; when=true, replicates::Int=0, parallel::Bool=false, step0::Bool=true)
 
   if replicates > 0
     if parallel

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -59,7 +59,8 @@ function step! end
 #######################################################################################
 dummystep(args...) = nothing
 
-step!(model::ABM, agent_step!, n::Union{Integer, Function} = 1) = step!(model, agent_step!, dummystep, n)
+step!(model::ABM, agent_step!, n::Union{Integer, Function} = 1) =
+step!(model, agent_step!, dummystep, n)
 
 function step!(model::ABM, agent_step!::F, model_step!::G, n::Int = 1) where {F<:Function, G<:Function}
   for i in 1:n
@@ -87,18 +88,16 @@ step!(model::ABM, agent_step!, n, properties; kwargs...) =
 step!(model, agent_step!, dummystep, n, properties; kwargs...)
 
 function step!(model::ABM, agent_step!, model_step!, n, properties;
-  when=true, replicates::Int=0, parallel::Bool=false, step0::Bool=true, Nmax=Inf)
+  parallel::Bool=false, kwargs...)
 
   if replicates > 0
     if parallel
-      dataall = parallel_replicates(model, agent_step!, model_step!, n, properties, when=when, replicates=replicates, step0=step0)
+      dataall = parallel_replicates(model, agent_step!, model_step!, n, properties; kwargs...)
     else
-      dataall = series_replicates(model, agent_step!, model_step!, properties, when, n, replicates, step0)
+      dataall = series_replicates(model, agent_step!, model_step!, n, properties; kwargs...)
     end
     return dataall
   end
-
   df = _step!(model, agent_step!, model_step!, properties, when, n, step0)
-
   return df
 end


### PR DESCRIPTION
This PR addresses #163 , by improving the API of `step!`.

It allows `when` to be just `true` (i.e. collect at every step). 

As I was coding this, I realized it is extremely important to have a fail safe mechanism. Some way to terminate evolution even if `n` doesn't give true.

This is done by the keyword `Nmax`.

But now @kavir1698 you really have to help me here. The source code inside `data_collector.jl`is a nightmare to deal with:

* No keyword propagation technique was used whatsoever, making the code base unmaintainable (I just wanted to add a new keyword, and now all hell broke loose... :D ) . To fix this I started using keyword propagation in step!, but we need much more.
* arguments are in entirely arbitrary order, completely incinsistent with `step!`, which has `n` before `properties`
* the `_step!` functions have crazy syntax. All keyword arguments are given as arguments, and then `df` is given.... Time to put all keyword arguments of `step!` to also be keyword arguments of `_step!`.

This is all so confusing. Can you please re-write this part of the code?