### PR TITLE
Type Stability & better constructors

### DIFF
--- a/examples/HK.jl
+++ b/examples/HK.jl
@@ -33,10 +33,10 @@
 using Agents
 using Statistics: mean
 
-mutable struct HKAgent{T <: AbstractFloat} <: AbstractAgent
+mutable struct HKAgent <: AbstractAgent
     id::Int
-    old_opinion::T
-    new_opinion::T
+    old_opinion::Float64
+    new_opinion::Float64
 end
 
 function hk_model(;numagents = 100, ϵ = 0.4)

--- a/examples/continuous_space.jl
+++ b/examples/continuous_space.jl
@@ -2,11 +2,11 @@
 
 using Agents, Random, Plots
 
-mutable struct Agent{D, F<:AbstractFloat} <: AbstractAgent
+mutable struct Agent <: AbstractAgent
   id::Int
-  pos::NTuple{D, F}
-  vel::NTuple{D, F}
-  diameter::F
+  pos::NTuple{2, Float64}
+  vel::NTuple{2, Float64}
+  diameter::Float64
   moved::Bool
 end
 

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -132,7 +132,18 @@ Checks for mutability and existence and correct types for fields depending on `S
 """
 function agent_validator(::Type{A}, space::S) where {A<:AbstractAgent, S<:SpaceType}
     # Check A for required properties & fields
-    all(isconcretetype, fieldtypes(A)) || throw(ArgumentError("Agent struct must be a concrete type. If your agent is parametrically typed, this probably happened because you gave `Agent` instead of `Agent{T}` to this function. You can also create and instance of your agent and pass it to this function."))
+    if VERSION < v"1.1"
+        isconcrete = true
+        for f in 1:fieldcount(A)
+            if !isconcretetype(fieldtype(A, f))
+                isconcrete = false
+                break
+            end
+        end
+    else
+        iscontrete = all(isconcretetype, fieldtypes(A))
+    end
+    isconcrete || throw(ArgumentError("Agent struct must be a concrete type. If your agent is parametrically typed, this probably happened because you gave `Agent` instead of `Agent{T}` to this function. You can also create and instance of your agent and pass it to this function."))
     isbitstype(A) && throw(ArgumentError("Agent struct must be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition."))
     (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("First field of Agent struct must be `id` (it should be of type `Integer`)."))
     if space != nothing

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -105,9 +105,9 @@ function AgentBasedModel(
         agent::A, space::S = nothing;
         scheduler::F = fastest, properties::P = nothing
         ) where {A<:AbstractAgent, S<:SpaceType, F, P}
-    agent_validator(A, space)
+    agent_validator(typeof(agent), space)
 
-    agents = Dict{Int, A}()
+    agents = Dict{Int, typeof(agent)}()
     return ABM{A, S, F, P}(agents, space, scheduler, properties)
 end
 

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -26,10 +26,10 @@ end
 ```
 while for e.g. a [`ContinuousSpace`](@ref) we would use
 ```julia
-mutable struct ExampleAgent{D} <: AbstractAgent
+mutable struct ExampleAgent <: AbstractAgent
     id::Int
-    pos::NTuple{D, Float64}
-    vel::NTuple{D, Float64}
+    pos::NTuple{2, Float64}
+    vel::NTuple{2, Float64}
     weight::Float64
     happy::Bool
 end

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -13,24 +13,49 @@ mutable struct DiscreteVelocity <: AbstractAgent
     vel::NTuple{2, Int}
     diameter::Float64
 end
+mutable struct AmbiguousAgent <: AbstractAgent
+    id::Int
+    pos::NTuple{2, Int}
+    # The following types are abstract
+    weight::Real
+    info::AbstractString
+end
 
 @testset "Model construction" begin
     # Cannot use ImmutableAgent since it cannot be edited
     @test_throws ArgumentError ABM(ImmutableAgent)
+    agent = ImmutableAgent(1)
+    @test_throws ArgumentError ABM(agent)
     # Cannot use BadAgent since it has no `id` field
     @test_throws ArgumentError ABM(BadAgent)
+    agent = BadAgent(1,1)
+    @test_throws ArgumentError ABM(agent)
     # Cannot use BadAgent in a grid space context since `pos` has an invalid type
     @test_throws ArgumentError ABM(BadAgent, GridSpace((1,1)))
+    @test_throws ArgumentError ABM(agent, GridSpace((1,1)))
     # Cannot use Agent0 in a grid space context since it has no `pos` field
     @test_throws ArgumentError ABM(Agent0, GridSpace((1,1)))
+    agent = Agent0(1)
+    @test_throws ArgumentError ABM(agent, GridSpace((1,1)))
     # Cannot use Agent3 in a graph space context since `pos` has an invalid type
     @test_throws ArgumentError ABM(Agent3, GraphSpace(Agents.Graph(1)))
+    agent = Agent3(1, (1,1), 5.3)
+    @test_throws ArgumentError ABM(agent, GraphSpace(Agents.Graph(1)))
     # Cannot use Agent3 in a continuous space context since `pos` has an invalid type
     @test_throws ArgumentError ABM(Agent3, ContinuousSpace(2))
+    @test_throws ArgumentError ABM(agent, ContinuousSpace(2))
     # Cannot use Agent4 in a continuous space context since it has no `vel` field
     @test_throws ArgumentError ABM(Agent4, ContinuousSpace(2))
+    agent = Agent4(1, (1,1), 5)
+    @test_throws ArgumentError ABM(agent, ContinuousSpace(2))
     # Cannot use DiscreteVelocity in a continuous space context since `vel` has an invalid type
     @test_throws ArgumentError ABM(DiscreteVelocity, ContinuousSpace(2))
+    agent = DiscreteVelocity(1, (1,1), (2,3), 2.4)
+    @test_throws ArgumentError ABM(agent, ContinuousSpace(2))
+    # Cannot use AmbiguousAgent since it is not a concrete type
+    @test_throws ArgumentError ABM(AmbiguousAgent, GridSpace((1,1)))
+    agent = AmbiguousAgent(1, (1,1), 4.9, "Info")
+    @test_throws ArgumentError ABM(agent, GridSpace((1,1)))
 end
 
 model1 = ABM(Agent1, GridSpace((3,3)))

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -13,7 +13,7 @@ mutable struct DiscreteVelocity <: AbstractAgent
     vel::NTuple{2, Int}
     diameter::Float64
 end
-mutable struct ParametricAgent{T} <: AbstractAgent where {T <:Integer}
+mutable struct ParametricAgent{T <: Integer} <: AbstractAgent
     id::T
     pos::NTuple{2, T}
     weight::T

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -13,12 +13,11 @@ mutable struct DiscreteVelocity <: AbstractAgent
     vel::NTuple{2, Int}
     diameter::Float64
 end
-mutable struct AmbiguousAgent <: AbstractAgent
-    id::Int
-    pos::NTuple{2, Int}
-    # The following types are abstract
-    weight::Real
-    info::AbstractString
+mutable struct ParametricAgent{T} <: AbstractAgent where {T <:Integer}
+    id::T
+    pos::NTuple{2, T}
+    weight::T
+    info::String
 end
 
 @testset "Model construction" begin
@@ -52,10 +51,13 @@ end
     @test_throws ArgumentError ABM(DiscreteVelocity, ContinuousSpace(2))
     agent = DiscreteVelocity(1, (1,1), (2,3), 2.4)
     @test_throws ArgumentError ABM(agent, ContinuousSpace(2))
-    # Cannot use AmbiguousAgent since it is not a concrete type
-    @test_throws ArgumentError ABM(AmbiguousAgent, GridSpace((1,1)))
-    agent = AmbiguousAgent(1, (1,1), 4.9, "Info")
-    @test_throws ArgumentError ABM(agent, GridSpace((1,1)))
+    # Cannot use ParametricAgent since it is not a concrete type
+    @test_throws ArgumentError ABM(ParametricAgent, GridSpace((1,1)))
+    # ParametricAgent{Int} is the correct way to use such an agent
+    @test Agents.agenttype(ABM(ParametricAgent{Int}, GridSpace((1,1)))) <: AbstractAgent
+    #Type inferance using an instance can help users here
+    agent = ParametricAgent(1, (1,1), 5, "Info")
+    @test Agents.agenttype(ABM(agent, GridSpace((1,1)))) <: AbstractAgent
 end
 
 model1 = ABM(Agent1, GridSpace((3,3)))

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -4,10 +4,10 @@
 using Agents
 using Random
 
-mutable struct Tree{T<:Integer} <: AbstractAgent
-  id::T
-  pos::Tuple{T, T}
-  status::T  # 1: green, 2: burning, 3: burned
+mutable struct Tree <: AbstractAgent
+  id::Int
+  pos::Tuple{Int, Int}
+  status::Int  # 1: green, 2: burning, 3: burned
 end
 
 # we can put the model initiation in a function


### PR DESCRIPTION
Fixes to the `ABM` constructor following from #159 and subsequent discussions.
- New `AgentBasedModel(agent::A ...) where {A<:AbstractAgent}` constructor
- Updated documentation
- More verbose and helpful errors when `agent` is not instantiated according to our requirements
- Examples and benchmarks are now up to date and functioning in accordance with these changes. Closes #174. 