### PR TITLE
Remove coord/vertex from API

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,8 +38,6 @@ get_node_agents
 isempty(::Integer, ::ABM)
 NodeIterator
 nodes
-coord2vertex
-vertex2coord
 ```
 
 ## Continuous space exclusives

--- a/src/CA2D.jl
+++ b/src/CA2D.jl
@@ -17,9 +17,12 @@ function build_model(;rules::Tuple, dims=(100,100), Moore=true)
   space = GridSpace(dims, moore=Moore)
   properties = Dict(:rules => rules, :Moore=>Moore)
   model = ABM(Cell, space; properties = properties, scheduler=by_id)
-  nnodes = dims[1]*dims[2]
-  for n in 1:nnodes
-    add_agent!(Cell(n, vertex2coord(n, dims), "0"), (n,1), model)
+  node_idx = 1
+  for y in 1:dims[1]
+    for x in 1:dims[2]
+      add_agent_pos!(Cell(node_idx, (x,y), "0"), model)
+      node_idx += 1
+    end
   end
   return model
 end
@@ -69,14 +72,14 @@ function ca_step!(model)
     coord = agent.pos
     center = agent.status
     before, after = periodic_neighbors(coord, model.space.dimensions)
-    right = model.agents[coord2vertex((after[1], coord[2]), model)].status
-    left = model.agents[coord2vertex((before[1], coord[2]), model)].status
-    top = model.agents[coord2vertex((coord[1], after[2]), model)].status
-    bottom = model.agents[coord2vertex((coord[1], after[2]), model)].status
-    topright = model.agents[coord2vertex((after[1], after[2]), model)].status
-    topleft = model.agents[coord2vertex((before[1], after[2]), model)].status
-    bottomright = model.agents[coord2vertex((after[1], before[2]), model)].status
-    bottomleft = model.agents[coord2vertex((before[1], before[2]), model)].status
+    right = model.agents[Agents.coord2vertex((after[1], coord[2]), model)].status
+    left = model.agents[Agents.coord2vertex((before[1], coord[2]), model)].status
+    top = model.agents[Agents.coord2vertex((coord[1], after[2]), model)].status
+    bottom = model.agents[Agents.coord2vertex((coord[1], after[2]), model)].status
+    topright = model.agents[Agents.coord2vertex((after[1], after[2]), model)].status
+    topleft = model.agents[Agents.coord2vertex((before[1], after[2]), model)].status
+    bottomright = model.agents[Agents.coord2vertex((after[1], before[2]), model)].status
+    bottomleft = model.agents[Agents.coord2vertex((before[1], before[2]), model)].status
 
     if model.properties[:Moore]
       nstatus = [topleft, top, topright, left, right, bottomleft, bottom, bottomright]

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -65,21 +65,26 @@ in the model and remove it from the old position
 """
 function move_agent!(agent::AbstractAgent, pos::Tuple, model::ABM)
   nodenumber = coord2vertex(pos, model)
-  _move_agent!(agent, nodenumber, model)
+  move_agent!(agent, nodenumber, model)
 end
 
-function _move_agent!(agent::AbstractAgent, pos::Integer, model::ABM)
+function move_agent!(agent::AbstractAgent, pos::Integer, model::ABM)
   # remove agent from old position
-  oldnode = coord2vertex(agent.pos, model)
-  splice!(model.space.agent_positions[oldnode], findfirst(a->a==agent.id, model.space.agent_positions[oldnode]))
-  agent.pos = vertex2coord(pos, model)  # update agent position
+  if typeof(agent.pos) <: Tuple
+    oldnode = coord2vertex(agent.pos, model)
+    splice!(model.space.agent_positions[oldnode], findfirst(a->a==agent.id, model.space.agent_positions[oldnode]))
+    agent.pos = vertex2coord(pos, model)  # update agent position
+  else
+    splice!(model.space.agent_positions[agent.pos], findfirst(a->a==agent.id, model.space.agent_positions[agent.pos]))
+    agent.pos = pos
+  end
   push!(model.space.agent_positions[pos], agent.id)
   return agent
 end
 
 function move_agent!(agent::AbstractAgent, model::ABM)
   nodenumber = rand(1:nv(model.space))
-  _move_agent!(agent, nodenumber, model)
+  move_agent!(agent, nodenumber, model)
   return agent
 end
 

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -2,7 +2,7 @@
 This file establishes the agent-space interaction API.
 =#
 export move_agent!, add_agent!, add_agent_single!, add_agent_pos!,
-move_agent_single!, kill_agent!, coord2vertex, vertex2coord, genocide!
+move_agent_single!, kill_agent!, genocide!
 
 #######################################################################################
 # Killing agents
@@ -13,11 +13,7 @@ move_agent_single!, kill_agent!, coord2vertex, vertex2coord, genocide!
 Remove an agent from model, and from the space if the model has a space.
 """
 function kill_agent!(agent::AbstractAgent, model::ABM{A, S}) where {A, S<:AbstractSpace}
-  if typeof(agent.pos) <: Tuple
-    agentnode = coord2vertex(agent.pos, model)
-  else
-    agentnode = agent.pos
-  end
+  agentnode = coord2vertex(agent.pos, model)
    # remove from the space
   splice!(agent_positions(model)[agentnode],
           findfirst(a->a==agent.id, agent_positions(model)[agentnode]))
@@ -69,26 +65,21 @@ in the model and remove it from the old position
 """
 function move_agent!(agent::AbstractAgent, pos::Tuple, model::ABM)
   nodenumber = coord2vertex(pos, model)
-  move_agent!(agent, nodenumber, model)
+  _move_agent!(agent, nodenumber, model)
 end
 
-function move_agent!(agent::AbstractAgent, pos::Integer, model::ABM)
+function _move_agent!(agent::AbstractAgent, pos::Integer, model::ABM)
   # remove agent from old position
-  if typeof(agent.pos) <: Tuple
-    oldnode = coord2vertex(agent.pos, model)
-    splice!(model.space.agent_positions[oldnode], findfirst(a->a==agent.id, model.space.agent_positions[oldnode]))
-    agent.pos = vertex2coord(pos, model)  # update agent position
-  else
-    splice!(model.space.agent_positions[agent.pos], findfirst(a->a==agent.id, model.space.agent_positions[agent.pos]))
-    agent.pos = pos
-  end
+  oldnode = coord2vertex(agent.pos, model)
+  splice!(model.space.agent_positions[oldnode], findfirst(a->a==agent.id, model.space.agent_positions[oldnode]))
+  agent.pos = vertex2coord(pos, model)  # update agent position
   push!(model.space.agent_positions[pos], agent.id)
   return agent
 end
 
 function move_agent!(agent::AbstractAgent, model::ABM)
   nodenumber = rand(1:nv(model.space))
-  move_agent!(agent, nodenumber, model)
+  _move_agent!(agent, nodenumber, model)
   return agent
 end
 
@@ -149,13 +140,7 @@ function add_agent!(agent::A, pos::Integer, model::ABM{A, <: DiscreteSpace}) whe
   push!(model.space.agent_positions[pos], agent.id)
   model.agents[agent.id] = agent
   # update agent position
-  if typeof(agent.pos) <: Integer
-    agent.pos = pos
-  elseif typeof(agent.pos) <: Tuple
-    agent.pos = vertex2coord(pos, model)
-  else
-    error("Unknown type of agent.pos.")
-  end
+  agent.pos = vertex2coord(pos, model)
   return agent
 end
 

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -1,5 +1,4 @@
-export vertex2coords, coords2vertex, node_neighbors,
-find_empty_nodes, pick_empty, has_empty_nodes, get_node_contents,
+export node_neighbors, find_empty_nodes, pick_empty, has_empty_nodes, get_node_contents,
 id2agent, NodeIterator, space_neighbors, nodes, get_node_agents
 export nv, ne
 export GraphSpace, GridSpace
@@ -361,7 +360,7 @@ Return the ids of agents in the node at `coords`.
 """
 function get_node_contents(coords::Tuple, model)
   node_number = coord2vertex(coords, model)
-  get_node_contents(node_number, model)
+  agent_positions(model)[node_number]
 end
 
 """

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -370,7 +370,6 @@ instead of just the list of IDs.
 """
 get_node_agents(x, model) = [id2agent(id, model) for id in get_node_contents(x, model)]
 
-
 """
     id2agent(id::Integer, model)
 

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -51,7 +51,7 @@ function clean_space!(model::ABM)
             model.space.agent_positions[node] = Int[]
         end
         for (k, v) in model.agents
-            push!(model.space.agent_positions[coord2vertex(v.pos, model)], v.id)
+            push!(get_node_contents(v,model), v.id)
         end
     end
 end

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -1,5 +1,3 @@
-using Agents, Test, Random
-
 mutable struct BadAgent <: AbstractAgent
     useless::Int
     pos::Int
@@ -38,9 +36,16 @@ model1 = ABM(Agent1, GridSpace((3,3)))
 agent = add_agent!((1,1), model1)
 @test agent.pos == (1, 1)
 @test agent.id == 1
+pos1 = get_node_contents((1,1), model1)
+@test length(pos1) == 1
+@test pos1[1] == 1
 
 move_agent!(agent, (2,2), model1)
 @test agent.pos == (2,2)
+pos1 = get_node_contents((1,1), model1)
+@test length(pos1) == 0
+pos2 = get_node_contents((2,2), model1)
+@test pos2[1] == 1
 
 # %% Scheduler tests
 N = 1000
@@ -115,6 +120,76 @@ properties = [model.agents[id].weight for id in ids]
 
   sample!(model2, 40, :weight)
   @test Agents.nagents(model2) == 40
+end
+
+@testset "move_agent!" begin
+  # GraphSpace
+  model = ABM(Agent5, GraphSpace(path_graph(6)))
+  agent = add_agent!(model, 5.3)
+  init_pos = agent.pos
+  # Checking specific indexing
+  move_agent!(agent, rand([i for i in 1:6 if i != init_pos]), model)
+  new_pos = agent.pos
+  @test new_pos != init_pos
+  # Checking a random move
+  move_agent!(agent, model)
+  @test agent.pos != new_pos
+
+  # GridSpace
+  model = ABM(Agent1, GridSpace((5,5)))
+  agent = add_agent!((2,4), model)
+  move_agent!(agent, (1,3), model)
+  @test agent.pos == (1,3)
+  move_agent!(agent, model)
+  @test agent.pos != (1,3)
+  model = ABM(Agent1, GridSpace((2,1)))
+  agent = add_agent!((1,1), model)
+  move_agent_single!(agent, model)
+  @test agent.pos == (2,1)
+  agent2 = add_agent!((1,1), model)
+  move_agent_single!(agent2, model)
+  # Agent shouldn't move since the grid is saturated
+  @test agent2.pos == (1,1)
+
+  # ContinuousSpace
+  model = ABM(Agent6, ContinuousSpace(2))
+  agent = add_agent!((0.0,0.0), model, (1.0,0.0), 1.0)
+  move_agent!(agent, model)
+  @test agent.pos == (1.0,0.0)
+end
+
+@testset "kill_agent!" begin
+  # No Space
+  model = ABM(Agent0)
+  add_agent!(model)
+  agent = add_agent!(model)
+  @test nagents(model) == 2
+  kill_agent!(agent, model)
+  @test nagents(model) == 1
+  # GraphSpace
+  model = ABM(Agent5, GraphSpace(path_graph(6)))
+  add_agent!(model, 5.3)
+  add_agent!(model, 2.7)
+  @test nagents(model) == 2
+  kill_agent!(model.agents[1], model)
+  @test nagents(model) == 1
+  # GridSpace
+  model = ABM(Agent1, GridSpace((5,5)))
+  add_agent!((1,3), model)
+  add_agent!((1,3), model)
+  add_agent!((5,2), model)
+  @test nagents(model) == 3
+  for agent in get_node_agents((1,3), model)
+    kill_agent!(agent, model)
+  end
+  @test nagents(model) == 1
+  # ContinuousSpace
+  model = ABM(Agent6, ContinuousSpace(2))
+  add_agent!((0.7,0.1), model, (15,20), 5.0)
+  add_agent!((0.2,0.9), model, (8,35), 1.7)
+  @test nagents(model) == 2
+  kill_agent!(id2agent(1,model), model)
+  @test nagents(model) == 1
 end
 
 @testset "genocide!" begin

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -38,17 +38,9 @@ model1 = ABM(Agent1, GridSpace((3,3)))
 agent = add_agent!((1,1), model1)
 @test agent.pos == (1, 1)
 @test agent.id == 1
-pos1 = model1.space.agent_positions[coord2vertex((1,1), model1)]
-@test length(pos1) == 1
-@test pos1[1] == 1
 
 move_agent!(agent, (2,2), model1)
-
 @test agent.pos == (2,2)
-pos1 = model1.space.agent_positions[coord2vertex((1,1), model1)]
-@test length(pos1) == 0
-pos2 = model1.space.agent_positions[coord2vertex((2,2), model1)]
-@test pos2[1] == 1
 
 # %% Scheduler tests
 N = 1000

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -24,7 +24,7 @@ function model_initiation(;d, griddims, seed)
     pp = rand()
     if pp <= forest.properties[:d]
       # Set all trees in the first column on fire.
-      if vertex2coord(node, forest)[1] == 1
+      if id2agent(node, model).pos[1] == 1
         tree = Tree(node, (1,1), 2)
       else
         tree = Tree(node, (1,1), 1)

--- a/test/interaction_tests.jl
+++ b/test/interaction_tests.jl
@@ -72,18 +72,13 @@ end
   @test agent.pos == (3,4)
   @test agent.id in model.space.agent_positions[63]
 
-  agent = model.agents[2]
-  move_agent!(agent, 83, model)  # pos (3,5)
-  @test agent.pos == (3,5)
-  @test agent.id in model.space.agent_positions[83]
-
   new_pos = move_agent!(agent, model)
-  @test agent.id in model.space.agent_positions[coord2vertex(new_pos, model)]
+  @test agent.id in get_node_contents(new_pos, model)
 
   add_agent!(agent, (2,9), model)
   @test agent.pos == (2,9)
-  @test agent.id in model.space.agent_positions[coord2vertex((2,9), model)]
-  @test agent.id in model.space.agent_positions[coord2vertex(new_pos, model)]
+  @test agent.id in get_node_contents((2,9), model)
+  @test agent.id in get_node_contents(new_pos, model)
 
   model1 = ABM(Agent1, GridSpace((3,3)))
   add_agent!(1, model1)
@@ -99,8 +94,7 @@ end
   @test model2.agents[2].pos == (2,1)
   @test 2 in model2.space.agent_positions[2]
   ag = add_agent!(model2, 12)
-  @test ag.id in model2.space.agent_positions[coord2vertex(ag.pos, model2)]
-
+  @test ag.id in get_node_contents(ag, model2)
 
   @test agent.id in get_node_contents(agent, model)
 
@@ -108,8 +102,7 @@ end
   @test id2agent(ii.id, model) == model.agents[ii.id]
 
   agent = model.agents[1]
-  agent_pos = coord2vertex(agent.pos, model)
   kill_agent!(agent, model)
   @test_throws KeyError id2agent(1, model)
-  @test !in(1, Agents.agent_positions(model)[agent_pos])
+  @test !in(1, get_node_contents(agent, model))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Agents, Random, SQLite, DataFrames
+using Test, Agents, Random, LightGraphs, SQLite, DataFrames
 
 mutable struct Agent0 <: AbstractAgent
   id::Int

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -79,27 +79,27 @@ end
 end
 
 @testset "grid coord/vertex conversions" begin
-  @test coord2vertex((2,2,1), (3,4,1)) == 5
-  @test coord2vertex((2,2), (3,4)) == 5
-  @test coord2vertex((2,2,1), (3,4,1)) == 5
-  @test coord2vertex((2,2), (3,4)) == 5
-  @test vertex2coord(5, (3,4,1)) == (2,2,1)
-  @test vertex2coord(5, (3,4)) == (2,2)
+  @test Agents.coord2vertex((2,2,1), (3,4,1)) == 5
+  @test Agents.coord2vertex((2,2), (3,4)) == 5
+  @test Agents.coord2vertex((2,2,1), (3,4,1)) == 5
+  @test Agents.coord2vertex((2,2), (3,4)) == 5
+  @test Agents.vertex2coord(5, (3,4,1)) == (2,2,1)
+  @test Agents.vertex2coord(5, (3,4)) == (2,2)
 
-  @test coord2vertex((2,2,1), (2,3,3)) == 4
-  @test coord2vertex((2,2,2), (2,3,3)) == 10
-  @test coord2vertex((2,2,3), (2,3,3)) == 16
-  @test coord2vertex(((1,3,1)), (2,3,3)) == 5
-  @test coord2vertex((1,3,2), (2,3,3)) == 11
-  @test coord2vertex((1,3,3), (2,3,3)) == 17
+  @test Agents.coord2vertex((2,2,1), (2,3,3)) == 4
+  @test Agents.coord2vertex((2,2,2), (2,3,3)) == 10
+  @test Agents.coord2vertex((2,2,3), (2,3,3)) == 16
+  @test Agents.coord2vertex(((1,3,1)), (2,3,3)) == 5
+  @test Agents.coord2vertex((1,3,2), (2,3,3)) == 11
+  @test Agents.coord2vertex((1,3,3), (2,3,3)) == 17
 
-  @test vertex2coord(5, (2,3,3)) == (1,3,1)
-  @test vertex2coord(7, (2,3,3)) == (1,1,2)
-  @test vertex2coord(13, (2,3,3)) == (1,1,3)
-  @test vertex2coord(13, (2,3,3)) == (1,1,3)
-  @test vertex2coord(15, (2,3,3)) == (1,2,3)
-  @test vertex2coord(18, (2,3,3)) == (2,3,3)
-  @test vertex2coord(18, (2,3,3)) == (2,3,3)
+  @test Agents.vertex2coord(5, (2,3,3)) == (1,3,1)
+  @test Agents.vertex2coord(7, (2,3,3)) == (1,1,2)
+  @test Agents.vertex2coord(13, (2,3,3)) == (1,1,3)
+  @test Agents.vertex2coord(13, (2,3,3)) == (1,1,3)
+  @test Agents.vertex2coord(15, (2,3,3)) == (1,2,3)
+  @test Agents.vertex2coord(18, (2,3,3)) == (2,3,3)
+  @test Agents.vertex2coord(18, (2,3,3)) == (2,3,3)
 end
 
 @testset "nodes" begin

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -1,4 +1,3 @@
-using Random
 Random.seed!(209)
 
 @testset "Deprecated spaces" begin


### PR DESCRIPTION
Here's some work connected to #148. There was a lot of different discussions there, and some have already been fixed via the `Space` depreciation and #159.

This PR drops the public facing `coord2vertex` and `vertex2coord` function and replaces their use in example cases where needed. 

One place where this hasn't been done explicitly is `src/CA2D.jl`, which is going to be dropped in #128 anyhow.

Doesn't seem like this simplifies all that much, so would be good to get some feedback on what additional things could be done here.