### PR TITLE
Mixed method additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `node_neighbors` now accepts a `neighbor_type` keyword for working with directed graphs.
 * Added example of flocking birds in `ContinuousSpace` and Daisyworld in `GridSpace`.
 - Collection of model and agent data simultaneously is now possible using the `mdata` and `adata` keywords (respectively) used in conjunction with the revamped data collection scheme (see below).
+- Better support for mixed-ABMs and a new `by_type` scheduler.
 
 ## Breaking Changes
 * Deprecated `Space` in favor of the individual spaces: `Nothing, GridSpace, GraphSpace, ContinuousSpace`.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -92,6 +92,7 @@ by_id
 random_activation
 partial_activation
 property_activation
+by_type
 ```
 
 ## Plotting

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -10,6 +10,7 @@ import Base.length
 
 # Core structures of Agents.jl
 include("core/model.jl")
+include("core/schedule.jl")
 include("core/space.jl")
 include("core/agent_space_interaction.jl")
 include("core/continuous_space.jl")

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -1,6 +1,4 @@
-export nagents, AbstractAgent, ABM, AgentBasedModel,
-random_activation, by_id, fastest, partial_activation, random_agent,
-property_activation, allagents
+export AbstractAgent, ABM, AgentBasedModel, nagents, random_agent, allagents
 
 abstract type AbstractSpace end
 
@@ -55,9 +53,23 @@ struct AgentBasedModel{A<:AbstractAgent, S<:SpaceType, F, P}
     scheduler::F
     properties::P
 end
+
 const ABM = AgentBasedModel
+
 agenttype(::ABM{A}) where {A} = A
 spacetype(::ABM{A, S}) where {A, S} = S
+
+"""
+    union_types(U)
+Return a set of types within a `Union`. Preserves order.
+"""
+union_types(x::Union) = union_types(x.a, x.b)
+union_types(a::Union, b::Type) = (union_types(a)..., b)
+union_types(a::Type, b::Type) = (a, b)
+union_types(x::Type) = (x,)
+# For completness
+union_types(a::Type, b::Union) = (a, union_types(b)...)
+
 
 """
     AgentBasedModel(AgentType [, space]; scheduler, properties) → model
@@ -225,60 +237,3 @@ Return an iterator over all agents of the model.
 """
 allagents(model) = values(model.agents)
 
-####################################
-# Schedulers
-####################################
-"""
-    fastest
-Activate all agents once per step in the order dictated by the agent's container,
-which is arbitrary (the keys sequence of a dictionary).
-This is the fastest way to activate all agents once per step.
-"""
-fastest(model) = keys(model.agents)
-
-"""
-    by_id
-Activate agents at each step according to their id.
-"""
-function by_id(model::ABM)
-  agent_ids = sort(collect(keys(model.agents)))
-  return agent_ids
-end
-
-@deprecate as_added by_id
-
-"""
-    random_activation
-Activate agents once per step in a random order.
-Different random ordering is used at each different step.
-"""
-function random_activation(model::ABM)
-  order = shuffle(collect(keys(model.agents)))
-end
-
-"""
-    partial_activation(p)
-At each step, activate only `p` percentage of randomly chosen agents.
-"""
-function partial_activation(p::Real)
-    function partial(model::ABM{A, S, F, P}) where {A, S, F, P}
-        ids = collect(keys(model.agents))
-        return randsubseq(ids, p)
-    end
-    return partial
-end
-
-"""
-    property_activation(property)
-At each step, activate the agents in an order dictated by their `property`,
-with agents with greater `property` acting first. `property` is a `Symbol`, which
-just dictates which field the agents to compare.
-"""
-function property_activation(p::Symbol)
-    function by_property(model::ABM{A, S, F, P}) where {A, S, F, P}
-        ids = collect(keys(model.agents))
-        properties = [getproperty(model.agents[id], p) for id in ids]
-        s = sortperm(properties)
-        return ids[s]
-    end
-end

--- a/src/core/schedule.jl
+++ b/src/core/schedule.jl
@@ -60,7 +60,7 @@ function property_activation(p::Symbol)
 end
 
 """
-    by_type(shuffle)
+    by_type(shuffle::Bool)
 Useful only for mixed agent models using `Union` types.
 Activate agents by type in order of appearance in the `Union`.
 To group by type, but randomize the type order, set `shuffle = true`.

--- a/src/core/schedule.jl
+++ b/src/core/schedule.jl
@@ -1,0 +1,105 @@
+####################################
+# Schedulers
+####################################
+
+export random_activation, by_id, fastest, partial_activation, property_activation, by_type
+
+"""
+    fastest
+Activate all agents once per step in the order dictated by the agent's container,
+which is arbitrary (the keys sequence of a dictionary).
+This is the fastest way to activate all agents once per step.
+"""
+fastest(model::ABM) = keys(model.agents)
+
+function fastest(sets::Vector{Vector{Integer}})
+    vcat(sets...)
+end
+
+"""
+    by_id
+Activate agents at each step according to their id.
+"""
+function by_id(model::ABM)
+    agent_ids = sort(collect(keys(model.agents)))
+    return agent_ids
+end
+
+function by_id(sets::Vector{Vector{Integer}})
+    [sort!(set) for set in sets]
+    vcat(sets...)
+end
+
+@deprecate as_added by_id
+
+"""
+    random_activation
+Activate agents once per step in a random order.
+Different random ordering is used at each different step.
+"""
+function random_activation(model::ABM)
+    order = shuffle(collect(keys(model.agents)))
+end
+
+function random_activation(sets::Vector{Vector{Integer}})
+    [shuffle!(set) for set in sets]
+    shuffle!(sets)
+    vcat(sets...)
+end
+
+"""
+    partial_activation(p)
+At each step, activate only `p` percentage of randomly chosen agents.
+"""
+function partial_activation(p::Real)
+    function partial(model::ABM{A,S,F,P}) where {A,S,F,P}
+        ids = collect(keys(model.agents))
+        return randsubseq(ids, p)
+    end
+    return partial
+end
+
+function partial_activation(sets::Vector{Vector{Integer}}, p::Real)
+    subset = [randsubseq(set, p) for set in sets]
+    vcat(subset...)
+end
+
+"""
+    property_activation(property)
+At each step, activate the agents in an order dictated by their `property`,
+with agents with greater `property` acting first. `property` is a `Symbol`, which
+just dictates which field the agents to compare.
+"""
+function property_activation(p::Symbol)
+    function by_property(model::ABM{A,S,F,P}) where {A,S,F,P}
+        ids = collect(keys(model.agents))
+        properties = [getproperty(model.agents[id], p) for id in ids]
+        s = sortperm(properties)
+        return ids[s]
+    end
+end
+
+"""
+    by_type(fastest)
+Useful only for mixed agent models using `Union` types.
+Activate agents by type order, then by a subsequent `method`.
+
+`method` may be any inbuilt scheduler listed above (except for `property_activation`),
+or a custom function that accepts `sets::Vector{Vector{Integer}}` of agent ids separated
+into `n` vectors, where `n` is the number of `AbstractAgent` types inside the `Union`.
+
+Any additional scheduler properties are passed on, for example
+`by_type(partial_activation, p)`.
+"""
+function by_type(method::Function, properties...)
+    function by_union(model::ABM{A,S,F,P}) where {A,S,F,P}
+        types = union_types(A)
+        sets = [Integer[] for _ in types]
+        for agent in allagents(model)
+            idx = findfirst(t -> t == typeof(agent), types)
+            push!(sets[idx], agent.id)
+        end
+        return method(sets, properties...)
+    end
+end
+

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -75,6 +75,7 @@ end
     @test_throws ArgumentError ABM(Union{Agent0,BadAgent}; warn=false)
 end
 
+Random.seed!(65465)
 model1 = ABM(Agent1, GridSpace((3,3)))
 
 agent = add_agent!((1,1), model1)

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -69,6 +69,10 @@ end
     #Type inferance using an instance can help users here
     agent = ParametricAgent(1, (1,1), 5, "Info")
     @test Agents.agenttype(ABM(agent, GridSpace((1,1)))) <: AbstractAgent
+    #Mixed agents
+    @test Agents.agenttype(ABM(Union{Agent0,Agent1}; warn=false)) <: AbstractAgent
+    @test_logs (:warn, "AgentType is not concrete. If your agent is parametrically typed, you're probably seeing this warning because you gave `Agent` instead of `Agent{Float64}` (for example) to this function. You can also create an instance of your agent and pass it to this function. If you want to use `Union` types for mixed agent models, you can silence this warning.") ABM(Union{Agent0,Agent1})
+    @test_throws ArgumentError ABM(Union{Agent0,BadAgent}; warn=false)
 end
 
 model1 = ABM(Agent1, GridSpace((3,3)))

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -87,49 +87,6 @@ pos1 = get_node_contents((1,1), model1)
 pos2 = get_node_contents((2,2), model1)
 @test pos2[1] == 1
 
-# %% Scheduler tests
-N = 1000
-
-# by_id
-model = ABM(Agent0; scheduler = by_id)
-for i in 1:N; add_agent!(model); end
-@test sort!(collect(keys(model.agents))) == 1:N
-@test model.scheduler(model) == 1:N
-
-# fastest
-Random.seed!(12)
-model = ABM(Agent0; scheduler = fastest)
-for i in 1:N; add_agent!(model); end
-@test sort!(collect(model.scheduler(model))) == 1:N
-
-# random
-Random.seed!(12)
-model = ABM(Agent0; scheduler = random_activation)
-for i in 1:N; add_agent!(model); end
-@test model.scheduler(model)[1:3] == [913, 522, 637] # reproducibility test
-
-# partial
-Random.seed!(12)
-model = ABM(Agent0; scheduler = partial_activation(0.1))
-for i in 1:N; add_agent!(model); end
-
-a = model.scheduler(model)
-@test length(a) < N
-@test a[1] == 74 # reproducibility test
-
-# by property
-model = ABM(Agent2; scheduler = property_activation(:weight))
-for i in 1:N; add_agent!(model, rand()/rand()); end
-
-Random.seed!(12)
-a = model.scheduler(model)
-
-ids = collect(keys(model.agents))
-properties = [model.agents[id].weight for id in ids]
-
-@test ids[sortperm(properties)] == a
-
-
 # %% get/set testing
 model = ABM(Agent1, GridSpace((10,10)); properties=Dict(:number => 1, :nested => BadAgent(1,1)))
 add_agent!(model)
@@ -320,9 +277,10 @@ end
   @test nagents(model) == 5
 
   # Testing genocide!(model::ABM, f::Function) when the function is invalid (i.e. does not return a bool)
+  Random.seed!(1565)
   for i in 1:20
-    agent = Agent3(i, (1,1), i*2)
-    add_agent_single!(agent, model)
+    agent = Agent3(i, (rand(1:10),rand(1:10)), i*2)
+    add_agent_pos!(agent, model)
   end
   @test_throws TypeError genocide!(model, a -> a.id)
 
@@ -336,5 +294,5 @@ end
     end
   end
   genocide!(model, complex_logic)
-  @test nagents(model) == 17
+  @test nagents(model) == 13
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,7 @@ Agent8(id, pos; f1, f2) = Agent8(id, pos, f1, f2)
 @testset "Agents.jl Tests" begin
 
     include("api_tests.jl")
+    include("scheduler_tests.jl")
     include("model_access.jl")
     include("space_test.jl")
     include("interaction_tests.jl")

--- a/test/scheduler_tests.jl
+++ b/test/scheduler_tests.jl
@@ -1,0 +1,120 @@
+# %% Scheduler tests
+@testset "Standard Scheduler" begin
+    N = 1000
+
+    # by_id
+    model = ABM(Agent0; scheduler = by_id)
+    for i in 1:N
+        add_agent!(model)
+    end
+    @test sort!(collect(keys(model.agents))) == 1:N
+    @test model.scheduler(model) == 1:N
+
+    # fastest
+    Random.seed!(12)
+    model = ABM(Agent0; scheduler = fastest)
+    for i in 1:N
+        add_agent!(model)
+    end
+    @test sort!(collect(model.scheduler(model))) == 1:N
+
+    # random
+    Random.seed!(12)
+    model = ABM(Agent0; scheduler = random_activation)
+    for i in 1:N
+        add_agent!(model)
+    end
+    @test model.scheduler(model)[1:3] == [913, 522, 637] # reproducibility test
+
+    # partial
+    Random.seed!(12)
+    model = ABM(Agent0; scheduler = partial_activation(0.1))
+    for i in 1:N
+        add_agent!(model)
+    end
+
+    a = model.scheduler(model)
+    @test length(a) < N
+    @test a[1] == 74 # reproducibility test
+
+    # by property
+    model = ABM(Agent2; scheduler = property_activation(:weight))
+    for i in 1:N
+        add_agent!(model, rand() / rand())
+    end
+
+    Random.seed!(12)
+    a = model.scheduler(model)
+
+    ids = collect(keys(model.agents))
+    properties = [model.agents[id].weight for id in ids]
+
+    @test ids[sortperm(properties)] == a
+end
+
+# Mixed model
+function init_mixed_model(; scheduler = fastest)
+    model = ABM(Union{Agent0,Agent1,Agent2,Agent3}, scheduler = scheduler, warn = false)
+    for id in 1:5
+        a0 = Agent0(id)
+        add_agent!(a0, model)
+    end
+    for id in 6:10
+        a1 = Agent1(id, (0, 0))
+        add_agent!(a1, model)
+    end
+    for id in 11:15
+        a2 = Agent2(id, 5.0)
+        add_agent!(a2, model)
+    end
+    for id in 16:20
+        a3 = Agent3(id, (0, 0), 5.0)
+        add_agent!(a3, model)
+    end
+    return model
+end
+
+@testset "Mixed Scheduler" begin
+    model = init_mixed_model()
+    @test sort!(collect(model.scheduler(model))) == 1:20
+
+    model = init_mixed_model(scheduler = by_type(fastest))
+    @test sort!(collect(model.scheduler(model))) == 1:20
+
+    model = init_mixed_model(scheduler = by_id)
+    @test model.scheduler(model) == 1:20
+
+    model = init_mixed_model(scheduler = by_type(by_id))
+    @test model.scheduler(model) == 1:20
+
+    # Swapping union order
+    model = ABM(Union{Agent0,Agent1}, scheduler = by_type(by_id), warn = false)
+    for id in 1:5
+        a1 = Agent1(id, (0, 0))
+        add_agent!(a1, model)
+    end
+    for id in 6:10
+        a0 = Agent0(id)
+        add_agent!(a0, model)
+    end
+
+    @test model.scheduler(model) == vcat(6:10, 1:5)
+
+    Random.seed!(12)
+    model = init_mixed_model(scheduler = random_activation)
+    @test model.scheduler(model)[1:3] == [17, 5, 11] # reproducibility test
+
+    Random.seed!(12)
+    model = init_mixed_model(scheduler = by_type(random_activation))
+    @test model.scheduler(model)[1:3] == [1, 2, 5] # reproducibility test
+
+    Random.seed!(12)
+    model = init_mixed_model(scheduler = partial_activation(0.5))
+    @test model.scheduler(model) == [18, 16, 11, 17, 8, 4, 3, 5, 13]
+
+    Random.seed!(12)
+    model = init_mixed_model(scheduler = by_type(partial_activation, 0.5))
+    @test model.scheduler(model) == [2, 3, 5, 8, 6, 13, 14, 15, 18]
+    @test count(a -> a == Agent2, typeof(model[id]) for id in model.scheduler(model)) == 4
+end
+


### PR DESCRIPTION
Improve support for mixed models.
- Adds a `by_type` method (as discussed in #235)
- As a result, schedulers have been moved to their own file
- A method to capture types in a `Union` `union_types`
- We now iterate over subtypes of the union and provide warnings/errors for each.

We can bikeshed naming the scheduler functions, there's probably better ones to use.