### PR TITLE
Graph neighbor improvements (Discussion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `GraphSpace` and `GridSpace` are completely separated entities, reducing complexity of source code dramatically, and removing unnecessary functions like `vertex2coord`.
 - Many things have been renamed to have clearer name that indicates their meaning
   (see Breaking changes).
+- Performance increase of finding neighbors in GraphSpace with r > 1.
 
 ## Breaking changes
 All changes in this section (besides changes to default values) are deprecated and
@@ -14,6 +15,7 @@ therefore are not "truly breaking".
 - Keyword `moore` of `GridSpace` doesn't exist anymore. Use `metric` instead.
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allows to have performance updates in the future that may change internals but not lead to breaking changes.
+- `vertex2coord, coord2vertex` do not exist anymore because they are unecessary in the new design.
 
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -61,7 +61,7 @@ remove_agent_from_space!(agent, model) = notimplemented(model)
 """
     space_neighbors(position, model::ABM, r=1; kwargs...) → ids
 
-Return an iterator of the ids of the agents within "radius" `r` of the given `position`
+Return an iterable of the ids of the agents within "radius" `r` of the given `position`
 (which must match type with the spatial structure of the `model`).
 
 What the "radius" means depends on the space type:
@@ -86,7 +86,7 @@ space_neighbors(position, model, r=1) = notimplemented(model)
 """
     node_neighbors(position, model::ABM, r=1; kwargs...) → positions
 
-Return an iterator of all positions within "radius" `r` of the given `position`
+Return an iterable of all positions within "radius" `r` of the given `position`
 (which excludes given `position`).
 The `position` must match type with the spatial structure of the `model`).
 
@@ -251,7 +251,7 @@ end
 """
     space_neighbors(agent::AbstractAgent, model::ABM, r=1)
 
-Same as `space_neighbors(agent.pos, model, r)` but the iterator *excludes* the given
+Same as `space_neighbors(agent.pos, model, r)` but the iterable *excludes* the given
 `agent`'s id.
 """
 function space_neighbors(agent::A, model::ABM{A}, args...; kwargs...) where {A<:AbstractAgent}

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -91,11 +91,7 @@ nodes(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
 #######################################################################################
 function space_neighbors(pos::Int, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A}
     nn = node_neighbors(pos, model, args...; kwargs...)
-    # TODO: Use flatten here or something for performance?
-    # `model.space.s[nn]...` allocates, because it creates a new array!
-    # Also `vcat` allocates a second time
-    # We include the current node in the search since we are searching over space
-    vcat(model.space.s[pos], model.space.s[nn]...)
+    Iterators.flatten(model.space.s[i] for i in Iterators.flatten((pos,nn)))
 end
 
 function node_neighbors(
@@ -113,7 +109,7 @@ function node_neighbors(
     else
         LightGraphs.all_neighbors
     end
-    neighborfn(model.space.graph, node_number)
+    Base.Generator(Int, neighborfn(model.space.graph, node_number))
 end
 
 function node_neighbors(
@@ -123,25 +119,9 @@ function node_neighbors(
     kwargs...,
 ) where {A}
     neighbor_nodes = Set(node_neighbors(node_number, model; kwargs...))
-    included_nodes = Set()
-    for rad in 2:radius
-        templist = Vector{Int}()
-        for nn in neighbor_nodes
-            if !in(nn, included_nodes)
-                newns = node_neighbors(nn, model; kwargs...)
-                for newn in newns
-                    push!(templist, newn)
-                end
-            end
-        end
-        for tt in templist
-            push!(neighbor_nodes, tt)
-        end
+    for _ in 2:radius
+        newnns = (node_neighbors(nn, model; kwargs...) for nn in neighbor_nodes)
+        union!(neighbor_nodes, newnns...)
     end
-    nlist = collect(neighbor_nodes)
-    j = findfirst(a -> a == node_number, nlist)
-    if j != nothing
-        deleteat!(nlist, j)
-    end
-    return nlist
+    Iterators.filter(i->i!=node_number, Base.Generator(Int, neighbor_nodes))
 end


### PR DESCRIPTION
Closes #312 

I've done a number of iterations on this. Whilst it's not the best performing in every situation, it aligns with our output requirements for these functions (iterators, not vectors) and provides the best all round numbers that I can find.

The big discrepancy is that the LightGraphs implementation that returns a vector must be wrapped in an iterator, and that increases the time spent here. Any ideas how to mitigate this? (we could state that graph space returns vectors and grid space iterators, but that's not a clean solution).

(tests have not been updated, that will come once we get an agreed upon implementation)

```julia
model = ABM(Agent5, GraphSpace(path_graph(500)))
for _ in 1:2000 add_agent!(model, rand()) end
a = random_agent(model)
pos = a.pos
```

Baseline
```julia
@btime node_neighbors($pos, $model) # vector
  19.265 ns (0 allocations: 0 bytes)

@btime node_neighbors($pos, $model, 20) # vector
  126.809 μs (2110 allocations: 85.63 KiB)

@btime space_neighbors($pos, $model) # vector
  169.447 ns (3 allocations: 304 bytes)
  
@btime space_neighbors($pos, $model, 20) # vector
  131.059 μs (2113 allocations: 87.36 KiB)

@btime space_neighbors($a, $model) #iter
  317.117 ns (5 allocations: 352 bytes)
  
@btime space_neighbors($a, $model, 20) #iter
  131.335 μs (2115 allocations: 87.41 KiB)
```

Current
```julia
@btime node_neighbors($pos, $model) #iter 
  84.422 ns (1 allocation: 32 bytes)

@btime node_neighbors($pos, $model, 20) #iter 
  102.718 μs (1270 allocations: 44.53 KiB)

@btime space_neighbors($pos, $model) #iter 
  286.460 ns (6 allocations: 272 bytes)

@btime space_neighbors($pos, $model, 20) #iter 
  103.476 μs (1270 allocations: 44.53 KiB)

@btime space_neighbors($a, $model) #iter 
  458.462 ns (9 allocations: 432 bytes)

@btime space_neighbors($a, $model, 20) #iter 
  103.711 μs (1270 allocations: 44.53 KiB)
```

George: an implementation with vectors:
```julia
function node_neighbors_vec(    
    node_number::Integer,    
    model::ABM{A,<:GraphSpace},    
    radius::Integer;    
    kwargs...,    
) where {A}    
    output = copy(collect(node_neighbors(pos, model; kwargs...)))
    for _ in 2:radius 
        newnns = (collect(node_neighbors(nn, model; kwargs...)) for nn in output)
        append!(output, reduce(vcat, newnns))
        unique!(output)
    end
    Iterators.filter(i->i!=node_number, (n for n in output))    
end

@btime node_neighbors_vec($pos, $model, 20)  
  112.217 μs (1388 allocations: 195.80 KiB)
```

We're forced to copy and collect a lot here. One possible improvement could be to take most of the meat out of the `r=1` function that calls `neighborfn` and put all of that behind a function guard, where the only purpose of node_neighbors is to wrap the array in an iterator. This new function can be called internally from the node_neighbors_vec function, which drops the need to `collect` so many times. The `copy` will still be needed though I think.

Any suggestions anywhere?

