### PR TITLE
Cover run!(model, agent_step!, n) correctly.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Ali Vahdati", "George Datseris", "Tim DuBois"]
-version = "3.6"
+version = "3.6.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -68,10 +68,13 @@ By default both keywords are `nothing`, i.e. nothing is collected/aggregated.
 """
 function run! end
 
-run!(model::ABM, agent_step!, n::Int = 1; kwargs...) =
+run!(model::ABM, agent_step!::Function, n::Int = 1; kwargs...) =
 run!(model::ABM, agent_step!, dummystep, n; kwargs...)
 
-function run!(model::ABM, agent_step!, model_step!, n;
+run!(model::ABM, agent_step!::Function, n::Function; kwargs...) =
+run!(model::ABM, agent_step!, dummystep, n; kwargs...)
+
+function run!(model::ABM, agent_step!::Function, model_step!::Function, n;
   replicates::Int=0, parallel::Bool=false, kwargs...)
 
   r = replicates

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -68,13 +68,13 @@ By default both keywords are `nothing`, i.e. nothing is collected/aggregated.
 """
 function run! end
 
-run!(model::ABM, agent_step!::Function, n::Int = 1; kwargs...) =
+run!(model::ABM, agent_step!, n::Int = 1; kwargs...) =
 run!(model::ABM, agent_step!, dummystep, n; kwargs...)
 
-run!(model::ABM, agent_step!::Function, n::Function; kwargs...) =
+run!(model::ABM, agent_step!, n; kwargs...) =
 run!(model::ABM, agent_step!, dummystep, n; kwargs...)
 
-function run!(model::ABM, agent_step!::Function, model_step!::Function, n;
+function run!(model::ABM, agent_step!, model_step!, n;
   replicates::Int=0, parallel::Bool=false, kwargs...)
 
   r = replicates

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -130,6 +130,17 @@
         @test df[1, aggname(:weight, mean, ytest)] ≈ 0.67
     end
 
+    @testset "run! conditions without model_step!" begin
+        model = initialize()
+        agent_data, _ = run!(model, agent_step!, 2; adata = [(:weight, mean)])
+        @test size(agent_data) == (3, 2)
+
+        model = initialize()
+        until(model, step) = step == 5
+        agent_data, _ = run!(model, agent_step!, until; adata = [(:weight, mean)])
+        @test size(agent_data) == (6, 2)
+    end
+
     @testset "High-level API for Collections" begin
         # Extract data from the model every year for five years,
         # with the average `weight` of all agents every six months.


### PR DESCRIPTION
We have `run!(model, agent_step! [, model_step!], n; kwargs...)` in the docs, but #283 requires
`run!(model, agent_step!, dummystep, n; kwargs...)` when `n::Function`. This rectifies that omission.