### PR TITLE
Correct handling of no space in sample

### DIFF
--- a/src/core/agent_space_interaction.jl
+++ b/src/core/agent_space_interaction.jl
@@ -143,6 +143,11 @@ function add_agent_pos!(agent::A, model::ABM{A,<:DiscreteSpace}) where {A<:Abstr
     return model[agent.id]
 end
 
+function add_agent_pos!(agent::A, model::ABM{A,Nothing}) where {A<:AbstractAgent}
+    model[agent.id] = agent
+    return model[agent.id]
+end
+
 """
     add_agent!(agent::AbstractAgent [, position], model::ABM) → agent
 
@@ -158,8 +163,7 @@ function add_agent!(agent::A, model::ABM{A,<:DiscreteSpace}) where {A<:AbstractA
 end
 
 function add_agent!(agent::A, model::ABM{A,Nothing}) where {A<:AbstractAgent}
-    model[agent.id] = agent
-    return model[agent.id]
+    add_agent_pos!(agent, model)
 end
 
 function add_agent!(
@@ -223,9 +227,7 @@ function add_agent!(
     properties...;
     kwargs...,
 ) where {A<:AbstractAgent}
-    id = nextid(model)
-    model[id] = A(id, properties...; kwargs...)
-    return model[id]
+    add_agent_pos!(A(nextid(model), properties...; kwargs...), model)
 end
 
 function add_agent!(

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -41,7 +41,7 @@ function sample!(model::ABM{A, S}, n::Int, weight=nothing; replace=true,
       for t in 2:noccurances
         newagent = deepcopy(model.agents[id])
         newagent.id = n
-        add_agent!(newagent, model)
+        add_agent_pos!(newagent, model)
         n += 1
       end
     end


### PR DESCRIPTION
Ali alerted me to a bug I introduced in sample! due to how a `Nothing` space is handled. We do need the `add_agent_pos!` method for this space type.