### PR TITLE
Deepcopy data when saving to DataFrame

### DIFF
--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -5,8 +5,8 @@ export run!, collect_agent_data!, collect_model_data!,
 ###################################################
 # Definition of the data collection API
 ###################################################
-get_data(a, s::Symbol) = getproperty(a, s)
-get_data(a, f::Function) = f(a)
+get_data(a, s::Symbol) = deepcopy(getproperty(a, s))
+get_data(a, f::Function) = deepcopy(f(a))
 
 should_we_collect(s, model, when::AbstractVector) = s ∈ when
 should_we_collect(s, model, when::Bool) = when


### PR DESCRIPTION
Fixes #280 

Whilst we enabled users to save arbitrary data structures into the dataframe, we didn't test that too well. This PR performs a `deepcopy` whenever we take data from the model and store it in the dataframe upon collection.