### PR TITLE
Additional documentation

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,12 +5,15 @@ The core API is defined by [`AgentBasedModel`](@ref), [Space](@ref Space), [`Abs
 ## Agent information and retrieval
 ```@docs
 space_neighbors
-id2agent
 random_agent
 nagents
 allagents
 ```
-
+In addition to these functions, a number of standard Julia methods have been implemented for `AgentBasedModel`.
+```@docs
+getindex
+getproperty
+```
 
 ## Model-Agent interaction
 The following API is mostly universal across all types of [Space](@ref Space).
@@ -54,6 +57,7 @@ But there are other functions that are related to simulations listed here.
 ```@docs
 paramscan
 sample!
+dummystep
 ```
 
 ## Schedulers

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -70,7 +70,7 @@ After the basic types and functions are defined, we can run the model using the 
 In addition, by providing keywords to `step!`, it is also possible to collect and process data while the model evolves.
 
 ```@docs
-Agents.step!
+step!
 ```
 
 Notice that besides `step!`, there is also the [`paramscan`](@ref) function that performs data collection, while scanning ranges of the parameters of the model.

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -114,15 +114,36 @@ function Base.show(io::IO, abm::ABM{A}) where {A}
     end
 end
 
+"""
+    getindex(model::ABM, id::Integer)
+
+Return an agent given its ID.
+"""
 Base.getindex(m::ABM, id::Integer) = m.agents[id]
+
+"""
+    setindex!(model::ABM, agent::AbstractAgent, id::Int)
+
+Add an `agent` to the `model` at a given index: `id`. Note this method will return an error if the `id` requested is not equal to `agent.id`.
+"""
 function Base.setindex!(m::ABM, a::AbstractAgent, id::Int)
     a.id ≠ id && throw(ArgumentError("You are adding an agent to an ID not equal with the agent's ID!"))
     m.agents[id] = a
 end
 
-Base.getindex(m::ABM, id::Integer) = m.agents[id]
+"""
+    getproperty(model::ABM, prop::Symbol)
 
+Return a property from the current `model`. Possibilities are
+- `:agents`, list of all agents present
+- `:space`, current space information
+- `:scheduler`, which sheduler is being used
+- `:properties`, dictionary of all model properties
+- Any symbol that exists within the model properties dictionary
 
+Alternatively, all of these values can be returned using the `model.x` syntax.
+For example, if a model has the set of properties `Dict(:weight => 5, :current => false)`, retrieving these values can be obtained via `model.properties` as well as the `getproperty()` method. Equivalently, we can use `getproperty(model, :weight)` and `model.weight`.
+"""
 function Base.getproperty(m::ABM{A, S, F, P}, s::Symbol) where {A, S, F, P}
     if s === :agents
         return getfield(m, :agents)

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -376,7 +376,7 @@ get_node_agents(x, model) = [model[id] for id in get_node_contents(x, model)]
 Return an agent given its ID.
 """
 function id2agent(id::Integer, model::ABM)
-  @warn "`id2agent(id, model)` is deprecated. Use `model[id]` instead!"
+    @warn "`id2agent(id, model)` is deprecated. Use `model[id]` or `getindex(model, id)` instead!"
   model[id]
 end
 

--- a/src/core/space.jl
+++ b/src/core/space.jl
@@ -1,5 +1,5 @@
 export node_neighbors, find_empty_nodes, pick_empty, has_empty_nodes, get_node_contents,
-id2agent, NodeIterator, space_neighbors, nodes, get_node_agents
+NodeIterator, space_neighbors, nodes, get_node_agents
 export nv, ne
 export GraphSpace, GridSpace
 
@@ -370,15 +370,7 @@ instead of just the list of IDs.
 """
 get_node_agents(x, model) = [model[id] for id in get_node_contents(x, model)]
 
-"""
-    id2agent(id::Integer, model)
-
-Return an agent given its ID.
-"""
-function id2agent(id::Integer, model::ABM)
-    @warn "`id2agent(id, model)` is deprecated. Use `model[id]` or `getindex(model, id)` instead!"
-  model[id]
-end
+@deprecate id2agent(id::Integer, model::ABM) model[id]
 
 """
     space_neighbors(position, model::ABM [, r]) → ids

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -52,7 +52,18 @@ function step! end
 #######################################################################################
 # basic stepping
 #######################################################################################
+
+"""
+    dummystep(model)
+
+Ignore the model dynamics on this `step!`. Use in-place of `model_step!`.
+"""
 dummystep(model) = nothing
+"""
+    dummystep(agent, model)
+
+Ignore the agent dynamics on this `step!`. Use in-place of `agent_step!`.
+"""
 dummystep(agent, model) = nothing
 
 step!(model::ABM, agent_step!, n::Int = 1) = step!(model, agent_step!, dummystep, n)

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -62,7 +62,7 @@ dummystep(model) = nothing
 """
     dummystep(agent, model)
 
-Ignore the agent dynamics on this `step!`. Use in-place of `agent_step!`.
+Ignore the agent dynamics on this `step!`. Use instead of `agent_step!`.
 """
 dummystep(agent, model) = nothing
 

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -56,7 +56,7 @@ function step! end
 """
     dummystep(model)
 
-Ignore the model dynamics on this `step!`. Use in-place of `model_step!`.
+Ignore the model dynamics on this `step!`. Use instead of `model_step!`.
 """
 dummystep(model) = nothing
 """

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -1,4 +1,3 @@
-using Agents, Test, Random, LightGraphs
 mutable struct BadAgent <: AbstractAgent
     useless::Int
     pos::Int


### PR DESCRIPTION
Great work on #182 - it all looks amazing! Sorry I've been AFK all weekend.

Since there's been a lot of churn and I didn't get the change to do a proper review, I've gone through the final version and think it's solid.

I went through the docs and made sure all exported functions are now represented, as well as if we have any dangling exports. The only method we don't account for in the API docs currently is `dummystep`.
Also, the `Base` extensions could be considered as documentation, although I'm guessing it's not that important to have them explicitly discussed if we use the `model.x` and `model[id]` forms throughout.

If however, it makes sense to be a little verbose in the docs, I've added some words to that effect here. An exception to that is `setindex!` in accordance with 5f5b244.

Expecting these were considered omissions, so feel free to close this if such is the case.

**Concerning `id2agent`**:
Is the plan to completely depreciate that in v4, but keep it alive in v3 with a warning? We didn't give `Space` the same treatment. Should `id2agent` just be another deprecated, breaking change?