### PR TITLE
Patch up models and examples

### DIFF
--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -2,9 +2,13 @@
 
 # ![](opinion.gif)
 
-# This is a simple model of how an opinion spreads through a community. Each individual has a number of opinions as a list of integers. They can change their opinion by changing the numbers in the list.
+# This is a simple model of how an opinion spreads through a community.
+# Each individual has a number of opinions as a list of integers.
+# They can change their opinion by changing the numbers in the list.
 
-# Agents can change their opinion at each step. They choose one of their neighbors randomly, and adopt one of the neighbor's opinion. They are more likely to adopt their neighbors opinion if the share more opinions with each other.
+# Agents can change their opinion at each step.
+# They choose one of their neighbors randomly, and adopt one of the neighbor's opinion.
+# They are more likely to adopt their neighbors opinion if the share more opinions with each other.
 
 using Agents
 using AgentsPlots
@@ -14,83 +18,105 @@ using Random
 # ### 1. Model creation
 
 mutable struct Citizen <: AbstractAgent
-	id::Int
-	pos::Tuple{Int, Int}
-	stabilized::Bool
-	opinion::Array{Int, 1}
-	prev_opinion::Array{Int, 1}
+    id::Int
+    pos::Tuple{Int,Int}
+    stabilized::Bool
+    opinion::Array{Int,1}
+    prev_opinion::Array{Int,1}
 end
 
-function create_model(;dims=(10, 10), nopinions=3, levels_per_opinion=4)
-	space = GridSpace(dims, periodic=true, moore=true)
-	properties = Dict(:nopinions=>nopinions) 
-	model = AgentBasedModel(Citizen, space, scheduler=random_activation, properties=properties)
-	for cell in 1:nv(model)
-		add_agent!(cell, model, false, rand(1:levels_per_opinion, nopinions), rand(1:levels_per_opinion, nopinions))
-	end
-	return model
+function create_model(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
+    space = GridSpace(dims, periodic = true, moore = true)
+    properties = Dict(:nopinions => nopinions)
+    model = AgentBasedModel(
+        Citizen,
+        space,
+        scheduler = random_activation,
+        properties = properties,
+    )
+    for cell in 1:nv(model)
+        add_agent!(
+            vertex2coord(cell,model),
+            model,
+            false,
+            rand(1:levels_per_opinion, nopinions),
+            rand(1:levels_per_opinion, nopinions),
+        )
+    end
+    return model
 end
 
 # ### 2. Stepping functions
 
 function adopt!(agent, model)
-	neighbor = rand(space_neighbors(agent, model))
-	matches = model[neighbor].opinion .== agent.opinion
-	nmatches = count(matches)
-	if nmatches < model.nopinions && rand() < nmatches/model.nopinions
-		switchId = rand(findall(x-> x==false, matches))
-		agent.opinion[switchId] = model[neighbor].opinion[switchId]
-	end
+    neighbor = rand(space_neighbors(agent, model))
+    matches = model[neighbor].opinion .== agent.opinion
+    nmatches = count(matches)
+    if nmatches < model.nopinions && rand() < nmatches / model.nopinions
+        switchId = rand(findall(x -> x == false, matches))
+        agent.opinion[switchId] = model[neighbor].opinion[switchId]
+    end
 end
 
 function update_prev_opinion!(agent, model)
-	for i in 1:model.nopinions
-		agent.prev_opinion[i] = agent.opinion[i]
-	end
+    for i in 1:(model.nopinions)
+        agent.prev_opinion[i] = agent.opinion[i]
+    end
 end
 
 function is_stabilized!(agent, model)
-	if agent.prev_opinion == agent.opinion
-		agent.stabilized = true
-	else
-		agent.stabilized = false
-	end
+    if agent.prev_opinion == agent.opinion
+        agent.stabilized = true
+    else
+        agent.stabilized = false
+    end
 end
 
 function agent_step!(agent, model)
-	update_prev_opinion!(agent, model)
-	adopt!(agent, model)
-	is_stabilized!(agent, model)
+    update_prev_opinion!(agent, model)
+    adopt!(agent, model)
+    is_stabilized!(agent, model)
 end
 
 # ## Running the model
 
-levels_per_opinion=4
-model = create_model(nopinions=3,levels_per_opinion=levels_per_opinion)
+levels_per_opinion = 4
+model = create_model(nopinions = 3, levels_per_opinion = levels_per_opinion)
 
 "run the model until all agents stabilize"
-rununtil(model, s) = count(getproperty.(values(model.agents), :stabilized)) == prod(model.space.dimensions)
+rununtil(model, s) =
+    count(getproperty.(values(model.agents), :stabilized)) == prod(model.space.dimensions)
 
-agentdata, _ = run!(model, agent_step!, dummystep, rununtil, adata=[(:stabilized, count)])
+agentdata, _ = run!(model, agent_step!, dummystep, rununtil, adata = [(:stabilized, count)])
 
 # ## Plotting
 
-# The plot shows the number of stable agents, that is, number of agents whose opinions don't change from one step to the next. Note that the number of stable agents can fluctuate before the final convergence.
+# The plot shows the number of stable agents, that is, number of agents whose opinions
+# don't change from one step to the next. Note that the number of stable agents can 
+# fluctuate before the final convergence.
 
-plot(1:size(agentdata, 1), agentdata.count_stabilized, legend=false, xlabel="generation", ylabel="# of stabilized agents")
+plot(
+    1:size(agentdata, 1),
+    agentdata.count_stabilized,
+    legend = false,
+    xlabel = "generation",
+    ylabel = "# of stabilized agents",
+)
 
 # ### Animation
 
-# Here is an animation that shows change of agent opinions over time. The first three opinions of an agent determines its color in RGB.
+# Here is an animation that shows change of agent opinions over time.
+# The first three opinions of an agent determines its color in RGB.
 levels_per_opinion = 3
 ac(agent) = RGB((agent.opinion[1:3] ./ levels_per_opinion)...)
-model = create_model(nopinions=3, levels_per_opinion=levels_per_opinion)
+model = create_model(nopinions = 3, levels_per_opinion = levels_per_opinion)
 anim = @animate for sp in 1:500
-  step!(model, agent_step!)
-  p = plotabm(model, ac=ac, as=12, am=:square)
-  title!(p, "Step $(sp)")
-  if rununtil(model, 1)
-    break
-  end
+    step!(model, agent_step!)
+    p = plotabm(model, ac = ac, as = 12, am = :square)
+    title!(p, "Step $(sp)")
+    if rununtil(model, 1)
+        break
+    end
 end
 gif(anim, "opinion.gif")
+

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -98,7 +98,7 @@ function initialize_model(;
         fully_grown = rand(Bool)
         countdown = fully_grown ? regrowth_time : rand(1:regrowth_time) - 1
         grass = Grass(id, (0, 0), fully_grown, regrowth_time, countdown)
-        add_agent!(grass, n, model)
+        add_agent!(grass, vertex2coord(n,model), model)
     end
     return model
 end

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -160,7 +160,7 @@ nothing # hide
 # Sheep and wolves move to a random adjacent cell with the `move!` function.
 function move!(agent, model)
     neighbors = node_neighbors(agent, model)
-    cell = rand(neighbors)
+    cell = rand(collect(neighbors))
     move_agent!(agent, cell, model)
 end
 nothing # hide

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -116,7 +116,7 @@ end
 #######################################################################################
 # %% Model accessing api
 #######################################################################################
-export random_agent, nagents, allagents, allids
+export random_agent, nagents, allagents, allids, nextid
 
 """
     model[id]

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -17,5 +17,6 @@ include("predator_prey.jl")
 include("growing_bacteria.jl")
 include("game_of_life.jl")
 include("opinion.jl")
+include("sugarscape.jl")
 
 end

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -24,7 +24,7 @@ function opinion(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
     )
     for cell in 1:nv(model)
         add_agent!(
-            cell,
+            vertex2coord(cell,model),
             model,
             false,
             rand(1:levels_per_opinion, nopinions),

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -77,7 +77,7 @@ function predator_prey(;
         fully_grown = rand(Bool)
         countdown = fully_grown ? regrowth_time : rand(1:regrowth_time) - 1
         grass = Grass(id, (0, 0), fully_grown, regrowth_time, countdown)
-        add_agent!(grass, n, model)
+        add_agent!(grass, vertex2coord(n, model), model)
     end
     return model, predator_prey_agent_step!, dummystep
 end

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -125,7 +125,7 @@ end
 
 function move!(agent, model)
     neighbors = node_neighbors(agent, model)
-    cell = rand(neighbors)
+    cell = rand(collect(neighbors))
     move_agent!(agent, cell, model)
 end
 

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -1,124 +1,153 @@
-
-using Agents
-using AgentsPlots
-using Random
-
 mutable struct SugarSeeker <: AbstractAgent
-	id::Int
-	pos::Tuple{Int, Int}
-	vision::Int
-	metabolic_rate::Int
-	age::Int
-	max_age::Int
-	wealth::Int
+    id::Int
+    pos::Tuple{Int,Int}
+    vision::Int
+    metabolic_rate::Int
+    age::Int
+    max_age::Int
+    wealth::Int
 end
 
 function distances(pos, sugar_peaks, max_sugar)
-	all_dists = Array{Int, 1}(undef, length(sugar_peaks))
-	for (ind, peak) in enumerate(sugar_peaks)
-		d = round(Int, sqrt(sum((pos .- peak).^2)))
-		all_dists[ind] = d
-	end
-	return minimum(all_dists)
+    all_dists = Array{Int,1}(undef, length(sugar_peaks))
+    for (ind, peak) in enumerate(sugar_peaks)
+        d = round(Int, sqrt(sum((pos .- peak) .^ 2)))
+        all_dists[ind] = d
+    end
+    return minimum(all_dists)
 end
 
-function sugar_caps(dims, sugar_peaks, max_sugar, dia=4)
-	sugar_capacities = zeros(Int, dims)
-	for i in 1:dims[1], j in 1:dims[2]
-		sugar_capacities[i, j] = distances((i,j), sugar_peaks, max_sugar)
-	end
-	for i in 1:dims[1]
-		for j in 1:dims[2]
-			sugar_capacities[i, j] = max(0, max_sugar - (sugar_capacities[i, j] ÷ dia))
-		end
-	end
-	return sugar_capacities
+function sugar_caps(dims, sugar_peaks, max_sugar, dia = 4)
+    sugar_capacities = zeros(Int, dims)
+    for i in 1:dims[1], j in 1:dims[2]
+        sugar_capacities[i, j] = distances((i, j), sugar_peaks, max_sugar)
+    end
+    for i in 1:dims[1]
+        for j in 1:dims[2]
+            sugar_capacities[i, j] = max(0, max_sugar - (sugar_capacities[i, j] ÷ dia))
+        end
+    end
+    return sugar_capacities
 end
 
-"Start a sugarscape simulation"
-function sugarscape(;dims=(50,50), sugar_peaks=((10, 40), (40, 10)), growth_rate=1, N=250, w0_dist=(5, 25), metabolic_rate_dist=(1,4), vision_dist=(1,6), 	max_age_dist=(60, 100), max_sugar = 4)
-	sugar_capacities = sugar_caps(dims, sugar_peaks, max_sugar, 6)
-	sugar_values = deepcopy(sugar_capacities)
-	space = GridSpace(dims, periodic=true, moore=true)
-	properties = Dict(
-		:growth_rate => growth_rate,
-		:N => N,
-		:w0_dist => w0_dist,
-		:metabolic_rate_dist => metabolic_rate_dist,
-		:vision_dist => vision_dist,
-		:max_age_dist => max_age_dist,
-		:sugar_values => sugar_values,
-		:sugar_capacities => sugar_capacities
-		)
-	model = AgentBasedModel(SugarSeeker, space, scheduler=random_activation,
-		properties=properties)
-	for ag in 1:N
-		add_agent_single!(model, 
-			rand(vision_dist[1]:vision_dist[2]),
-			rand(metabolic_rate_dist[1]:metabolic_rate_dist[2]),
-			0,
-			rand(max_age_dist[1]:max_age_dist[2]),
-			rand(w0_dist[1]:w0_dist[2]),
-		)
-	end
-	return model, sugarscape_agent_step!, sugarscape_env!
+"""
+``` julia
+sugarscape(;
+    dims = (50, 50),
+    sugar_peaks = ((10, 40), (40, 10)),
+    growth_rate = 1,
+    N = 250,
+    w0_dist = (5, 25),
+    metabolic_rate_dist = (1, 4),
+    vision_dist = (1, 6),
+    max_age_dist = (60, 100),
+    max_sugar = 4,
+)
+```
+Same as in [Sugarscape](@ref).
+"""
+function sugarscape(;
+    dims = (50, 50),
+    sugar_peaks = ((10, 40), (40, 10)),
+    growth_rate = 1,
+    N = 250,
+    w0_dist = (5, 25),
+    metabolic_rate_dist = (1, 4),
+    vision_dist = (1, 6),
+    max_age_dist = (60, 100),
+    max_sugar = 4,
+)
+    sugar_capacities = sugar_caps(dims, sugar_peaks, max_sugar, 6)
+    sugar_values = deepcopy(sugar_capacities)
+    space = GridSpace(dims, periodic = true, moore = true)
+    properties = Dict(
+        :growth_rate => growth_rate,
+        :N => N,
+        :w0_dist => w0_dist,
+        :metabolic_rate_dist => metabolic_rate_dist,
+        :vision_dist => vision_dist,
+        :max_age_dist => max_age_dist,
+        :sugar_values => sugar_values,
+        :sugar_capacities => sugar_capacities,
+    )
+    model = AgentBasedModel(
+        SugarSeeker,
+        space,
+        scheduler = random_activation,
+        properties = properties,
+    )
+    for _ in 1:N
+        add_agent_single!(
+            model,
+            rand(vision_dist[1]:vision_dist[2]),
+            rand(metabolic_rate_dist[1]:metabolic_rate_dist[2]),
+            0,
+            rand(max_age_dist[1]:max_age_dist[2]),
+            rand(w0_dist[1]:w0_dist[2]),
+        )
+    end
+    return model, sugarscape_agent_step!, sugarscape_env!
 end
 
 function sugarscape_env!(model)
-	## At each cell, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
-	togrow = findall(x -> model.sugar_values[x] < model.sugar_capacities[x], 1:prod(model.space.dimensions))
-	model.sugar_values[togrow] .+= model.growth_rate
+    # At each cell, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
+    togrow = findall(
+        x -> model.sugar_values[x] < model.sugar_capacities[x],
+        1:prod(model.space.dimensions),
+    )
+    model.sugar_values[togrow] .+= model.growth_rate
 end
 
 function movement!(agent, model)
-	posvertex = coord2vertex(agent.pos, model)
-	newsite = posvertex
-	## find all unoccupied cells within vision
-	neighbors = node_neighbors(coord2vertex(agent.pos, model), model, agent.vision)
-	empty_nodes = [i for i in neighbors if isempty(i, model)]
-	if length(empty_nodes) > 0
-		## identify the one(s) with greatest amount of sugar
-		maxsugar = maximum(model.sugar_values[empty_nodes])
-		if maxsugar > 0
-		sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_nodes])
-		sugary_sites = empty_nodes[sugary_sites_inds]
-		## select the nearest one (randomly if more than one)
-		for dia in 1:agent.vision
-			nn = node_neighbors(posvertex, model, dia)
-			suitable = intersect(nn, sugary_sites)
-			if length(suitable) > 0
-				newsite = rand(suitable)
-				break
-			end
-		end
-		## move there and collect all the sugar in it
-		newsite != posvertex && move_agent!(agent, newsite, model)
-		end
-	end
-	## update wealth (collected - consumed)
-	agent.wealth += (model.sugar_values[newsite] - agent.metabolic_rate)
-	model.sugar_values[newsite] = 0
-	## age
-	agent.age += 1
+    posvertex = coord2vertex(agent.pos, model)
+    newsite = posvertex
+    # find all unoccupied cells within vision
+    neighbors = node_neighbors(coord2vertex(agent.pos, model), model, agent.vision)
+    empty_nodes = [i for i in neighbors if isempty(i, model)]
+    if length(empty_nodes) > 0
+        # identify the one(s) with greatest amount of sugar
+        maxsugar = maximum(model.sugar_values[empty_nodes])
+        if maxsugar > 0
+            sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_nodes])
+            sugary_sites = empty_nodes[sugary_sites_inds]
+            # select the nearest one (randomly if more than one)
+            for dia in 1:(agent.vision)
+                nn = node_neighbors(posvertex, model, dia)
+                suitable = intersect(nn, sugary_sites)
+                if length(suitable) > 0
+                    newsite = rand(suitable)
+                    break
+                end
+            end
+            # move there and collect all the sugar in it
+            newsite != posvertex && move_agent!(agent, newsite, model)
+        end
+    end
+    # update wealth (collected - consumed)
+    agent.wealth += (model.sugar_values[newsite] - agent.metabolic_rate)
+    model.sugar_values[newsite] = 0
+    agent.age += 1
 end
 
 function replacement!(agent, model)
-	## If the agent's sugar wealth become zero or less, it dies
-	if agent.wealth <= 0 || agent.age >= agent.max_age
-		kill_agent!(agent, model)
-		## Whenever an agent dies, a young one is added to a random pos.
-		## New agent has random attributes
-		add_agent_single!(model, 
-			rand(model.vision_dist[1]:model.vision_dist[2]),
-			rand(model.metabolic_rate_dist[1]:model.metabolic_rate_dist[2]),
-			0,
-			rand(model.max_age_dist[1]:model.max_age_dist[2]),
-			rand(model.w0_dist[1]:model.w0_dist[2]),
-		)
-	end
+    # If the agent's sugar wealth become zero or less, it dies
+    if agent.wealth <= 0 || agent.age >= agent.max_age
+        kill_agent!(agent, model)
+        # Whenever an agent dies, a young one is added to a random pos.
+        # New agent has random attributes
+        add_agent_single!(
+            model,
+            rand(model.vision_dist[1]:model.vision_dist[2]),
+            rand(model.metabolic_rate_dist[1]:model.metabolic_rate_dist[2]),
+            0,
+            rand(model.max_age_dist[1]:model.max_age_dist[2]),
+            rand(model.w0_dist[1]:model.w0_dist[2]),
+        )
+    end
 end
 
 function sugarscape_agent_step!(agent, model)
-	movement!(agent, model)
-	replacement!(agent, model)
+    movement!(agent, model)
+    replacement!(agent, model)
 end
+

--- a/src/models/wealth_distribution.jl
+++ b/src/models/wealth_distribution.jl
@@ -1,4 +1,4 @@
-mutable struct WealthAgent <: AbstractAgent
+mutable struct WealthInSpace <: AbstractAgent
     id::Int
     pos::NTuple{2,Int}
     wealth::Int

--- a/src/spaces/discrete_space.jl
+++ b/src/spaces/discrete_space.jl
@@ -382,7 +382,8 @@ function add_agent_single!(
     ) where {A<:AbstractAgent}
     empty_cells = find_empty_nodes(model)
     if length(empty_cells) > 0
-        add_agent!(rand(empty_cells), model, properties...; kwargs...)
+        pos = correct_pos_type(rand(empty_cells), model)
+        add_agent!(pos, model, properties...; kwargs...)
     end
 end
 

--- a/src/spaces/discrete_space.jl
+++ b/src/spaces/discrete_space.jl
@@ -550,12 +550,6 @@ to `:out`. For undirected graphs, all options are equivalent to `:out`.
 - `:in` returns incoming vertex neighbors.
 - `:out` returns outgoing vertex neighbors.
 """
-node_neighbors(
-    agent::AbstractAgent,
-    model::ABM{A,<:DiscreteSpace},
-    args...;
-    kwargs...,
-) where {A} = node_neighbors(agent.pos, model, args...; kwargs...)
 function node_neighbors(node_number::Integer, model::ABM{A, <: DiscreteSpace}; neighbor_type::Symbol=:default) where {A}
     @assert neighbor_type ∈ (:default, :all, :in, :out)
     neighborfn =


### PR DESCRIPTION
Recent changes have altered some of the mechanisms we use, that killed off a lot of the functionality in the Models library and broke some examples. This PR fixes that, alongside a few other fixes, like the pre-emptive merge of sugarscape and an omission in the wealth model.