### PR TITLE
Re-enable codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_script:
   - git config --global user.email "git@us.er"
 
 codecov: true
+after_success:
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_script:
   - git config --global user.name "GitUser"
   - git config --global user.email "git@us.er"
 
+codecov: true
+
 matrix:
   allow_failures:
     - julia: nightly


### PR DESCRIPTION
1c97912e689d2 seemed to kill off codecov, which was using the old way of integrating coverage anyhow. 

From the looks of it, everything is still set up to have it running, it's just disabled currently.