### PR TITLE
New syntax for aggname

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -93,6 +93,7 @@ by_id
 random_activation
 partial_activation
 property_activation
+by_type
 ```
 
 ## Plotting

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -246,14 +246,14 @@ results, _ = run!(model, agent_step!, n_steps; adata = adata)
 
 @df results plot(
     :step,
-    cols(aggname(sheep, count)),
+    :count_sheep,
     grid = false,
     xlabel = "Step",
     ylabel = "Population",
     label = "Sheep",
 )
-@df results plot!(:step, cols(aggname(wolves, count)), label = "Wolves")
-@df results plot!(:step, cols(aggname(grass, count)), label = "Grass")
+@df results plot!(:step, :count_wolves, label = "Wolves")
+@df results plot!(:step, :count_grass, label = "Grass")
 
 # Altering the input conditions, we now see a landscape where all three agents find an
 # equilibrium.
@@ -267,15 +267,14 @@ model = initialize_model(
     wolf_reproduce = 0.08,
 )
 results, _ = run!(model, agent_step!, n_steps; adata = adata)
-
 @df results plot(
     :step,
-    cols(aggname(sheep, count)),
+    :count_sheep,
     grid = false,
     xlabel = "Step",
     ylabel = "Population",
     label = "Sheep",
 )
-@df results plot!(:step, cols(aggname(wolves, count)), label = "Wolves")
-@df results plot!(:step, cols(aggname(grass, count)), label = "Grass")
+@df results plot!(:step, :count_wolves, label = "Wolves")
+@df results plot!(:step, :count_grass, label = "Grass")
 

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -289,9 +289,9 @@ data[1:10, :]
 
 N = sum(model.Ns) # Total initial population
 x = data.step
-p = Plots.plot(x, log10.(data[:, Symbol("infected(status)")]), label = "infected")
-plot!(p, x, log10.(data[:, Symbol("recovered(status)")]), label = "recovered")
-dead = log10.(N .- data[:, Symbol("length(status)")])
+p = Plots.plot(x, log10.(data[:, aggname(:status, infected)]), label = "infected")
+plot!(p, x, log10.(data[:, aggname(:status, recovered)]), label = "recovered")
+dead = log10.(N .- data[:, aggname(:status, length)])
 plot!(p, x, dead, label = "dead")
 xlabel!(p, "steps")
 ylabel!(p, "log( count )")

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -323,9 +323,9 @@ data1[(end - 10):end, :]
 
 # Now, we can plot the number of infected versus time
 
-p = plot(data1[:, Symbol("infected(status)")], label = "r=$r1, beta=$β1")
-plot!(p, data2[:, Symbol("infected(status)")], label = "r=$r2, beta=$β1")
-plot!(p, data3[:, Symbol("infected(status)")], label = "r=$r1, beta=$β2")
+p = plot(data1[:, aggname(:status, infected)], label = "r=$r1, beta=$β1")
+plot!(p, data2[:, aggname(:status, infected)], label = "r=$r2, beta=$β1")
+plot!(p, data3[:, aggname(:status, infected)], label = "r=$r1, beta=$β2")
 yaxis!(p, "Infected")
 p
 
@@ -368,7 +368,7 @@ data4, _ = run!(
     adata = adata,
 )
 
-plot!(p, data4[:, Symbol("infected(status)")], label = "r=$r4, social distancing")
+plot!(p, data4[:, aggname(:status, infected)], label = "r=$r4, social distancing")
 p
 
 # Here you can see the characteristic "flattening the curve" phrase you hear all over the

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -30,8 +30,8 @@ two `DataFrame`s, one for agent-level data and one for model-level data.
   entry is an aggregating function that aggregates the key, e.g. `mean, maximum`. So,
   continuing from the above example, we would have
   `adata = [(:weight, mean), (f, maximum)]`. The resulting data name columns
-  use the function [`aggname`](@ref), and create something like `mean(weight)` or
-  `maximum(f)`. This name doesn't play well with anonymous functions!
+  use the function [`aggname`](@ref), and create something like `:mean_weight` or
+  `:maximum_f`. This name doesn't play well with anonymous functions!
 
   **Notice:** Aggregating only works if there are agents to be aggregated over.
   If you remove agents during model run, you should modify the aggregating functions.
@@ -192,9 +192,9 @@ function `agg`.
 """
 function aggname(k, agg)
     @static if VERSION >= v"1.1"
-        Symbol(join([string(agg),"(", string(k), ")"], ""))
+        Symbol(join([string(agg), string(k)], "_"))
     else
-        Symbol(join([split(string(agg), ".")[end],"(", string(k), ")"], ""))
+        Symbol(join([split(string(agg), ".")[end], string(k)], "_"))
     end
 end
 

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -38,8 +38,8 @@ model = initialize()
 end
 
 @testset "aggname" begin
-    @test aggname(:weight, mean) == Symbol("mean(weight)")
-    @test aggname(x_position, length) == Symbol("length(x_position)")
+    @test aggname(:weight, mean) == :mean_weight
+    @test aggname(x_position, length) == :length_x_position
 end
 
 @testset "Aggregate Collections" begin
@@ -57,8 +57,8 @@ end
     # Activate aggregation. Weight column is expected to be one value for this step,
     # renamed mean(weight). ID is meaningless and will therefore be dropped.
     @test size(df) == (1, 2)
-    @test names(df) == [:step, Symbol("mean(weight)")]
-    @test df[1, Symbol("mean(weight)")] ≈ 0.3917615139
+    @test names(df) == [:step, :mean_weight]
+    @test df[1, aggname(:weight, mean)] ≈ 0.3917615139
 
     # Add a function as a property
     props = [:weight, x_position]
@@ -72,8 +72,8 @@ end
     df = init_agent_dataframe(model, props)
     collect_agent_data!(df, model, props, 1)
     @test size(df) == (1, 3)
-    @test names(df) == [:step, Symbol("mean(weight)"), Symbol("mean(x_position)")]
-    @test df[1, Symbol("mean(x_position)")] ≈ 4.3333333
+    @test names(df) == [:step, :mean_weight, :mean_x_position]
+    @test df[1, aggname(x_position, mean)] ≈ 4.3333333
 end
 
 @testset "High-level API for Collections" begin
@@ -93,7 +93,7 @@ end
     )
 
     @test size(agent_data) == (11, 2)
-    @test names(agent_data) == [:step, Symbol("mean(weight)")]
+    @test names(agent_data) == [:step, :mean_weight]
     @test maximum(agent_data[!, :step]) == 1820
 
     @test size(model_data) == (6, 3)
@@ -128,7 +128,7 @@ end
     @test maximum(daily_model_data[!, :step]) == 1825
 
     @test size(daily_agent_aggregate) == (1825, 2)
-    @test names(daily_agent_aggregate) == [:step, Symbol("mean(weight)")]
+    @test names(daily_agent_aggregate) == [:step, :mean_weight]
     @test maximum(daily_agent_aggregate[!, :step]) == 1825
 
     @test size(yearly_agent_data) == (15, 3)


### PR DESCRIPTION
Closes #234 by swapping `mean(weight)` to `:mean_weight` syntax.