### PR TITLE
Update schelling.jl (Aggregate is deprecated)

### DIFF
--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -277,11 +277,12 @@ data, _ = paramscan(
 data[(end - 10):end, :]
 
 # We can combine all replicates with an aggregating function, such as mean, using
-# the `aggregate` function from the `DataFrames` package:
+# the `groupby` and `combine` functions from the `DataFrames` package:
 
-using DataFrames: aggregate, Not, select!
+using DataFrames: groupby, combine, Not, select!
 using Statistics: mean
-data_mean = aggregate(data, [:step, :min_to_be_happy, :numagents], mean)
+gd = groupby(data,[:step, :min_to_be_happy, :numagents])
+data_mean = combine(gd,[:happyperc_mood,:replicate].=>mean)
 select!(data_mean, Not(:replicate_mean))
 
 # Note that the second argument takes the column names on which to split the data,

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -282,7 +282,8 @@ data[(end - 10):end, :]
 using DataFrames: groupby, combine, Not, select!
 using Statistics: mean
 gd = groupby(data,[:step, :min_to_be_happy, :numagents])
-data_mean = combine(gd,[:happyperc_mood,:replicate].=>mean)
+data_mean = combine(gd,[:happyperc_mood,:replicate] .=> mean)
+
 select!(data_mean, Not(:replicate_mean))
 
 # Note that the second argument takes the column names on which to split the data,
@@ -290,4 +291,3 @@ select!(data_mean, Not(:replicate_mean))
 # the `:step` column and any parameter that changes among simulations. But it should
 # not include the `:replicate` column.
 # So in principle what we are doing here is simply averaging our result across the replicates.
-


### PR DESCRIPTION
Aggregate is deprecated in favor of 'split-apply-combine' in DataFrames.jl.
(see https://juliadata.github.io/DataFrames.jl/stable/man/split_apply_combine/)