### PR TITLE
Change biggest_id to next_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * If `model.properties` is a dictionary with key type Symbol, then the
   convenience syntax `model.prop` returns `model.properties[:prop]`.
 * Version of `add_agent!` now has keyword propagation as well (in case you make your types with `@kwdef` or Parameters.jl)
-* Change biggest_id to nextid and export it
+* New function `nextid`
 
 ## Breaking Changes
 * Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * If `model.properties` is a dictionary with key type Symbol, then the
   convenience syntax `model.prop` returns `model.properties[:prop]`.
 * Version of `add_agent!` now has keyword propagation as well (in case you make your types with `@kwdef` or Parameters.jl)
+* Change biggest_id to nextid and export it
 
 ## Breaking Changes
 * Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,6 +8,7 @@ space_neighbors
 random_agent
 nagents
 allagents
+nextid
 ```
 In addition to these functions, a number of standard Julia methods have been implemented for `AgentBasedModel`.
 ```@docs

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -2,7 +2,7 @@
 This file establishes the agent-space interaction API.
 =#
 export move_agent!, add_agent!, add_agent_single!, add_agent_pos!,
-move_agent_single!, kill_agent!, genocide!
+move_agent_single!, kill_agent!, genocide!, nextid
 
 #######################################################################################
 # Killing agents
@@ -190,7 +190,7 @@ add_agent!(model; w = 0.5, k =true) # use keywords: weight becomes 0.5
 ```
 """
 function add_agent!(node, model::ABM{A, <: DiscreteSpace}, properties...; kwargs...) where {A}
-    id = next_id(model)
+    id = nextid(model)
     cnode = correct_pos_type(node, model)
     agent = A(id, cnode, properties...; kwargs...)
     add_agent!(agent, cnode, model)
@@ -198,13 +198,13 @@ end
 
 function add_agent!(model::ABM{A, Nothing}, properties...; kwargs...) where {A}
   @assert model.space == nothing
-  id = next_id(model)
+  id = nextid(model)
   model[id] = A(id, properties...; kwargs...)
   return model[id]
 end
 
 function add_agent!(model::ABM{A, S}, properties...; kwargs...) where {A, S<:AbstractSpace}
-  id = next_id(model)
+  id = nextid(model)
   n = rand(1:nv(model))
   cnode = correct_pos_type(n, model)
   model[id] = A(id, cnode, properties...; kwargs...)
@@ -212,7 +212,22 @@ function add_agent!(model::ABM{A, S}, properties...; kwargs...) where {A, S<:Abs
   return model[id]
 end
 
-next_id(model::ABM) = isempty(model.agents) ? 1 : maximum(keys(model.agents)) + 1
+"""
+Returns the next largest agent id.
+## Example
+```julia
+using Agents
+
+mutable struct Agent <: AbstractAgent
+    id::Int
+    pos::Int
+end
+
+model = ABM(Agent, GraphSpace(complete_digraph(5)))
+id = nextid(model) # returns 1
+```
+"""
+nextid(model::ABM) = isempty(model.agents) ? 1 : maximum(keys(model.agents)) + 1
 
 """
     add_agent_single!(agent::A, model::ABM{A, <: DiscreteSpace}, verbose = true) → agent
@@ -239,7 +254,7 @@ into a node with no other agents (does nothing if no such node exists).
 """
 function add_agent_single!(model::ABM{A, <: DiscreteSpace}, properties...; kwargs...) where {A}
   msa = model.space.agent_positions
-  id = next_id(model)
+  id = nextid(model)
   empty_cells = [i for i in 1:length(msa) if length(msa[i]) == 0]
   if length(empty_cells) > 0
     random_node = rand(empty_cells)

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -190,7 +190,7 @@ add_agent!(model; w = 0.5, k =true) # use keywords: weight becomes 0.5
 ```
 """
 function add_agent!(node, model::ABM{A, <: DiscreteSpace}, properties...; kwargs...) where {A}
-    id = biggest_id(model) + 1
+    id = next_id(model)
     cnode = correct_pos_type(node, model)
     agent = A(id, cnode, properties...; kwargs...)
     add_agent!(agent, cnode, model)
@@ -198,13 +198,13 @@ end
 
 function add_agent!(model::ABM{A, Nothing}, properties...; kwargs...) where {A}
   @assert model.space == nothing
-  id = biggest_id(model) + 1
+  id = next_id(model)
   model[id] = A(id, properties...; kwargs...)
   return model[id]
 end
 
 function add_agent!(model::ABM{A, S}, properties...; kwargs...) where {A, S<:AbstractSpace}
-  id = biggest_id(model) + 1
+  id = next_id(model)
   n = rand(1:nv(model))
   cnode = correct_pos_type(n, model)
   model[id] = A(id, cnode, properties...; kwargs...)
@@ -212,7 +212,7 @@ function add_agent!(model::ABM{A, S}, properties...; kwargs...) where {A, S<:Abs
   return model[id]
 end
 
-biggest_id(model::ABM) = isempty(model.agents) ? 0 : maximum(keys(model.agents))
+next_id(model::ABM) = isempty(model.agents) ? 1 : maximum(keys(model.agents)) + 1
 
 
 """
@@ -240,7 +240,7 @@ into a node with no other agents (does nothing if no such node exists).
 """
 function add_agent_single!(model::ABM{A, <: DiscreteSpace}, properties...; kwargs...) where {A}
   msa = model.space.agent_positions
-  id = biggest_id(model) + 1
+  id = next_id(model)
   empty_cells = [i for i in 1:length(msa) if length(msa[i]) == 0]
   if length(empty_cells) > 0
     random_node = rand(empty_cells)

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -199,7 +199,7 @@ end
 function add_agent!(model::ABM{A, Nothing}, properties...; kwargs...) where {A}
   @assert model.space == nothing
   id = biggest_id(model) + 1
-  model[id] = A(id, properties...)
+  model[id] = A(id, properties...; kwargs...)
   return model[id]
 end
 
@@ -207,7 +207,7 @@ function add_agent!(model::ABM{A, S}, properties...; kwargs...) where {A, S<:Abs
   id = biggest_id(model) + 1
   n = rand(1:nv(model))
   cnode = correct_pos_type(n, model)
-  model[id] = A(id, cnode, properties...)
+  model[id] = A(id, cnode, properties...; kwargs...)
   push!(model.space.agent_positions[n], id)
   return model[id]
 end

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -212,12 +212,7 @@ function add_agent!(model::ABM{A, S}, properties...; kwargs...) where {A, S<:Abs
   return model[id]
 end
 
-<<<<<<< HEAD
 next_id(model::ABM) = isempty(model.agents) ? 1 : maximum(keys(model.agents)) + 1
-=======
-next_id(model::ABM) = isempty(model.agents) ? 0 : maximum(keys(model.agents)) + 1
->>>>>>> 9d7148294d9501fc04bf772155eebe3d31dbf546
-
 
 """
     add_agent_single!(agent::A, model::ABM{A, <: DiscreteSpace}, verbose = true) → agent

--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -213,19 +213,8 @@ function add_agent!(model::ABM{A, S}, properties...; kwargs...) where {A, S<:Abs
 end
 
 """
-Returns the next largest agent id.
-## Example
-```julia
-using Agents
-
-mutable struct Agent <: AbstractAgent
-    id::Int
-    pos::Int
-end
-
-model = ABM(Agent, GraphSpace(complete_digraph(5)))
-id = nextid(model) # returns 1
-```
+    nextid(model::ABM) → id
+Return a valid `id` for creating a new agent with it.
 """
 nextid(model::ABM) = isempty(model.agents) ? 1 : maximum(keys(model.agents)) + 1
 

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -150,7 +150,7 @@ function add_agent!(model::ABM{A, <: ContinuousSpace}, args...) where {A<:Abstra
 end
 
 function add_agent!(pos::Tuple, model::ABM{A, <: ContinuousSpace}, args...) where {A<:AbstractAgent}
-  id = biggest_id(model) + 1
+  id = next_id(model)
   agent = A(id, pos, args...)
   add_agent_pos!(agent, model)
 end

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -150,7 +150,7 @@ function add_agent!(model::ABM{A, <: ContinuousSpace}, args...) where {A<:Abstra
 end
 
 function add_agent!(pos::Tuple, model::ABM{A, <: ContinuousSpace}, args...) where {A<:AbstractAgent}
-  id = next_id(model)
+  id = nextid(model)
   agent = A(id, pos, args...)
   add_agent_pos!(agent, model)
 end


### PR DESCRIPTION
This PR changes `biggest_id` to `next_id` because all uses of `biggest_id` add 1 to the largest id to obtain the next id. This is also useful when creating models with heterogeneous agents because the ids need to be managed by the user when new agents are added dynamically throughout the model run.