### PR TITLE
Two convenience syntaxes for getting model propertries and agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@
 * Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`.
 * If `model.properties` is a dictionary with key type Symbol, then the
   convenience syntax `model.prop` returns `model.properties[:prop]`.
+* Version of `add_agent!` now has keyword propagation as well (in case you make your types with `@kwdef` or Parameters.jl)
 
 ## Breaking Changes
 * Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.
 * Reworked the public API of `GridSpace` to be simpler: position must be `NTuple{Int}`. As a result `vertex2coord` and stuff no longer exported, since they are obsolete.
 - `AgentBasedModel` checks the construction of your agent and will return errors when it is malformed (no `id` or `pos` when required, incorrect types). Warnings when possible problems may occur (immutable agents, types which are not concrete, `vel` not of the correct type when using `ContinuousSpace`).
 - `id2agent` is deprecated in favor of `getindex(model, id) == model[id]`
-* Version of `add_agent!` now has keyword propagation as well (in case you make your types with `@kwdef` or Parameters.jl)
+
 
 # v2.1
 * Renamed the old scheduler `as_added` to `by_id`, to reflect reality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * New convenience function `allagents`
 * New continuous space functions `nearest_neighbor` and `elastic_collision!`
 * New iterator `interacting_pairs`
-* Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`.
+* Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`. `model[id] = agent` also works.
 * If `model.properties` is a dictionary with key type Symbol, then the
   convenience syntax `model.prop` returns `model.properties[:prop]`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * New convenience function `allagents`
 * New continuous space functions `nearest_neighbor` and `elastic_collision!`
 * New iterator `interacting_pairs`
-* Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`. `model[id] = agent` also works.
+* Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`.
 * If `model.properties` is a dictionary with key type Symbol, then the
   convenience syntax `model.prop` returns `model.properties[:prop]`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
 # v3.0
+## Additions
+- `AgentBasedModel` now allows you to pass in an `AbstractAgent` type, or an instance of your agent.
 * Added `ContinuousSpace` as a space option!!!
-* Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.
 * new function `space_neighbors`, which works for any space. It always and consistently returns the **IDs** of neighbors irrespectively
   of the spatial structure.
-* Reworked the public API of `GridSpace` to be simpler: position must be `NTuple{Int}`. As a result `vertex2coord` and stuff no longer exported, since they are obsolete.
 * New convenience function `allagents`
 * New continuous space functions `nearest_neighbor` and `elastic_collision!`
 * New iterator `interacting_pairs`
-- `AgentBasedModel` now allows you to pass in an `AbstractAgent` type, or an instance of your agent.
+* Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`.
+* If `model.properties` is a dictionary with key type Symbol, then the
+  convenience syntax `model.prop` returns `model.properties[:prop]`.
+
+## Breaking Changes
+* Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.
+* Reworked the public API of `GridSpace` to be simpler: position must be `NTuple{Int}`. As a result `vertex2coord` and stuff no longer exported, since they are obsolete.
 - `AgentBasedModel` checks the construction of your agent and will return errors when it is malformed (no `id` or `pos` when required, incorrect types). Warnings when possible problems may occur (immutable agents, types which are not concrete, `vel` not of the correct type when using `ContinuousSpace`).
-- Warnings produced by `AgentBasedModel` may be suppressed via the boolean flag `warn`.
+- `id2agent` is deprecated in favor of `getindex(model, id) == model[id]`
 
 # v2.1
 * Renamed the old scheduler `as_added` to `by_id`, to reflect reality.

--- a/examples/HK.jl
+++ b/examples/HK.jl
@@ -71,7 +71,7 @@ end
 
 function model_step!(model)
     for i in keys(model.agents)
-        agent = id2agent(i, model)
+        agent = model[i]
         updateold(agent)
     end
 end
@@ -110,7 +110,7 @@ using Plots
 plotsim(data, ϵ) = plot(
                         data[!, :step],
                         data[!, :new_opinion],
-                        leg= false, 
+                        leg= false,
                         group = data[!, :id],
                         title = "epsilon = $(ϵ)"
                         )
@@ -122,4 +122,3 @@ plt001,plt015,plt03 = map(
                           )
 
 plot(plt001, plt015, plt03, layout = (3,1))
-

--- a/examples/HK.jl
+++ b/examples/HK.jl
@@ -55,7 +55,7 @@ end
 get_old_opinion(agent)::Float64 = agent.old_opinion
 
 function boundfilter(agent,model)
-    filter(j->abs(get_old_opinion(agent) - j) < model.properties[:ϵ],
+    filter(j->abs(get_old_opinion(agent) - j) < model.ϵ,
      get_old_opinion.(values(model.agents)))
 end
 

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -61,7 +61,7 @@ function forest_step!(forest)
     if length(nc) == 0
         rand() ≤ forest.properties[:p] && add_agent!(node, forest, true)
     else
-      tree = id2agent(nc[1], forest) # by definition only 1 agent per node
+      tree = forest[nc[1]] # by definition only 1 agent per node
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -41,7 +41,7 @@ function model_initiation(; f, d, p, griddims, seed = 111)
     ## create and add trees to each node with probability d,
     ## which determines the density of the forest
     for node in nodes(forest)
-        if rand() ≤ forest.properties[:d]
+        if rand() ≤ forest.d
             add_agent!(node, forest, true)
         end
     end
@@ -59,13 +59,13 @@ function forest_step!(forest)
     nc = get_node_contents(node, forest)
     ## the cell is empty, maybe a tree grows here
     if length(nc) == 0
-        rand() ≤ forest.properties[:p] && add_agent!(node, forest, true)
+        rand() ≤ forest.p && add_agent!(node, forest, true)
     else
       tree = forest[nc[1]] # by definition only 1 agent per node
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else
-        if rand() ≤ forest.properties[:f]  # the tree ignites spntaneously
+        if rand() ≤ forest.f  # the tree ignites spntaneously
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
           for cell in node_neighbors(node, forest)

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -43,8 +43,7 @@ space = GridSpace((10,10), moore = true)
 # We also want to include a property `min_to_be_happy` in our model, and so we have:
 
 properties = Dict(:min_to_be_happy => 3)
-schelling = ABM(SchellingAgent, space;
-                scheduler = fastest, properties = properties)
+schelling = ABM(SchellingAgent, space; properties = properties)
 
 
 # Here we used the default scheduler (which is also the fastest one) to create
@@ -104,7 +103,7 @@ function agent_step!(agent, model)
         agent_id = node_contents[1]
         ## ...and increment count_neighbors_same_group if the neighbor's group is
         ## the same.
-        neighbor_agent_group = model.agents[agent_id].group
+        neighbor_agent_group = model[agent_id].group
         if neighbor_agent_group == agent.group
             count_neighbors_same_group += 1
         end

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -91,7 +91,7 @@ end
 
 function agent_step!(agent, model)
     agent.mood == true && return # do nothing if already happy
-    minhappy = model.properties[:min_to_be_happy]
+    minhappy = model.min_to_be_happy
     neighbor_cells = node_neighbors(agent, model)
     count_neighbors_same_group = 0
     ## For each neighbor, get group and compare to current agent's group

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -76,7 +76,7 @@ function model_initiation(;Ns, migration_rates, β_und, β_det, infection_period
   for city in 1:C
     inds = get_node_contents(city, model)
     for n in 1:Is[city]
-      agent = id2agent(inds[n], model)
+      agent = model[inds[n]]
       agent.status = :I # Infected
       agent.days_infected = 1
     end
@@ -195,7 +195,7 @@ function transmit!(agent, model)
   n == 0 && return
 
   for contactID in get_node_contents(agent, model)
-    contact = id2agent(contactID, model)
+    contact = model[contactID]
     if contact.status == :S || (contact.status == :R && rand() ≤ prop[:reinfection_probability])
       contact.status = :I
       n -= 1

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -55,7 +55,7 @@ model = ball_model()
 
 # The agent step function for now is trivial. It is just [`move_agent!`](@ref) in
 # continuous space
-agent_step!(agent, model) =  move_agent!(agent, model, model.properties[:dt])
+agent_step!(agent, model) =  move_agent!(agent, model, model.dt)
 
 # `dt` is our time resolution, but we will talk about this more later!
 # Cool, let's see now how this model evolves.
@@ -232,9 +232,9 @@ function transmit!(a1, a2, rp)
 end
 
 function sir_model_step!(model)
-    r = model.properties[:interaction_radius]
+    r = model.interaction_radius
     for (a1, a2) in interacting_pairs(model, r)
-        transmit!(a1, a2, model.properties[:reinfection_probability])
+        transmit!(a1, a2, model.reinfection_probability)
         elastic_collision!(a1, a2, :mass)
     end
 end
@@ -247,7 +247,7 @@ end
 # agent has been infected, and whether they have to die or not.
 
 function sir_agent_step!(agent, model)
-    move_agent!(agent, model, model.properties[:dt])
+    move_agent!(agent, model, model.dt)
     update!(agent)
     recover_or_die!(agent, model)
 end
@@ -255,8 +255,8 @@ end
 update!(agent) = agent.status == :I && (agent.days_infected += 1)
 
 function recover_or_die!(agent, model)
-    if agent.days_infected ≥ model.properties[:infection_period]
-        if rand() ≤ model.properties[:death_rate]
+    if agent.days_infected ≥ model.infection_period
+        if rand() ≤ model.death_rate
             kill_agent!(agent, model)
         else
             agent.status = :R

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -120,7 +120,7 @@ gif(anim, "socialdist2.gif", fps = 45);
 model3 = ball_model()
 
 for id in 1:400
-    agent = id2agent(id, model3)
+    agent = model3[id]
     agent.mass = Inf
     agent.vel = (0.0, 0.0)
 end

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -100,9 +100,9 @@ function agent_step_2d!(agent, model)
     neighboring_nodes = node_neighbors(agent_node, model)
     push!(neighboring_nodes, agent_node) # also consider current node
     rnode = rand(neighboring_nodes) # the node that we will exchange with
-    available_agents = get_node_contents(rnode, model)
-    if length(available_agents) > 0
-        random_neighbor_agent = id2agent(rand(available_agents), model)
+    available_ids = get_node_contents(rnode, model)
+    if length(available_ids) > 0
+        random_neighbor_agent = model[rand(available_ids)]
         agent.wealth -= 1
         random_neighbor_agent.wealth += 1
     end

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -143,7 +143,7 @@ end
 
 function add_agent!(agent::A, pos::Integer, model::ABM{A, <: DiscreteSpace}) where {A}
   push!(model.space.agent_positions[pos], agent.id)
-  model.agents[agent.id] = agent
+  model[agent.id] = agent
   # update agent position
   agent.pos = vertex2coord(pos, model)
   return agent
@@ -154,7 +154,7 @@ function add_agent!(agent::A, model::ABM{A, <: DiscreteSpace}) where {A}
     nodenumber = rand(1:nv(model.space))
     add_agent!(agent, nodenumber, model)
   else
-    model.agents[agent.id] = agent
+    model[agent.id] = agent
   end
   return agent
 end
@@ -195,17 +195,17 @@ end
 function add_agent!(model::ABM{A, Nothing}, properties...) where {A}
   @assert model.space == nothing
   id = biggest_id(model) + 1
-  model.agents[id] = A(id, properties...)
-  return model.agents[id]
+  model[id] = A(id, properties...)
+  return model[id]
 end
 
 function add_agent!(model::ABM{A, S}, properties...) where {A, S<:DiscreteSpace}
   id = biggest_id(model) + 1
   n = rand(1:nv(model))
   cnode = correct_pos_type(n, model)
-  model.agents[id] = A(id, cnode, properties...)
+  model[id] = A(id, cnode, properties...)
   push!(model.space.agent_positions[n], id)
-  return model.agents[id]
+  return model[id]
 end
 
 biggest_id(model::ABM) = isempty(model.agents) ? 0 : maximum(keys(model.agents))

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -208,9 +208,7 @@ function add_agent!(model::ABM{A, S}, properties...) where {A, S<:DiscreteSpace}
   return model.agents[id]
 end
 
-function biggest_id(model) where {A}
-    isempty(model.agents) ? 0 : maximum(keys(model.agents))
-end
+biggest_id(model::ABM) = isempty(model.agents) ? 0 : maximum(keys(model.agents))
 
 
 """

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -262,13 +262,13 @@ function nearest_neighbor(agent, model, r)
   length(n) == 0 && return nothing
   d, j = Inf, 0
   for i in 1:length(n)
-    @inbounds dnew = sqrt(sum(abs2.(agent.pos .- id2agent(n[i], model).pos)))
+    @inbounds dnew = sqrt(sum(abs2.(agent.pos .- model[n[i]].pos)))
     _, j = findmin(d)
     if dnew < d
       d, j = dnew, i
     end
   end
-  return id2agent(n[j], model)
+  return model[n[j]]
 end
 
 using LinearAlgebra
@@ -342,7 +342,7 @@ function interacting_pairs(model, r)
   for id in keys(model.agents)
     # Skip already checked agents
     any(isequal(id), p[2] for p in pairs) && continue
-    a1 = id2agent(id, model)
+    a1 = model[id]
     a2 = nearest_neighbor(a1, model, r)
     a2 ≠ nothing && push!(pairs, (id, a2.id))
   end

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -124,14 +124,8 @@ end
 # central, low level function that is always called by all others!
 function add_agent_pos!(agent::A, model::ABM{A, <: ContinuousSpace}) where {A<:AbstractAgent}
   DBInterface.execute(model.space.insertq, (agent.pos..., agent.id))
-  model.agents[agent.id] = agent
+  model[agent.id] = agent
   return agent
-end
-
-function biggest_id(model::ABM{A, <: ContinuousSpace}) where {A}
-  db = model.space.db
-  ids = collect_ids(DBInterface.execute(db, "select max(id) as id from tab"))
-  id = ismissing(ids[1]) ? 0 : ids[1]
 end
 
 function randompos(space::ContinuousSpace)

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -152,9 +152,7 @@ end
 function add_agent!(pos::Tuple, model::ABM{A, <: ContinuousSpace}, args...) where {A<:AbstractAgent}
   id = biggest_id(model) + 1
   agent = A(id, pos, args...)
-  DBInterface.execute(model.space.insertq, (agent.pos..., id))
-  model.agents[id] = agent
-  return agent
+  add_agent_pos!(agent, model)
 end
 
 """

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -61,23 +61,24 @@ spacetype(::ABM{A, S}) where {A, S} = S
 
 """
     AgentBasedModel(AgentType [, space]; scheduler, properties) → model
-Create an agent based model from the given agent type
-and the `space`.
-You can provide an agent _instance_ instead of type, and the type will be
-deduced. `ABM` is equivalent with `AgentBasedModel`.
-The agents are stored in a dictionary `model.agents` that maps unique ids (integers)
+Create an agent based model from the given agent type and `space`.
+You can provide an agent _instance_ instead of type, and the type will be deduced.
+ `ABM` is equivalent with `AgentBasedModel`.
+ 
+The agents are stored in a dictionary that maps unique ids (integers)
 to agents. Use `model[id]` to get the agent with the given `id`.
 
 `space` is a subtype of `AbstractSpace`: [`GraphSpace`](@ref), [`GridSpace`](@ref) or
 [`ContinuousSpace`](@ref).
 If it is ommited then all agents are virtually in one node and have no spatial structure.
 
-`properties = nothing` is additional model-level properties (typically a dictionary),
-which becomes a field of the model.
-If `properties` is a dictionary with key type `Symbol`, then the syntax
-`model.name` is short hand for `model.properties[:name]`
-(obviously this syntax can't be used for `agents, space, scheduler, properties`,
-which are the fields of `AgentBasedModel`).
+`properties = nothing` is additional model-level properties (typically a dictionary)
+that can be accessed as `model.properties`. However, if `properties` is a dictionary with
+key type `Symbol`, or of it is a struct, then the syntax
+`model.name` is short hand for `model.properties[:name]` (or `model.properties.name`
+for structs).
+This syntax can't be used for `name` being `agents, space, scheduler, properties`,
+which are the fields of `AgentBasedModel`.
 
 `scheduler = fastest` decides the order with which agents are activated
 (see e.g. [`by_id`](@ref) and the scheduler API).

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -34,6 +34,8 @@ mutable struct ExampleAgent <: AbstractAgent
     happy::Bool
 end
 ```
+where `vel` is optional, useful if you want to use [`move_agent!`](@ref) in continuous
+space.
 """
 abstract type AbstractAgent end
 
@@ -109,7 +111,7 @@ function Base.show(io::IO, abm::ABM{A}) where {A}
     end
 end
 
-Base.getindex(m::ABM, id::Integer) = model.agents[id]
+Base.getindex(m::ABM, id::Integer) = m.agents[id]
 
 
 function Base.getproperty(m::ABM, s::Symbol)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -86,14 +86,8 @@ function AgentBasedModel(
 end
 const ABM = AgentBasedModel
 
-function AgentBasedModel(
-        agent::A, space::S = nothing;
-        scheduler::F = fastest, properties::P = nothing, warn = true
-        ) where {A<:AbstractAgent, S<:SpaceType, F, P}
-    agent_validator(typeof(agent), space, warn)
-
-    agents = Dict{Int, A}()
-    return ABM{A, S, F, P}(agents, space, scheduler, properties)
+function AgentBasedModel(agent::AbstractAgent, args...; kwargs...)
+    return ABM(typeof(agent), args...; kwargs...)
 end
 
 function Base.show(io::IO, abm::ABM{A}) where {A}

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -116,11 +116,19 @@ end
 Base.getindex(m::ABM, id::Integer) = m.agents[id]
 
 
-function Base.getproperty(m::ABM, s::Symbol)
-    if s ∈ (:agents, :space, :scheduler, :properties)
-        return Base.getfield(m, s)
-    else
-        return Base.getindex(m.properties, s)
+function Base.getproperty(m::ABM{A, S, F, P}, s::Symbol) where {A, S, F, P}
+    if s === :agents
+        return getfield(m, :agents)
+    elseif s === :space
+        return getfield(m, :space)
+    elseif s === :scheduler
+        return getfield(m, :scheduler)
+    elseif s === :properties
+        return getfield(m, :properties)
+    elseif P <: Dict
+        return getindex(getfield(m, :properties), s)
+    else # properties is assumed to be a struct
+        return getproperty(getfield(m, :properties), s)
     end
 end
 

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -131,8 +131,8 @@ Checks for mutability and existence and correct types for fields depending on `S
 function agent_validator(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:SpaceType}
     # Check A for required properties & fields
     if warn
-        isconcretetype(A) || @warn "Given AgentType is not concrete. If your agent is parametrically typed, you're probably seeing this warning because you gave `Agent` instead of `Agent{Float64}` (for example) to this function. You can also create an instance of your agent and pass it to this function. If you want to use `Union` types for mixed agent models, you can silence this warning."
-        isbitstype(A) && @warn "Agent struct should be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition."
+        isconcretetype(A) || @warn "AgentType is not concrete. If your agent is parametrically typed, you're probably seeing this warning because you gave `Agent` instead of `Agent{Float64}` (for example) to this function. You can also create an instance of your agent and pass it to this function. If you want to use `Union` types for mixed agent models, you can silence this warning."
+        isbitstype(A) && @warn "AgentType should be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition."
     end
     (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("First field of Agent struct must be `id` (it should be of type `Int`)."))
     fieldtype(A, :id) <: Integer || throw(ArgumentError("`id` field in Agent struct must be of type `Int`."))

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -60,7 +60,7 @@ agenttype(::ABM{A}) where {A} = A
 spacetype(::ABM{A, S}) where {A, S} = S
 
 """
-    AgentBasedModel(AgentType [, space]; scheduler, properties, warn)
+    AgentBasedModel(AgentType [, space]; scheduler, properties) → model
 Create an agent based model from the given agent type
 and the `space`.
 You can provide an agent _instance_ instead of type, and the type will be
@@ -72,16 +72,18 @@ to agents. Use `model[id]` to get the agent with the given `id`.
 [`ContinuousSpace`](@ref).
 If it is ommited then all agents are virtually in one node and have no spatial structure.
 
-`properties = nothing` is additional model-level properties (typically a dictionary).
+`properties = nothing` is additional model-level properties (typically a dictionary),
+which becomes a field of the model.
 If `properties` is a dictionary with key type `Symbol`, then the syntax
-`model.property_name` is short hand for `model.properties[:property_name]`
-(obviously this syntax returns model properties for `agents, space, scheduler, properties`).
+`model.name` is short hand for `model.properties[:name]`
+(obviously this syntax can't be used for `agents, space, scheduler, properties`,
+which are the fields of `AgentBasedModel`).
 
 `scheduler = fastest` decides the order with which agents are activated
 (see e.g. [`by_id`](@ref) and the scheduler API).
 
 Type tests for `AgentType` are done, and by default
-warnings are thrown when appropriate. Use `warn=false` to supress that.
+warnings are thrown when appropriate. Use keyword `warn=false` to supress that.
 """
 function AgentBasedModel(
         ::Type{A}, space::S = nothing;

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -64,7 +64,7 @@ spacetype(::ABM{A, S}) where {A, S} = S
 Create an agent based model from the given agent type and `space`.
 You can provide an agent _instance_ instead of type, and the type will be deduced.
  `ABM` is equivalent with `AgentBasedModel`.
- 
+
 The agents are stored in a dictionary that maps unique ids (integers)
 to agents. Use `model[id]` to get the agent with the given `id`.
 
@@ -112,6 +112,12 @@ function Base.show(io::IO, abm::ABM{A}) where {A}
     if abm.properties ≠ nothing
         print(io, "\n properties: ", abm.properties)
     end
+end
+
+Base.getindex(m::ABM, id::Integer) = m.agents[id]
+function Base.setindex!(m::ABM, a::AbstractAgent, id::Int)
+    a.id ≠ id && throw(ArgumentError("You are adding an agent to an ID not equal with the agent's ID!"))
+    m.agents[id] = a
 end
 
 Base.getindex(m::ABM, id::Integer) = m.agents[id]

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -368,14 +368,17 @@ end
 Same as `get_node_contents(x, model)` but directly returns the list of agents
 instead of just the list of IDs.
 """
-get_node_agents(x, model) = [id2agent(id, model) for id in get_node_contents(x, model)]
+get_node_agents(x, model) = [model[id] for id in get_node_contents(x, model)]
 
 """
     id2agent(id::Integer, model)
 
 Return an agent given its ID.
 """
-id2agent(id::Integer, model::ABM) = model.agents[id]
+function id2agent(id::Integer, model::ABM)
+  @warn "`id2agent(id, model)` is deprecated. Use `model[id]` instead!"
+  model[id]
+end
 
 """
     space_neighbors(position, model::ABM [, r]) → ids

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -60,7 +60,7 @@ end
     # Warning is suppressed if flag is set
     @test Agents.agenttype(ABM(agent, ContinuousSpace(2); warn=false)) <: AbstractAgent
     # Shouldn't use ParametricAgent since it is not a concrete type
-    @test_logs (:warn, "Agent struct should be a concrete type. If your agent is parametrically typed, you're probably seeing this warning because you gave `Agent` instead of `Agent{Float64}` (for example) to this function. You can also create an instance of your agent and pass it to this function.") ABM(ParametricAgent, GridSpace((1,1)))
+    @test_logs (:warn, "AgentType is not concrete. If your agent is parametrically typed, you're probably seeing this warning because you gave `Agent` instead of `Agent{Float64}` (for example) to this function. You can also create an instance of your agent and pass it to this function. If you want to use `Union` types for mixed agent models, you can silence this warning.") ABM(ParametricAgent, GridSpace((1,1)))
     # Warning is suppressed if flag is set
     @test Agents.agenttype(ABM(ParametricAgent, GridSpace((1,1)); warn=false)) <: AbstractAgent
     # ParametricAgent{Int} is the correct way to use such an agent

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -193,9 +193,9 @@ end
 
   # ContinuousSpace
   model = ABM(Agent6, ContinuousSpace(2))
-  agent = add_agent!((0.0,0.0), model, (1.0,0.0), 1.0)
+  agent = add_agent!((0.0,0.0), model, (0.5,0.0), 1.0)
   move_agent!(agent, model)
-  @test agent.pos == (1.0,0.0)
+  @test agent.pos == (0.5,0.0)
 end
 
 @testset "kill_agent!" begin

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -281,3 +281,21 @@ end
   genocide!(model, complex_logic)
   @test nagents(model) == 17
 end
+
+# %% accessing model
+@testset "Accessing model" begin
+    model = ABM(Agent0; properties = Dict(:a => 2, :b => "test"))
+    # add 5 aents
+    for i in 1:5
+        add_agent!(model)
+    end
+    @test model.scheduler == fastest
+    @test typeof(model.agents) <: Dict
+    @test model.space == nothing
+    @test model.properties == Dict(:a => 2, :b => "test")
+    a = model[1]
+    @test a isa Agent0
+    @test a.id == 1
+    @test model.a == 2
+    @test model.b == "test"
+end

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -280,21 +280,3 @@ end
   genocide!(model, complex_logic)
   @test nagents(model) == 17
 end
-
-# %% accessing model
-@testset "Accessing model" begin
-    model = ABM(Agent0; properties = Dict(:a => 2, :b => "test"))
-    # add 5 aents
-    for i in 1:5
-        add_agent!(model)
-    end
-    @test model.scheduler == fastest
-    @test typeof(model.agents) <: Dict
-    @test model.space == nothing
-    @test model.properties == Dict(:a => 2, :b => "test")
-    a = model[1]
-    @test a isa Agent0
-    @test a.id == 1
-    @test model.a == 2
-    @test model.b == "test"
-end

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -228,7 +228,7 @@ end
   add_agent!((0.7,0.1), model, (15,20), 5.0)
   add_agent!((0.2,0.9), model, (8,35), 1.7)
   @test nagents(model) == 2
-  kill_agent!(id2agent(1,model), model)
+  kill_agent!(model[1], model)
   @test nagents(model) == 1
 end
 

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -23,9 +23,8 @@ end
 
 @testset "Model construction" begin
     # Shouldn't use ImmutableAgent since it cannot be edited
-    @test_logs (:warn, "Agent struct should be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition.") ABM(ImmutableAgent)
     agent = ImmutableAgent(1)
-    @test_logs (:warn, "Agent struct should be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition.") ABM(agent)
+    @test_logs (:warn, "AgentType should be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition.") ABM(agent)
     # Warning is suppressed if flag is set
     @test Agents.agenttype(ABM(agent; warn=false)) <: AbstractAgent
     # Cannot use BadAgent since it has no `id` field

--- a/test/benchmark/DynamicGrids/agents.jl
+++ b/test/benchmark/DynamicGrids/agents.jl
@@ -32,7 +32,7 @@ function forest_step!(forest)
     if length(nc) == 0
         rand() ≤ forest.properties[:p] && add_agent!(node, forest, true)
     else
-      tree = id2agent(nc[1], forest) # by definition only 1 agent per node
+      tree = forest[nc[1]] # by definition only 1 agent per node
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else

--- a/test/benchmark/benchmark.jl
+++ b/test/benchmark/benchmark.jl
@@ -12,8 +12,8 @@ println("\n\nmove_agent!")
 a = @benchmark move_agent!(model.agents[1], (3,4), model) setup=(model = model_initiation(f=0.1, d=0.8, p=0.1, griddims=(100, 50), seed=2))
 display(a)
 
-println("\n\nid2agent")
-a = @benchmark id2agent(250, model) setup=(model = model_initiation(f=0.1, d=0.8, p=0.1, griddims=(100, 50), seed=2))
+println("\n\ngetindex(model)")
+a = @benchmark model[250] setup=(model = model_initiation(f=0.1, d=0.8, p=0.1, griddims=(100, 50), seed=2))
 display(a)
 
 println("\n\nkill_agent!")
@@ -49,4 +49,3 @@ display(a)
 println("\n\nsample! 6 - with space - n == numagents/2")
 a = @benchmark sample!(m, 50) setup=(m = sampleModelInitializeS(n=100))
 display(a)
-

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -24,7 +24,7 @@ function model_initiation(;d, griddims, seed)
     pp = rand()
     if pp <= forest.properties[:d]
       # Set all trees in the first column on fire.
-      if id2agent(node, model).pos[1] == 1
+      if model[node].pos[1] == 1
         tree = Tree(node, (1,1), 2)
       else
         tree = Tree(node, (1,1), 1)

--- a/test/collisions_tests.jl
+++ b/test/collisions_tests.jl
@@ -47,8 +47,8 @@ function kinetic(model)
 end
 
 model = model_initiation()
-initvels = [id2agent(i, model).vel for i in 1:100]
-x = count(!isapprox(initvels[id][1], id2agent(id, model).vel[1]) for id in 1:100)
+initvels = [model[i].vel for i in 1:100]
+x = count(!isapprox(initvels[id][1], model[id].vel[1]) for id in 1:100)
 @test x == 0
 
 K0, p0 = kinetic(model)
@@ -58,9 +58,9 @@ ipairs = interacting_pairs(model, diameter)
 @test length(ipairs) ≠ 0
 
 step!(model, agent_step!, model_step!, 10)
-x = count(any(initvels[id] .≠ id2agent(id, model).vel) for id in 1:100)
+x = count(any(initvels[id] .≠ model[id].vel) for id in 1:100)
 
-y = count(!any(initvels[id] .≈ id2agent(id, model).vel) for id in 1:50)
+y = count(!any(initvels[id] .≈ model[id].vel) for id in 1:50)
 @test y == 0
 
 

--- a/test/interaction_tests.jl
+++ b/test/interaction_tests.jl
@@ -37,7 +37,7 @@ function forest_step!(forest)
       end
     else
       treeid = forest.space.agent_positions[node][1]  # id of the tree on this cell
-      tree = id2agent(treeid, forest)  # the tree on this cell
+      tree = forest[treeid] # the tree on this cell
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else
@@ -49,7 +49,7 @@ function forest_step!(forest)
           for cell in neighbor_cells
             treeid = get_node_contents(cell, forest)
             if length(treeid) != 0  # the cell is not empty
-              treen = id2agent(treeid[1], forest)
+              treen = forest[treeid[1]]
               if treen.status == false
                 tree.status = false
                 break
@@ -99,10 +99,10 @@ end
   @test agent.id in get_node_contents(agent, model)
 
   ii = model.agents[length(model.agents)]
-  @test id2agent(ii.id, model) == model.agents[ii.id]
+  @test model[ii.id] == model.agents[ii.id]
 
   agent = model.agents[1]
   kill_agent!(agent, model)
-  @test_throws KeyError id2agent(1, model)
+  @test_throws KeyError model[1]
   @test !in(1, get_node_contents(agent, model))
 end

--- a/test/model_access.jl
+++ b/test/model_access.jl
@@ -1,0 +1,34 @@
+# %% accessing model
+@testset "Accessing model" begin
+    model = ABM(Agent0; properties = Dict(:a => 2, :b => "test"))
+    # add 5 aents
+    for i in 1:5
+        add_agent!(model)
+    end
+    @test model.scheduler == fastest
+    @test typeof(model.agents) <: Dict
+    @test model.space == nothing
+    @test model.properties == Dict(:a => 2, :b => "test")
+    a = model[1]
+    @test a isa Agent0
+    @test a.id == 1
+    @test model.a == 2
+    @test model.b == "test"
+
+    prop2 = Agent2(1, 0.5)
+    model2 = ABM(Agent0; properties = prop2)
+    @test model2.weight == 0.5
+
+end
+
+@testset "model access typestability" begin
+    prop1 = Dict(:a => 0.5)
+    prop2 = Agent2(1, 0.5)
+    model1 = ABM(Agent0; properties = prop1)
+    model2 = ABM(Agent0; properties = prop2)
+
+    test1(model) = model.a
+    test2(model) = model.weight
+    @test_nowarn @inferred test1(model1)
+    @test_nowarn @inferred test2(model2)
+end

--- a/test/model_access.jl
+++ b/test/model_access.jl
@@ -15,6 +15,12 @@
     @test model.a == 2
     @test model.b == "test"
 
+
+    newa = Agent0(6)
+    model[6] = newa
+    @test model[6] == newa
+    @test_throws ArgumentError model[7] = newa
+
     prop2 = Agent2(1, 0.5)
     model2 = ABM(Agent0; properties = prop2)
     @test model2.weight == 0.5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,7 @@ end
 @testset "Agents.jl Tests" begin
 
 include("api_tests.jl")
+include("model_access.jl")
 include("space_test.jl")
 include("interaction_tests.jl")
 include("data_collector_test.jl")


### PR DESCRIPTION
This PR introduces two syntaxes that I find much beetter than what we have now:

1. `model[id]` gives the agent with `id`, i.e. it is `model.agents[id]`.
2. `model.property` gives the entry of `model.properties`. For example, `model.β` gives `model.properties[:β]`.

Motivation: I was extremely displeased about how super verbose it is to get model properties. I was also displeased that getting the agent with `id` is so complicated, given that the dictionary is central and should be more easy to do that. 

This PR resolves everything. It deprecates the function `id2agent` which is useless now.

Closes #166 .