### PR TITLE
Mixed model support in interacting_pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.1
+## Additions
+- Extend `interacting_pairs` to allow interactions of disparate types when using mixed models.
+
 # v3.0
 ## Additions
 * Added `ContinuousSpace` as a space option. Supports Euclidean and Cityblock metrics. Several new API functions were added for continuous space.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Ali Vahdati", "George Datseris", "Tim DuBois"]
-version = "3.0.0"
+version = "3.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -82,7 +82,7 @@ return df_agent, df_model
 ```
 (here `until` and `should_we_collect` are internal functions)
 
-## Schedulers
+## [Schedulers](@id Schedulers)
 The schedulers of Agents.jl have a very simple interface. All schedulers are functions,
 that take as an input the ABM and return an iterator over agent IDs.
 Notice that this iterator can be a "true" iterator or can be just a standard vector of IDs.

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -353,10 +353,11 @@ The argument `method` provides three pairing scenarios
   to only one pair. This functionality is useful e.g. when you want some agents to be
   paired "guaranteed", even if some other agents might be nearest to each other.
 - `:types`: For mixed agent models only. Return every pair of agents within radius `r`
-  (similar to `:all`), with an additional constraint that excludes neighbors with the same
-  type. For example, a mixed agent model of `Union{Sheep,Wolf,Grass}`, pairs of 
-  `(Sheep,Sheep)` will be excluded. To also exclude `(Wolf,Grass)` pairs, provide a
-  scheduler that samples only matchable parings.
+  (similar to `:all`), only capturing pairs of differing types. For example, a model of
+  `Union{Sheep,Wolf}` will only return pairs of `(Sheep, Wolf)`. In the case multiple
+  agent types, *e.g.* `Union{Sheep, Wolf, Grass}`, skipping pairings that involve
+  `Grass`, can be achived by a [`scheduler`](@ref Schedulers) that doesn't schedule `Grass`
+  types, *i.e.*: `scheduler = [a.id for a in allagents(model) of !(a isa Grass)]`.
 """
 function interacting_pairs(model::ABM, r::Real, method; scheduler = model.scheduler)
     @assert method ∈ (:scheduler, :nearest, :all, :types)

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -355,7 +355,6 @@ The argument `method` provides three pairing scenarios
 - `:types`: For mixed agent models only. Return every pair of agents within radius `r`
   (similar to `:all`), only capturing pairs of differing types. For example, a model of
   `Union{Sheep,Wolf}` will only return pairs of `(Sheep, Wolf)`. In the case of multiple
-
   agent types, *e.g.* `Union{Sheep, Wolf, Grass}`, skipping pairings that involve
   `Grass`, can be achived by a [`scheduler`](@ref Schedulers) that doesn't schedule `Grass`
   types, *i.e.*: `scheduler = [a.id for a in allagents(model) of !(a isa Grass)]`.

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -354,7 +354,8 @@ The argument `method` provides three pairing scenarios
   paired "guaranteed", even if some other agents might be nearest to each other.
 - `:types`: For mixed agent models only. Return every pair of agents within radius `r`
   (similar to `:all`), only capturing pairs of differing types. For example, a model of
-  `Union{Sheep,Wolf}` will only return pairs of `(Sheep, Wolf)`. In the case multiple
+  `Union{Sheep,Wolf}` will only return pairs of `(Sheep, Wolf)`. In the case of multiple
+
   agent types, *e.g.* `Union{Sheep, Wolf, Grass}`, skipping pairings that involve
   `Grass`, can be achived by a [`scheduler`](@ref Schedulers) that doesn't schedule `Grass`
   types, *i.e.*: `scheduler = [a.id for a in allagents(model) of !(a isa Grass)]`.

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -352,11 +352,11 @@ The argument `method` provides three pairing scenarios
   agent is paired to its nearest neighbor. Similar to `:nearest`, each agent can belong
   to only one pair. This functionality is useful e.g. when you want some agents to be
   paired "guaranteed", even if some other agents might be nearest to each other.
-- `:types`: For mixed models only. Return every pair of agents within radius `r` (similar
-  to `:all`), with an additional constraint that excludes neighbors with the same type.
-  For example, a mixed model of `Union{Sheep,Wolf,Grass}`, pairs of `(Sheep,Sheep)` will
-  be excluded. To also exclude `(Wolf,Grass)` pairs, provide a scheduler that samples only
-  matchable parings.
+- `:types`: For mixed agent models only. Return every pair of agents within radius `r`
+  (similar to `:all`), with an additional constraint that excludes neighbors with the same
+  type. For example, a mixed agent model of `Union{Sheep,Wolf,Grass}`, pairs of 
+  `(Sheep,Sheep)` will be excluded. To also exclude `(Wolf,Grass)` pairs, provide a
+  scheduler that samples only matchable parings.
 """
 function interacting_pairs(model::ABM, r::Real, method; scheduler = model.scheduler)
     @assert method ∈ (:scheduler, :nearest, :all, :types)

--- a/src/core/continuous_space.jl
+++ b/src/core/continuous_space.jl
@@ -352,9 +352,14 @@ The argument `method` provides three pairing scenarios
   agent is paired to its nearest neighbor. Similar to `:nearest`, each agent can belong
   to only one pair. This functionality is useful e.g. when you want some agents to be
   paired "guaranteed", even if some other agents might be nearest to each other.
+- `:types`: For mixed models only. Return every pair of agents within radius `r` (similar
+  to `:all`), with an additional constraint that excludes neighbors with the same type.
+  For example, a mixed model of `Union{Sheep,Wolf,Grass}`, pairs of `(Sheep,Sheep)` will
+  be excluded. To also exclude `(Wolf,Grass)` pairs, provide a scheduler that samples only
+  matchable parings.
 """
 function interacting_pairs(model::ABM, r::Real, method; scheduler = model.scheduler)
-    @assert method ∈ (:scheduler, :nearest, :all)
+    @assert method ∈ (:scheduler, :nearest, :all, :types)
     pairs = Tuple{Int,Int}[]
     if method == :nearest
         true_pairs!(pairs, model, r)
@@ -362,6 +367,8 @@ function interacting_pairs(model::ABM, r::Real, method; scheduler = model.schedu
         scheduler_pairs!(pairs, model, r, scheduler)
     elseif method == :all
         all_pairs!(pairs, model, r)
+    elseif method == :types
+        type_pairs!(pairs, model, r, scheduler)
     end
     return PairIterator(pairs, model.agents)
 end
@@ -411,6 +418,21 @@ function true_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM, r::Real)
                 # Replace this pair, it is not the true neighbor
                 pairs[idx] = new_pair
                 distances[idx] = dist
+            end
+        end
+    end
+end
+
+function type_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM, r::Real, scheduler)
+    # We don't know ahead of time what types the scheduler will provide. Get a list.
+    available_types = unique(typeof(model[id]) for id in scheduler(model))
+    for id in scheduler(model)
+        for nid in space_neighbors(model[id], model, r)
+            neigbor_type = typeof(model[nid])
+            if neigbor_type ∈ available_types && neigbor_type !== typeof(model[id])
+                # Sort the pair to overcome any uniqueness issues
+                new_pair = isless(id, nid) ? (id, nid) : (nid, id)
+                new_pair ∉ pairs && push!(pairs, new_pair)
             end
         end
     end


### PR DESCRIPTION
Closes #252 by supporting agent pairing separated by agent type in mixed models.

Continuing discussions from #252, whilst this is essentially a simple extension, so too are most of the `interacting_pairs` implementations that are already extant. In addition this change improves our mixed model support, so in general this is a win IMO.