### PR TITLE
Clarify NTuple type for GridSpace

### DIFF
--- a/src/core/discrete_space.jl
+++ b/src/core/discrete_space.jl
@@ -64,7 +64,8 @@ end
 Create a `GridSpace` instance that represents a grid of dimensionality `length(dims)`,
 with each dimension having the size of the corresponding entry of `dims`.
 Such grids are typically used in cellular-automata-like models.
-In this case, your agent type must have a `pos` field that is of type `NTuple{Int}`.
+In this case, your agent type must have a `pos` field that is of type `NTuple{N, Int}`,
+where `N` is the number of dimensions.
 
 The two keyword arguments denote if the grid should be periodic on its ends,
 and if the connections should be of type Moore or not (in the Moore case


### PR DESCRIPTION
NTuple{Int} is an incorrect type, so I changed the description to something more explanatory.