### PR TITLE
Extend setproperty!

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -139,6 +139,14 @@ function Base.getproperty(m::ABM{A, S, F, P}, s::Symbol) where {A, S, F, P}
     end
 end
 
+function Base.setproperty!(m::ABM{A, S, F, P}, s::Symbol, x) where {A, S, F, P}
+    properties = getfield(m, :properties)
+    if haskey(properties, s)
+        properties[s] = x
+    else
+        throw(ErrorException("Cannot set $(s) in this manner. Please use the `AgentBasedModel` constructor."))
+    end
+end
 
 """
     agent_validator(agent, space)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -141,7 +141,7 @@ end
 
 function Base.setproperty!(m::ABM{A, S, F, P}, s::Symbol, x) where {A, S, F, P}
     properties = getfield(m, :properties)
-    if haskey(properties, s)
+    if properties != nothing && haskey(properties, s)
         properties[s] = x
     else
         throw(ErrorException("Cannot set $(s) in this manner. Please use the `AgentBasedModel` constructor."))

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -130,6 +130,16 @@ properties = [model.agents[id].weight for id in ids]
 
 @test ids[sortperm(properties)] == a
 
+
+# %% get/set testing
+model = ABM(Agent1, GridSpace((10,10)); properties=Dict(:number => 1, :nested => BadAgent(1,1)))
+add_agent!(model)
+add_agent!(model)
+@test (model.number += 1) == 2
+@test (model.nested.pos = 5) == 5
+@test_throws ErrorException (model.space = ContinuousSpace(2))
+
+
 @testset "sample!" begin
   model = ABM(Agent2)
   for i in 1:20; add_agent!(model, rand()/rand()); end


### PR DESCRIPTION
Enables us to set properties in the model with our new extension, and bars all other overrides.

Usecase:

```julia
function model_step!(model)
    # Currently
    # model.properties[:tick] += 1
    # With this PR
    model.tick += 1
end

model = ABM(AgentX, GridSpace((10,10)); properties=Dict(:tick => 0))
add_agent(model)
step!(model, dummy_step, model_step!, 5)
@assert(model.tick == 5)
```

Nothing else is possible.
```julia
julia> model.space = ContinuousSpace(2)
ERROR: Cannot set space in this manner. Please use the `AgentBasedModel` constructor.
julia> model.agents = Agent1(1, (5,2))
ERROR: Cannot set agents in this manner. Please use the `AgentBasedModel` constructor.
```