### PR TITLE
API Simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ therefore are not "truly breaking".
 - Keyword `moore` of `GridSpace` doesn't exist anymore. Use `metric` instead.
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allows to have performance updates in the future that may change internals but not lead to breaking changes.
+- API simplification and renaming.
+  - `space_neighbors` -> `nearby_agents`
 
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ therefore are not "truly breaking".
 - Keyword `moore` of `GridSpace` doesn't exist anymore. Use `metric` instead.
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allow performance updates in the future that may change internals but not lead to breaking changes.
-- `vertex2coord, coord2vertex` do not exist anymore because they are unecessary in the new design.
+- `vertex2coord, coord2vertex` do not exist anymore because they are unnecessary in the new design.
 - API simplification and renaming.
-  - `space_neighbors` -> `nearby_agents`
+  - `space_neighbors` -> `nearby_ids`
   - `node_neighbors` -> `nearby_positions`
   - `get_node_contents` -> `agents_in_pos`
   - `pick_empty` -> `random_empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ therefore are not "truly breaking".
   - `pick_empty` -> `random_empty`
   - `find_empty_nodes` -> `empty_positions`
   - `has_empty_nodes` -> `has_empty_positions`
+  - `nodes` -> `positions`
 
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ therefore are not "truly breaking".
 - API simplification and renaming.
   - `space_neighbors` -> `nearby_agents`
   - `node_neighbors` -> `nearby_positions`
+  - `get_node_contents` -> `agents_in_pos`
 
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Many things have been renamed to have clearer name that indicates their meaning
   (see Breaking changes).
 - Performance increase of finding neighbors in GraphSpace with r > 1.
+- New wrapping function `nearby_agents` that returns an iterable of neigboring agents.
 
 ## Breaking changes
 All changes in this section (besides changes to default values) are deprecated and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ therefore are not "truly breaking".
 - API simplification and renaming.
   - `space_neighbors` -> `nearby_ids`
   - `node_neighbors` -> `nearby_positions`
-  - `get_node_contents` -> `agents_in_pos`
+  - `get_node_contents` -> `ids_in_position`
+  - `get_node_agents` -> `agents_in_position`
   - `pick_empty` -> `random_empty`
   - `find_empty_nodes` -> `empty_positions`
   - `has_empty_nodes` -> `has_empty_positions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Many things have been renamed to have clearer name that indicates their meaning
   (see Breaking changes).
 - Performance increase of finding neighbors in GraphSpace with r > 1.
-- New wrapping function `nearby_agents` that returns an iterable of neigboring agents.
+- New wrapping function `nearby_agents` that returns an iterable of neighboring agents.
 
 ## Breaking changes
 All changes in this section (besides changes to default values) are deprecated and
@@ -17,7 +17,7 @@ therefore are not "truly breaking".
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allow performance updates in the future that may change internals but not lead to breaking changes.
 - `vertex2coord, coord2vertex` do not exist anymore because they are unnecessary in the new design.
-- API simplification and renaming.
+- API simplification and renaming:
   - `space_neighbors` -> `nearby_ids`
   - `node_neighbors` -> `nearby_positions`
   - `get_node_contents` -> `ids_in_position`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## New features:
 - `GridSpace` has been re-written from scratch! It now supports **any dimensionality** and is about a **full order of magnitude faster** than the previous version!
 - Agents.jl now defines a clear API for new spaces types. To create a fundamentally different type of space you have to define the space structure and extend only 5 methods.
-- `GraphSpace` and `GridSpace` are completely separated entities, reducing complexity of source code dramatically, and removing unnecessary functions like `vertex2coord`.
+- `GraphSpace` and `GridSpace` are completely separated entities, reducing complexity of source code dramatically, and removing unnecessary functions like `vertex2coord` and `coord2vertex`.
 - Many things have been renamed to have clearer name that indicates their meaning
   (see Breaking changes).
 
@@ -13,7 +13,7 @@ therefore are not "truly breaking".
 
 - Keyword `moore` of `GridSpace` doesn't exist anymore. Use `metric` instead.
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
-- Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allows to have performance updates in the future that may change internals but not lead to breaking changes.
+- Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allow performance updates in the future that may change internals but not lead to breaking changes.
 - API simplification and renaming.
   - `space_neighbors` -> `nearby_agents`
   - `node_neighbors` -> `nearby_positions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ therefore are not "truly breaking".
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allows to have performance updates in the future that may change internals but not lead to breaking changes.
 - API simplification and renaming.
   - `space_neighbors` -> `nearby_agents`
+  - `node_neighbors` -> `nearby_positions`
 
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ therefore are not "truly breaking".
   - `node_neighbors` -> `nearby_positions`
   - `get_node_contents` -> `agents_in_pos`
   - `pick_empty` -> `random_empty`
+  - `find_empty_nodes` -> `empty_positions`
+  - `has_empty_nodes` -> `has_empty_positions`
 
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ therefore are not "truly breaking".
   - `space_neighbors` -> `nearby_agents`
   - `node_neighbors` -> `nearby_positions`
   - `get_node_contents` -> `agents_in_pos`
+  - `pick_empty` -> `random_empty`
 
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -167,7 +167,7 @@ SUITE["graph"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($p
 SUITE["graph"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $graph_model)
 
 SUITE["graph"]["position"]["contents"] = @benchmarkable agents_in_pos($pos, $graph_model)
-SUITE["graph"]["position"]["nodes"] = @benchmarkable nodes($graph_model)
+SUITE["graph"]["position"]["positions"] = @benchmarkable positions($graph_model)
 
 ##### API -> GRID ####
 
@@ -243,7 +243,7 @@ SUITE["grid"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($a,
 SUITE["grid"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $grid_model)
 
 SUITE["grid"]["position"]["contents"] = @benchmarkable agents_in_pos($pos, $grid_model)
-SUITE["graph"]["position"]["nodes"] = @benchmarkable nodes($graph_model)
+SUITE["graph"]["position"]["positions"] = @benchmarkable positions($graph_model)
 
 #### API -> CONTINUOUS ####
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -104,7 +104,7 @@ end
 
 function iterate_over_neighbors(a, model, r)
     s = 0
-    for x in nearby_agents(a, model, r)
+    for x in nearby_ids(a, model, r)
         s += x
     end
     return s
@@ -152,17 +152,17 @@ SUITE["graph"]["move"]["single"] = @benchmarkable move_agent_single!($a, $graph_
 
 # We use a digraph, so all agents are neighbors of each other
 SUITE["graph"]["neighbors"]["space_pos"] =
-    @benchmarkable nearby_agents($pos, $graph_model) setup =
-        (nearby_agents($pos, $graph_model))
+    @benchmarkable nearby_ids($pos, $graph_model) setup =
+        (nearby_ids($pos, $graph_model))
 SUITE["graph"]["neighbors"]["space_agent"] =
-    @benchmarkable nearby_agents($a, $graph_model) setup =
-        (nearby_agents($a, $graph_model))
+    @benchmarkable nearby_ids($a, $graph_model) setup =
+        (nearby_ids($a, $graph_model))
 SUITE["graph"]["neighbors"]["space_pos_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $graph_model, 1) setup =
-        (nearby_agents($pos, $graph_model))
+        (nearby_ids($pos, $graph_model))
 SUITE["graph"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $graph_model, 1) setup =
-        (nearby_agents($a, $graph_model))
+        (nearby_ids($a, $graph_model))
 SUITE["graph"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($pos, $graph_model)
 SUITE["graph"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $graph_model)
 
@@ -225,19 +225,19 @@ SUITE["grid"]["move"]["pos"] = @benchmarkable move_agent!($a, (14, 35), $grid_mo
 SUITE["grid"]["move"]["single"] = @benchmarkable move_agent_single!($a, $grid_model)
 
 SUITE["grid"]["neighbors"]["space_pos"] =
-    @benchmarkable nearby_agents($pos, $grid_model, 5) setup =
-        (nearby_agents($pos, $grid_model, 5))
+    @benchmarkable nearby_ids($pos, $grid_model, 5) setup =
+        (nearby_ids($pos, $grid_model, 5))
 SUITE["grid"]["neighbors"]["space_agent"] =
-    @benchmarkable nearby_agents($a, $grid_model, 5) setup =
-        (nearby_agents($a, $grid_model, 5))
+    @benchmarkable nearby_ids($a, $grid_model, 5) setup =
+        (nearby_ids($a, $grid_model, 5))
 
 SUITE["grid"]["neighbors"]["space_pos_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $grid_model, 30) setup =
-        (nearby_agents($pos, $grid_model, 30))
+        (nearby_ids($pos, $grid_model, 30))
 
 SUITE["grid"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $grid_model, 30) setup =
-        (nearby_agents($a, $grid_model, 30))
+        (nearby_ids($a, $grid_model, 30))
 
 SUITE["grid"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($a, $grid_model)
 SUITE["grid"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $grid_model)
@@ -311,19 +311,19 @@ SUITE["continuous"]["move"]["vel"] =
     @benchmarkable move_agent!($a, $continuous_model, (1.2, 0.0, 0.7))
 
 SUITE["continuous"]["neighbors"]["space_pos"] =
-    @benchmarkable nearby_agents($pos, $continuous_model, 5) setup =
-        (nearby_agents($pos, $continuous_model, 5))
+    @benchmarkable nearby_ids($pos, $continuous_model, 5) setup =
+        (nearby_ids($pos, $continuous_model, 5))
 
 SUITE["continuous"]["neighbors"]["space_agent"] =
-    @benchmarkable nearby_agents($a, $continuous_model, 5) setup =
-        (nearby_agents($a, $continuous_model, 5))
+    @benchmarkable nearby_ids($a, $continuous_model, 5) setup =
+        (nearby_ids($a, $continuous_model, 5))
 
 SUITE["continuous"]["neighbors"]["space_pos_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $continuous_model, 10) setup =
-        (nearby_agents($pos, $continuous_model, 10))
+        (nearby_ids($pos, $continuous_model, 10))
 SUITE["continuous"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $continuous_model, 10) setup =
-        (nearby_agents($a, $continuous_model, 10))
+        (nearby_ids($a, $continuous_model, 10))
 SUITE["continuous"]["neighbors"]["nearest"] =
     @benchmarkable nearest_neighbor($a, $continuous_model, 5)
 SUITE["continuous"]["neighbors"]["interacting"] =

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -166,7 +166,7 @@ SUITE["graph"]["neighbors"]["space_agent_iterate"] =
 SUITE["graph"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($pos, $graph_model)
 SUITE["graph"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $graph_model)
 
-SUITE["graph"]["position"]["contents"] = @benchmarkable get_node_contents($pos, $graph_model)
+SUITE["graph"]["position"]["contents"] = @benchmarkable agents_in_pos($pos, $graph_model)
 SUITE["graph"]["position"]["nodes"] = @benchmarkable nodes($graph_model)
 
 ##### API -> GRID ####
@@ -242,7 +242,7 @@ SUITE["grid"]["neighbors"]["space_agent_iterate"] =
 SUITE["grid"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($a, $grid_model)
 SUITE["grid"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $grid_model)
 
-SUITE["grid"]["position"]["contents"] = @benchmarkable get_node_contents($pos, $grid_model)
+SUITE["grid"]["position"]["contents"] = @benchmarkable agents_in_pos($pos, $grid_model)
 SUITE["graph"]["position"]["nodes"] = @benchmarkable nodes($graph_model)
 
 #### API -> CONTINUOUS ####

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -82,8 +82,8 @@ for space in ["graph", "grid", "continuous"]
             "space_agent",
             "space_pos_iterate",
             "space_agent_iterate",
-            "node_pos",
-            "node_agent",
+            "position_pos",
+            "position_agent",
         ])
     end
     SUITE[space]["collect"] = BenchmarkGroup(["init_agent", "store_agent"])
@@ -92,8 +92,8 @@ end
 push!(SUITE["grid"]["add_union"].tags, "agent_fill")
 push!(SUITE["grid"]["add"].tags, "create_fill")
 for space in ["grid", "graph"]
-    push!(SUITE[space].tags, "node")
-    SUITE[space]["node"] = BenchmarkGroup(["contents", "agents"])
+    push!(SUITE[space].tags, "position")
+    SUITE[space]["position"] = BenchmarkGroup(["contents", "agents"])
 end
 # some spaces need a few things dropped
 for add in ["add", "add_union"]
@@ -139,9 +139,9 @@ SUITE["graph"]["add_union"]["agent_single"] =
     @benchmarkable add_agent_single!($graph_agent, $graph_union_model)
 
 graph_model = ABM(GraphAgent, GraphSpace(complete_digraph(100)))
-for node in 1:100
+for position in 1:100
     for _ in 1:4
-        add_agent!(node, graph_model, 6.5, false)
+        add_agent!(position, graph_model, 6.5, false)
     end
 end
 a = graph_model[89]
@@ -163,11 +163,11 @@ SUITE["graph"]["neighbors"]["space_pos_iterate"] =
 SUITE["graph"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $graph_model, 1) setup =
         (nearby_agents($a, $graph_model))
-SUITE["graph"]["neighbors"]["node_pos"] = @benchmarkable node_neighbors($pos, $graph_model)
-SUITE["graph"]["neighbors"]["node_agent"] = @benchmarkable node_neighbors($a, $graph_model)
+SUITE["graph"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($pos, $graph_model)
+SUITE["graph"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $graph_model)
 
-SUITE["graph"]["node"]["contents"] = @benchmarkable get_node_contents($pos, $graph_model)
-SUITE["graph"]["node"]["nodes"] = @benchmarkable nodes($graph_model)
+SUITE["graph"]["position"]["contents"] = @benchmarkable get_node_contents($pos, $graph_model)
+SUITE["graph"]["position"]["nodes"] = @benchmarkable nodes($graph_model)
 
 ##### API -> GRID ####
 
@@ -239,11 +239,11 @@ SUITE["grid"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $grid_model, 30) setup =
         (nearby_agents($a, $grid_model, 30))
 
-SUITE["grid"]["neighbors"]["node_pos"] = @benchmarkable node_neighbors($a, $grid_model)
-SUITE["grid"]["neighbors"]["node_agent"] = @benchmarkable node_neighbors($a, $grid_model)
+SUITE["grid"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($a, $grid_model)
+SUITE["grid"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $grid_model)
 
-SUITE["grid"]["node"]["contents"] = @benchmarkable get_node_contents($pos, $grid_model)
-SUITE["graph"]["node"]["nodes"] = @benchmarkable nodes($graph_model)
+SUITE["grid"]["position"]["contents"] = @benchmarkable get_node_contents($pos, $grid_model)
+SUITE["graph"]["position"]["nodes"] = @benchmarkable nodes($graph_model)
 
 #### API -> CONTINUOUS ####
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -104,7 +104,7 @@ end
 
 function iterate_over_neighbors(a, model, r)
     s = 0
-    for x in space_neighbors(a, model, r)
+    for x in nearby_agents(a, model, r)
         s += x
     end
     return s
@@ -152,17 +152,17 @@ SUITE["graph"]["move"]["single"] = @benchmarkable move_agent_single!($a, $graph_
 
 # We use a digraph, so all agents are neighbors of each other
 SUITE["graph"]["neighbors"]["space_pos"] =
-    @benchmarkable space_neighbors($pos, $graph_model) setup =
-        (space_neighbors($pos, $graph_model))
+    @benchmarkable nearby_agents($pos, $graph_model) setup =
+        (nearby_agents($pos, $graph_model))
 SUITE["graph"]["neighbors"]["space_agent"] =
-    @benchmarkable space_neighbors($a, $graph_model) setup =
-        (space_neighbors($a, $graph_model))
+    @benchmarkable nearby_agents($a, $graph_model) setup =
+        (nearby_agents($a, $graph_model))
 SUITE["graph"]["neighbors"]["space_pos_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $graph_model, 1) setup =
-        (space_neighbors($pos, $graph_model))
+        (nearby_agents($pos, $graph_model))
 SUITE["graph"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $graph_model, 1) setup =
-        (space_neighbors($a, $graph_model))
+        (nearby_agents($a, $graph_model))
 SUITE["graph"]["neighbors"]["node_pos"] = @benchmarkable node_neighbors($pos, $graph_model)
 SUITE["graph"]["neighbors"]["node_agent"] = @benchmarkable node_neighbors($a, $graph_model)
 
@@ -225,19 +225,19 @@ SUITE["grid"]["move"]["pos"] = @benchmarkable move_agent!($a, (14, 35), $grid_mo
 SUITE["grid"]["move"]["single"] = @benchmarkable move_agent_single!($a, $grid_model)
 
 SUITE["grid"]["neighbors"]["space_pos"] =
-    @benchmarkable space_neighbors($pos, $grid_model, 5) setup =
-        (space_neighbors($pos, $grid_model, 5))
+    @benchmarkable nearby_agents($pos, $grid_model, 5) setup =
+        (nearby_agents($pos, $grid_model, 5))
 SUITE["grid"]["neighbors"]["space_agent"] =
-    @benchmarkable space_neighbors($a, $grid_model, 5) setup =
-        (space_neighbors($a, $grid_model, 5))
+    @benchmarkable nearby_agents($a, $grid_model, 5) setup =
+        (nearby_agents($a, $grid_model, 5))
 
 SUITE["grid"]["neighbors"]["space_pos_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $grid_model, 30) setup =
-        (space_neighbors($pos, $grid_model, 30))
+        (nearby_agents($pos, $grid_model, 30))
 
 SUITE["grid"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $grid_model, 30) setup =
-        (space_neighbors($a, $grid_model, 30))
+        (nearby_agents($a, $grid_model, 30))
 
 SUITE["grid"]["neighbors"]["node_pos"] = @benchmarkable node_neighbors($a, $grid_model)
 SUITE["grid"]["neighbors"]["node_agent"] = @benchmarkable node_neighbors($a, $grid_model)
@@ -311,19 +311,19 @@ SUITE["continuous"]["move"]["vel"] =
     @benchmarkable move_agent!($a, $continuous_model, (1.2, 0.0, 0.7))
 
 SUITE["continuous"]["neighbors"]["space_pos"] =
-    @benchmarkable space_neighbors($pos, $continuous_model, 5) setup =
-        (space_neighbors($pos, $continuous_model, 5))
+    @benchmarkable nearby_agents($pos, $continuous_model, 5) setup =
+        (nearby_agents($pos, $continuous_model, 5))
 
 SUITE["continuous"]["neighbors"]["space_agent"] =
-    @benchmarkable space_neighbors($a, $continuous_model, 5) setup =
-        (space_neighbors($a, $continuous_model, 5))
+    @benchmarkable nearby_agents($a, $continuous_model, 5) setup =
+        (nearby_agents($a, $continuous_model, 5))
 
 SUITE["continuous"]["neighbors"]["space_pos_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $continuous_model, 10) setup =
-        (space_neighbors($pos, $continuous_model, 10))
+        (nearby_agents($pos, $continuous_model, 10))
 SUITE["continuous"]["neighbors"]["space_agent_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $continuous_model, 10) setup =
-        (space_neighbors($a, $continuous_model, 10))
+        (nearby_agents($a, $continuous_model, 10))
 SUITE["continuous"]["neighbors"]["nearest"] =
     @benchmarkable nearest_neighbor($a, $continuous_model, 5)
 SUITE["continuous"]["neighbors"]["interacting"] =

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -68,20 +68,20 @@ for space in ["graph", "grid", "continuous"]
     if space == "continuous"
         SUITE[space]["move"] = BenchmarkGroup(["update", "vel"])
         SUITE[space]["neighbors"] = BenchmarkGroup([
-            "space_pos",
-            "space_agent",
-            "space_pos_iterate",
-            "space_agent_iterate",
+            "nearby_ids",
+            "nearby_agents",
+            "nearby_ids_iterate",
+            "nearby_agents_iterate",
             "nearest",
             "interacting",
         ])
     else
         SUITE[space]["move"] = BenchmarkGroup(["random", "pos", "single"])
         SUITE[space]["neighbors"] = BenchmarkGroup([
-            "space_pos",
-            "space_agent",
-            "space_pos_iterate",
-            "space_agent_iterate",
+            "nearby_ids",
+            "nearby_agents",
+            "nearby_ids_iterate",
+            "nearby_agents_iterate",
             "position_pos",
             "position_agent",
         ])
@@ -151,22 +151,22 @@ SUITE["graph"]["move"]["pos"] = @benchmarkable move_agent!($a, 68, $graph_model)
 SUITE["graph"]["move"]["single"] = @benchmarkable move_agent_single!($a, $graph_model)
 
 # We use a digraph, so all agents are neighbors of each other
-SUITE["graph"]["neighbors"]["space_pos"] =
+SUITE["graph"]["neighbors"]["nearby_ids"] =
     @benchmarkable nearby_ids($pos, $graph_model) setup =
         (nearby_ids($pos, $graph_model))
-SUITE["graph"]["neighbors"]["space_agent"] =
+SUITE["graph"]["neighbors"]["nearby_agents"] =
     @benchmarkable nearby_ids($a, $graph_model) setup =
         (nearby_ids($a, $graph_model))
-SUITE["graph"]["neighbors"]["space_pos_iterate"] =
+SUITE["graph"]["neighbors"]["nearby_ids_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $graph_model, 1) setup =
         (nearby_ids($pos, $graph_model))
-SUITE["graph"]["neighbors"]["space_agent_iterate"] =
+SUITE["graph"]["neighbors"]["nearby_agents_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $graph_model, 1) setup =
         (nearby_ids($a, $graph_model))
 SUITE["graph"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($pos, $graph_model)
 SUITE["graph"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $graph_model)
 
-SUITE["graph"]["position"]["contents"] = @benchmarkable agents_in_pos($pos, $graph_model)
+SUITE["graph"]["position"]["contents"] = @benchmarkable ids_in_position($pos, $graph_model)
 SUITE["graph"]["position"]["positions"] = @benchmarkable positions($graph_model)
 
 ##### API -> GRID ####
@@ -224,25 +224,25 @@ SUITE["grid"]["move"]["random"] = @benchmarkable move_agent!($a, $grid_model)
 SUITE["grid"]["move"]["pos"] = @benchmarkable move_agent!($a, (14, 35), $grid_model)
 SUITE["grid"]["move"]["single"] = @benchmarkable move_agent_single!($a, $grid_model)
 
-SUITE["grid"]["neighbors"]["space_pos"] =
+SUITE["grid"]["neighbors"]["nearby_ids"] =
     @benchmarkable nearby_ids($pos, $grid_model, 5) setup =
         (nearby_ids($pos, $grid_model, 5))
-SUITE["grid"]["neighbors"]["space_agent"] =
+SUITE["grid"]["neighbors"]["nearby_agents"] =
     @benchmarkable nearby_ids($a, $grid_model, 5) setup =
         (nearby_ids($a, $grid_model, 5))
 
-SUITE["grid"]["neighbors"]["space_pos_iterate"] =
+SUITE["grid"]["neighbors"]["nearby_ids_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $grid_model, 30) setup =
         (nearby_ids($pos, $grid_model, 30))
 
-SUITE["grid"]["neighbors"]["space_agent_iterate"] =
+SUITE["grid"]["neighbors"]["nearby_agents_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $grid_model, 30) setup =
         (nearby_ids($a, $grid_model, 30))
 
 SUITE["grid"]["neighbors"]["position_pos"] = @benchmarkable nearby_positions($a, $grid_model)
 SUITE["grid"]["neighbors"]["position_agent"] = @benchmarkable nearby_positions($a, $grid_model)
 
-SUITE["grid"]["position"]["contents"] = @benchmarkable agents_in_pos($pos, $grid_model)
+SUITE["grid"]["position"]["contents"] = @benchmarkable ids_in_position($pos, $grid_model)
 SUITE["graph"]["position"]["positions"] = @benchmarkable positions($graph_model)
 
 #### API -> CONTINUOUS ####
@@ -310,18 +310,18 @@ SUITE["continuous"]["move"]["update"] = @benchmarkable move_agent!($a, $continuo
 SUITE["continuous"]["move"]["vel"] =
     @benchmarkable move_agent!($a, $continuous_model, (1.2, 0.0, 0.7))
 
-SUITE["continuous"]["neighbors"]["space_pos"] =
+SUITE["continuous"]["neighbors"]["nearby_ids"] =
     @benchmarkable nearby_ids($pos, $continuous_model, 5) setup =
         (nearby_ids($pos, $continuous_model, 5))
 
-SUITE["continuous"]["neighbors"]["space_agent"] =
+SUITE["continuous"]["neighbors"]["nearby_agents"] =
     @benchmarkable nearby_ids($a, $continuous_model, 5) setup =
         (nearby_ids($a, $continuous_model, 5))
 
-SUITE["continuous"]["neighbors"]["space_pos_iterate"] =
+SUITE["continuous"]["neighbors"]["nearby_ids_iterate"] =
     @benchmarkable iterate_over_neighbors($pos, $continuous_model, 10) setup =
         (nearby_ids($pos, $continuous_model, 10))
-SUITE["continuous"]["neighbors"]["space_agent_iterate"] =
+SUITE["continuous"]["neighbors"]["nearby_agents_iterate"] =
     @benchmarkable iterate_over_neighbors($a, $continuous_model, 10) setup =
         (nearby_ids($a, $continuous_model, 10))
 SUITE["continuous"]["neighbors"]["nearest"] =

--- a/benchmark/forest.jl
+++ b/benchmark/forest.jl
@@ -49,14 +49,14 @@ function forest_model_step_array!(forest)
     end
 end
 
-function iterate_over_neighbors(a, model)
+function iterate_over_nearby_agents(a, model)
     s::Int = 0
     for x in nearby_agents(a, model)
         s::Int += x
     end
     return s
 end
-function iterate_over_neighbors2(aa::Vector, model)
+function iterate_over_nearby_agents2(aa::Vector, model)
     s::Int = 0
     for a in aa
     for x in nearby_agents(a, model)
@@ -77,14 +77,14 @@ a = random_agent(model)
 aa = [random_agent(model) for i in 1:100]
 sleep(1e-9)
 
-println("Space neighbors")
+println("Nearby Agents")
 @btime nearby_agents($a, $model);
-println("Iterate over space neighbors")
-@btime iterate_over_neighbors($a, $model);
-println("Iterate over position space neighbors")
-@btime iterate_over_neighbors($a.pos, $model);
-println("Iterate over space neighbors2")
-@btime iterate_over_neighbors2($aa, $model);
+println("Iterate over nearby agents")
+@btime iterate_over_nearby_agents($a, $model);
+println("Iterate over nearby agents with position")
+@btime iterate_over_nearby_agents($a.pos, $model);
+println("Iterate over nearby agents2")
+@btime iterate_over_nearby_agents2($aa, $model);
 println("node neighbors")
 @btime nearby_positions($a.pos, $model);
 

--- a/benchmark/forest.jl
+++ b/benchmark/forest.jl
@@ -39,7 +39,7 @@ function forest_model_step_array!(forest)
                 if rand() ≤ forest.f  # the tree ignites spontaneously
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
-                    neighbors = nearby_agents(tree, forest)
+                    neighbors = nearby_ids(tree, forest)
                     if any(n -> !(model[n].status), neighbors)
                         tree.status = false
                     end
@@ -49,17 +49,17 @@ function forest_model_step_array!(forest)
     end
 end
 
-function iterate_over_nearby_agents(a, model)
+function iterate_over_nearby_ids(a, model)
     s::Int = 0
-    for x in nearby_agents(a, model)
+    for x in nearby_ids(a, model)
         s::Int += x
     end
     return s
 end
-function iterate_over_nearby_agents2(aa::Vector, model)
+function iterate_over_nearby_ids2(aa::Vector, model)
     s::Int = 0
     for a in aa
-    for x in nearby_agents(a, model)
+    for x in nearby_ids(a, model)
         s::Int += x
     end
     end
@@ -78,13 +78,13 @@ aa = [random_agent(model) for i in 1:100]
 sleep(1e-9)
 
 println("Nearby Agents")
-@btime nearby_agents($a, $model);
+@btime nearby_ids($a, $model);
 println("Iterate over nearby agents")
-@btime iterate_over_nearby_agents($a, $model);
+@btime iterate_over_nearby_ids($a, $model);
 println("Iterate over nearby agents with position")
-@btime iterate_over_nearby_agents($a.pos, $model);
+@btime iterate_over_nearby_ids($a.pos, $model);
 println("Iterate over nearby agents2")
-@btime iterate_over_nearby_agents2($aa, $model);
+@btime iterate_over_nearby_ids2($aa, $model);
 println("nearby positions")
 @btime nearby_positions($a.pos, $model);
 

--- a/benchmark/forest.jl
+++ b/benchmark/forest.jl
@@ -27,12 +27,12 @@ end
 
 function forest_model_step_array!(forest)
     for pos in positions(forest, :random)
-        np = agents_in_pos(pos, forest)
+        ids = ids_in_position(pos, forest)
         ## the position is empty, maybe a tree grows here
-        if length(np) == 0
+        if length(ids) == 0
             rand() ≤ forest.p && add_agent!(pos, forest, true)
         else
-            tree = forest[np[1]] # by definition only 1 agent per position
+            tree = forest[ids[1]] # by definition only 1 agent per position
             if tree.status == false  # if it is has been burning, remove it.
                 kill_agent!(tree, forest)
             else

--- a/benchmark/forest.jl
+++ b/benchmark/forest.jl
@@ -86,7 +86,7 @@ println("Iterate over position space neighbors")
 println("Iterate over space neighbors2")
 @btime iterate_over_neighbors2($aa, $model);
 println("node neighbors")
-@btime node_neighbors($a.pos, $model);
+@btime nearby_positions($a.pos, $model);
 
 
 println("Move agent")

--- a/benchmark/forest.jl
+++ b/benchmark/forest.jl
@@ -17,7 +17,7 @@ function forest_fire_array(; f = 0.02, d = 0.9, p = 0.01,
 
     ## create and add trees to each pos with probability d,
     ## which determines the density of the forest
-    for pos in nodes(forest)
+    for pos in positions(forest)
         if rand() ≤ forest.d
             add_agent!(pos, forest, true)
         end
@@ -26,7 +26,7 @@ function forest_fire_array(; f = 0.02, d = 0.9, p = 0.01,
 end
 
 function forest_model_step_array!(forest)
-    for pos in nodes(forest, :random)
+    for pos in positions(forest, :random)
         np = agents_in_pos(pos, forest)
         ## the position is empty, maybe a tree grows here
         if length(np) == 0
@@ -85,7 +85,7 @@ println("Iterate over nearby agents with position")
 @btime iterate_over_nearby_agents($a.pos, $model);
 println("Iterate over nearby agents2")
 @btime iterate_over_nearby_agents2($aa, $model);
-println("node neighbors")
+println("nearby positions")
 @btime nearby_positions($a.pos, $model);
 
 

--- a/benchmark/forest.jl
+++ b/benchmark/forest.jl
@@ -39,7 +39,7 @@ function forest_model_step_array!(forest)
                 if rand() ≤ forest.f  # the tree ignites spontaneously
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
-                    neighbors = space_neighbors(tree, forest)
+                    neighbors = nearby_agents(tree, forest)
                     if any(n -> !(model[n].status), neighbors)
                         tree.status = false
                     end
@@ -51,7 +51,7 @@ end
 
 function iterate_over_neighbors(a, model)
     s::Int = 0
-    for x in space_neighbors(a, model)
+    for x in nearby_agents(a, model)
         s::Int += x
     end
     return s
@@ -59,7 +59,7 @@ end
 function iterate_over_neighbors2(aa::Vector, model)
     s::Int = 0
     for a in aa
-    for x in space_neighbors(a, model)
+    for x in nearby_agents(a, model)
         s::Int += x
     end
     end
@@ -78,7 +78,7 @@ aa = [random_agent(model) for i in 1:100]
 sleep(1e-9)
 
 println("Space neighbors")
-@btime space_neighbors($a, $model);
+@btime nearby_agents($a, $model);
 println("Iterate over space neighbors")
 @btime iterate_over_neighbors($a, $model);
 println("Iterate over position space neighbors")

--- a/benchmark/forest.jl
+++ b/benchmark/forest.jl
@@ -27,12 +27,12 @@ end
 
 function forest_model_step_array!(forest)
     for pos in nodes(forest, :random)
-        nc = get_node_contents(pos, forest)
-        ## the cell is empty, maybe a tree grows here
-        if length(nc) == 0
+        np = agents_in_pos(pos, forest)
+        ## the position is empty, maybe a tree grows here
+        if length(np) == 0
             rand() ≤ forest.p && add_agent!(pos, forest, true)
         else
-            tree = forest[nc[1]] # by definition only 1 agent per pos
+            tree = forest[np[1]] # by definition only 1 agent per position
             if tree.status == false  # if it is has been burning, remove it.
                 kill_agent!(tree, forest)
             else

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -36,7 +36,7 @@ sample!
 ## Neighbors
 ```@docs
 nearby_agents
-node_neighbors
+nearby_positions
 ```
 
 ### WARNING: Iteration

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -78,7 +78,7 @@ sort!(collect(space_agents(a, model)))
 
 ## Discrete space exclusives
 ```@docs
-nodes
+positions
 agents_in_pos
 fill_space!
 has_empty_positions

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -35,7 +35,7 @@ sample!
 
 ## Neighbors
 ```@docs
-space_neighbors
+nearby_agents
 node_neighbors
 ```
 
@@ -65,10 +65,10 @@ You will notice that only 1 agent got killed. This is simply because the final s
 To avoid problems like these, you need to `copy` the iterator to have a non dynamic version.
 
 **Lazy** means that when possible the outputs of the iteration are not collected and instead are generated on the fly.
-A good example to illustrate this is [`space_neighbors`](@ref), where doing something like
+A good example to illustrate this is [`nearby_agents`](@ref), where doing something like
 ```@example docs
 a = random_agent(model)
-sort!(space_neighbors(random_agent(model), model))
+sort!(nearby_agents(random_agent(model), model))
 ```
 leads to error, since you cannot `sort!` the returned iterator. This can be easily solved by adding a `collect` in between:
 ```@example docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -81,8 +81,8 @@ sort!(collect(space_agents(a, model)))
 nodes
 agents_in_pos
 fill_space!
-has_empty_nodes
-find_empty_nodes
+has_empty_positions
+empty_positions
 random_empty
 add_agent_single!
 move_agent_single!

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,7 +43,7 @@ nearby_positions
 
 Most iteration in Agents.jl is **dynamic** and **lazy**, when possible, for performance reasons.
 
-**Dynamic** means that when iterating over the result of e.g. the [`agents_in_pos`](@ref) function, the iterator will be affected by actions that would alter its contents.
+**Dynamic** means that when iterating over the result of e.g. the [`ids_in_position`](@ref) function, the iterator will be affected by actions that would alter its contents.
 Specifically, imagine the scenario
 ```@example docs
 using Agents, LightGraphs
@@ -56,12 +56,12 @@ model = ABM(Agent, GraphSpace(complete_digraph(10)))
 add_agent!(1, model)
 add_agent!(1, model)
 add_agent!(2, model)
-for agent in agents_in_pos(1, model)
-    kill_agent!(agent, model)
+for id in ids_in_position(1, model)
+    kill_agent!(id, model)
 end
 collect(allids(model))
 ```
-You will notice that only 1 agent got killed. This is simply because the final state of the iteration of `agents_in_pos` was reached unnaturally, because the length of its output was reduced by 1 *during* iteration.
+You will notice that only 1 agent got killed. This is simply because the final state of the iteration of `ids_in_position` was reached unnaturally, because the length of its output was reduced by 1 *during* iteration.
 To avoid problems like these, you need to `copy` the iterator to have a non dynamic version.
 
 **Lazy** means that when possible the outputs of the iteration are not collected and instead are generated on the fly.
@@ -79,7 +79,8 @@ sort!(collect(space_agents(a, model)))
 ## Discrete space exclusives
 ```@docs
 positions
-agents_in_pos
+ids_in_position
+agents_in_position
 fill_space!
 has_empty_positions
 empty_positions

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -27,7 +27,6 @@ random_position
 ### Moving and killing agents
 ```@docs
 move_agent!
-move_agent_single!
 kill_agent!
 genocide!
 sample!
@@ -73,7 +72,7 @@ sort!(nearby_ids(random_agent(model), model))
 leads to error, since you cannot `sort!` the returned iterator. This can be easily solved by adding a `collect` in between:
 ```@example docs
 a = random_agent(model)
-sort!(collect(space_agents(a, model)))
+sort!(collect(nearby_agents(a, model)))
 ```
 
 ## Discrete space exclusives

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -43,7 +43,7 @@ nearby_positions
 
 Most iteration in Agents.jl is **dynamic** and **lazy**, when possible, for performance reasons.
 
-**Dynamic** means that when iterating over the result of e.g. the [`get_node_contents`](@ref) function, the iterator will be affected by actions that would alter its contents.
+**Dynamic** means that when iterating over the result of e.g. the [`agents_in_pos`](@ref) function, the iterator will be affected by actions that would alter its contents.
 Specifically, imagine the scenario
 ```@example docs
 using Agents, LightGraphs
@@ -56,12 +56,12 @@ model = ABM(Agent, GraphSpace(complete_digraph(10)))
 add_agent!(1, model)
 add_agent!(1, model)
 add_agent!(2, model)
-for agent in get_node_contents(1, model)
+for agent in agents_in_pos(1, model)
     kill_agent!(agent, model)
 end
 collect(allids(model))
 ```
-You will notice that only 1 agent got killed. This is simply because the final state of the iteration of `get_node_contents` was reached unnaturally, because the length of its output was reduced by 1 *during* iteration.
+You will notice that only 1 agent got killed. This is simply because the final state of the iteration of `agents_in_pos` was reached unnaturally, because the length of its output was reduced by 1 *during* iteration.
 To avoid problems like these, you need to `copy` the iterator to have a non dynamic version.
 
 **Lazy** means that when possible the outputs of the iteration are not collected and instead are generated on the fly.
@@ -79,7 +79,7 @@ sort!(collect(space_agents(a, model)))
 ## Discrete space exclusives
 ```@docs
 nodes
-get_node_contents
+agents_in_pos
 fill_space!
 has_empty_nodes
 find_empty_nodes

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -83,7 +83,7 @@ agents_in_pos
 fill_space!
 has_empty_nodes
 find_empty_nodes
-pick_empty
+random_empty
 add_agent_single!
 move_agent_single!
 isempty(::Integer, ::ABM)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,9 +33,9 @@ genocide!
 sample!
 ```
 
-## Neighbors
+## Local area
 ```@docs
-nearby_agents
+nearby_ids
 nearby_positions
 ```
 
@@ -65,10 +65,10 @@ You will notice that only 1 agent got killed. This is simply because the final s
 To avoid problems like these, you need to `copy` the iterator to have a non dynamic version.
 
 **Lazy** means that when possible the outputs of the iteration are not collected and instead are generated on the fly.
-A good example to illustrate this is [`nearby_agents`](@ref), where doing something like
+A good example to illustrate this is [`nearby_ids`](@ref), where doing something like
 ```@example docs
 a = random_agent(model)
-sort!(nearby_agents(random_agent(model), model))
+sort!(nearby_ids(random_agent(model), model))
 ```
 leads to error, since you cannot `sort!` the returned iterator. This can be easily solved by adding a `collect` in between:
 ```@example docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -67,7 +67,7 @@ Use of ABMs have become feasible after the availability of computers and has bee
 
 An ABM consists of autonomous agents that behave given a set of rules.
 A classic example of an ABM is [Schelling's segregation model](https://www.tandfonline.com/doi/abs/10.1080/0022250X.1971.9989794), which we implement as an example here.
-This model uses a regular grid and defines agents as the cells of the grid.
+This model uses a regular grid and defines agents at random positions on the grid.
 Agents can be from different social groups.
 Agents are happy/unhappy based on the fraction of their neighbors that belong to the same group as they are.
 If they are unhappy, they keep moving to new locations until they are happy.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ Agents.jl is part of [JuliaDynamics](https://juliadynamics.github.io/JuliaDynami
 To get started, please read the [Tutorial](@ref) page.
 
 !!! tip "Latest news"
-    Interactive applications & predefined models!
+    Welcome to Agents.jl v4.0! This new release features improved `GridSpace` and `ContinuousSpace` (re-written from scratch), overall performance improvements of Agents.jl of a full order of magnitude (and sometimes more) and re-naming many API functions to make sense (deprecations have been put in place). Have a look at the [CHANGELOG](https://github.com/JuliaDynamics/Agents.jl/blob/master/CHANGELOG.md) for more details!
 
 ## Features
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -67,7 +67,7 @@ dummystep
 ```
 
 !!! note
-    Notice that the current step number is not explicitly given to the [`model_step!`](@ref)
+    Notice that the current step number is not explicitly given to the `model_step!`
     function, because this is useful only for a small subset of ABMs. If you need the
     step information, implement this by adding a counting parameter into the model
     `properties`, and incrementing it by 1 each time `model_step!` is called.

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -98,7 +98,7 @@ nothing # hide
 # In addition, temperature diffuses over time
 function diffuse_temperature!(node::Int, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
-    ids = space_neighbors(node, model)
+    ids = nearby_agents(node, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
     land = model[get_node_contents(node, model)[1]] # land at current node
     ## Each neighbor land patch is giving up 1/8 of the diffused

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -98,7 +98,7 @@ nothing # hide
 # In addition, temperature diffuses over time
 function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
-    ids = nearby_agents(pos, model)
+    ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
     land = model[agents_in_pos(pos, model)[1]] # land at current position
     ## Each neighbor land patch is giving up 1/8 of the diffused

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -338,7 +338,7 @@ plot!(p; xlabel = "tick", ylabel = "daisy count")
 p2 = plot(agent_df[!, :step], agent_df[!, aggname(adata[3])], ylabel = "temperature")
 p3 = plot(model_df[!, :step], model_df[!, :solar_luminosity], ylabel = "L", xlabel = "ticks")
 
-plot(p, p2, p3, layout = (3, 1))
+plot(p, p2, p3, layout = (3, 1), size=(600,700))
 
 
 # ## Interactive scientific research

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -76,7 +76,7 @@ const DaisyWorld = ABM{Union{Daisy, Land}};
 # absorb or reflect the starlight -- altering the local temperature.
 
 function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
-    ids = agents_in_pos(pos, model)
+    ids = ids_in_position(pos, model)
     ## All grid positions have at least one agent (the land)
     absorbed_luminosity = if length(ids) == 1
         ## Set luminosity via surface albedo
@@ -100,7 +100,7 @@ function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
     ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
-    land = model[agents_in_pos(pos, model)[1]] # land at current position
+    land = model[ids_in_position(pos, model)[1]] # land at current position
     ## Each neighbor land patch is giving up 1/8 of the diffused
     ## amount to each of *its* neighbors
     land.temperature = (1 - ratio)*land.temperature + ratio*meantemp
@@ -116,7 +116,7 @@ nothing # hide
 # close to them.
 
 function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
-    ids = agents_in_pos(pos, model)
+    ids = ids_in_position(pos, model)
     if length(ids) > 1
         daisy = model[ids[2]]
         temperature = model[ids[1]].temperature
@@ -127,7 +127,7 @@ function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
             empty_neighbors = Tuple{Int,Int}[]
             neighbors = nearby_positions(pos, model)
             for n in neighbors
-                if length(agents_in_pos(n, model)) == 1
+                if length(ids_in_position(n, model)) == 1
                     push!(empty_neighbors, n)
                 end
             end

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -76,8 +76,8 @@ const DaisyWorld = ABM{Union{Daisy, Land}};
 # absorb or reflect the starlight -- altering the local temperature.
 
 function update_surface_temperature!(node::Int, model::DaisyWorld)
-    ids = get_node_contents(node, model)
-    ## All grid points have at least one agent (the land)
+    ids = agents_in_pos(node, model)
+    ## All grid positions have at least one agent (the land)
     absorbed_luminosity = if length(ids) == 1
         ## Set luminosity via surface albedo
         (1 - model.surface_albedo) * model.solar_luminosity
@@ -100,7 +100,7 @@ function diffuse_temperature!(node::Int, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
     ids = nearby_agents(node, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
-    land = model[get_node_contents(node, model)[1]] # land at current node
+    land = model[agents_in_pos(node, model)[1]] # land at current position
     ## Each neighbor land patch is giving up 1/8 of the diffused
     ## amount to each of *its* neighbors
     land.temperature = (1 - ratio)*land.temperature + ratio*meantemp
@@ -116,7 +116,7 @@ nothing # hide
 # close to them.
 
 function propagate!(node::Int, model::DaisyWorld)
-    ids = get_node_contents(node, model)
+    ids = agents_in_pos(node, model)
     if length(ids) > 1
         daisy = model[ids[2]]
         temperature = model[ids[1]].temperature
@@ -127,7 +127,7 @@ function propagate!(node::Int, model::DaisyWorld)
             empty_neighbors = Int[]
             neighbors = nearby_positions(node, model)
             for n in neighbors
-                if length(get_node_contents(n, model)) == 1
+                if length(agents_in_pos(n, model)) == 1
                     push!(empty_neighbors, n)
                 end
             end

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -123,7 +123,7 @@ function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
         ## Set optimum growth rate to 22.5 ᵒC, with bounds of [5, 40]
         seed_threshold = (0.1457 * temperature - 0.0032 * temperature^2) - 0.6443
         if rand() < seed_threshold
-            ## Collect all adjacent cells that have no daisies
+            ## Collect all adjacent position that have no daisies
             empty_neighbors = Int[]
             neighbors = nearby_positions(pos, model)
             for n in neighbors
@@ -132,8 +132,8 @@ function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
                 end
             end
             if !isempty(empty_neighbors)
-                ## Seed a new daisy in one of those cells
-                seeding_place = vertex2coord(rand(empty_neighbors), model)
+                ## Seed a new daisy in one of those position
+                seeding_place = rand(empty_neighbors)
                 a = Daisy(nextid(model), seeding_place, daisy.breed, 0, daisy.albedo)
                 add_agent_pos!(a, model)
             end
@@ -221,10 +221,10 @@ function daisyworld(;
         scheduler = daisysched, properties = properties, warn = false
     )
 
-    ## fill model with `Land`: every grid cell has 1 land instance
+    ## fill model with `Land`: every grid position has 1 land instance
     fill_space!(Land, model, 0.0) # zero starting temperature
 
-    ## Populate with daisies: each cell has only one daisy (black or white)
+    ## Populate with daisies: each position has only one daisy (black or white)
     white_positions = StatsBase.sample(1:nv(space), Int(init_white * nv(space)); replace = false)
     for wp in white_positions
         wd = Daisy(nextid(model), wp, :white, rand(0:max_age), albedo_white)

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -124,7 +124,7 @@ function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
         seed_threshold = (0.1457 * temperature - 0.0032 * temperature^2) - 0.6443
         if rand() < seed_threshold
             ## Collect all adjacent position that have no daisies
-            empty_neighbors = Int[]
+            empty_neighbors = Tuple{Int,Int}[]
             neighbors = nearby_positions(pos, model)
             for n in neighbors
                 if length(agents_in_pos(n, model)) == 1
@@ -212,7 +212,7 @@ function daisyworld(;
         scenario = :default,
     )
 
-    space = GridSpace(griddims, moore = true, periodic = true)
+    space = GridSpace(griddims)
     properties = @dict max_age surface_albedo solar_luminosity solar_change scenario
     properties[:tick] = 0
     ## create a scheduler that only schedules Daisies
@@ -225,13 +225,15 @@ function daisyworld(;
     fill_space!(Land, model, 0.0) # zero starting temperature
 
     ## Populate with daisies: each position has only one daisy (black or white)
-    white_positions = StatsBase.sample(1:nv(space), Int(init_white * nv(space)); replace = false)
+    grid = collect(positions(model))
+    num_positions = prod(griddims)
+    white_positions = StatsBase.sample(grid, Int(init_white * num_positions); replace = false)
     for wp in white_positions
         wd = Daisy(nextid(model), wp, :white, rand(0:max_age), albedo_white)
         add_agent_pos!(wd, model)
     end
-    allowed = setdiff(1:nv(space), white_positions)
-    black_positions = StatsBase.sample(allowed, Int(init_black * nv(space)); replace = false)
+    allowed = setdiff(grid, white_positions)
+    black_positions = StatsBase.sample(allowed, Int(init_black * num_positions); replace = false)
     for bp in black_positions
         wd = Daisy(nextid(model), bp, :black, rand(0:max_age), albedo_black)
         add_agent_pos!(wd, model)

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -125,7 +125,7 @@ function propagate!(node::Int, model::DaisyWorld)
         if rand() < seed_threshold
             ## Collect all adjacent cells that have no daisies
             empty_neighbors = Int[]
-            neighbors = node_neighbors(node, model)
+            neighbors = nearby_positions(node, model)
             for n in neighbors
                 if length(get_node_contents(n, model)) == 1
                     push!(empty_neighbors, n)

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -75,8 +75,8 @@ const DaisyWorld = ABM{Union{Daisy, Land}};
 # The surface temperature of the world is heated by its sun, but daisies growing upon it
 # absorb or reflect the starlight -- altering the local temperature.
 
-function update_surface_temperature!(node::Int, model::DaisyWorld)
-    ids = agents_in_pos(node, model)
+function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
+    ids = agents_in_pos(pos, model)
     ## All grid positions have at least one agent (the land)
     absorbed_luminosity = if length(ids) == 1
         ## Set luminosity via surface albedo
@@ -96,11 +96,11 @@ end
 nothing # hide
 
 # In addition, temperature diffuses over time
-function diffuse_temperature!(node::Int, model::DaisyWorld)
+function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
-    ids = nearby_agents(node, model)
+    ids = nearby_agents(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
-    land = model[agents_in_pos(node, model)[1]] # land at current position
+    land = model[agents_in_pos(pos, model)[1]] # land at current position
     ## Each neighbor land patch is giving up 1/8 of the diffused
     ## amount to each of *its* neighbors
     land.temperature = (1 - ratio)*land.temperature + ratio*meantemp
@@ -115,8 +115,8 @@ nothing # hide
 # daisies compete for land and attempt to spawn a new plant of their `breed` in locations
 # close to them.
 
-function propagate!(node::Int, model::DaisyWorld)
-    ids = agents_in_pos(node, model)
+function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
+    ids = agents_in_pos(pos, model)
     if length(ids) > 1
         daisy = model[ids[2]]
         temperature = model[ids[1]].temperature
@@ -125,7 +125,7 @@ function propagate!(node::Int, model::DaisyWorld)
         if rand() < seed_threshold
             ## Collect all adjacent cells that have no daisies
             empty_neighbors = Int[]
-            neighbors = nearby_positions(node, model)
+            neighbors = nearby_positions(pos, model)
             for n in neighbors
                 if length(agents_in_pos(n, model)) == 1
                     push!(empty_neighbors, n)
@@ -160,10 +160,10 @@ nothing # hide
 # these methods are quite straightforward.
 
 function model_step!(model)
-    for n in nodes(model)
-        update_surface_temperature!(n, model)
-        diffuse_temperature!(n, model)
-        propagate!(n, model)
+    for p in positions(model)
+        update_surface_temperature!(p, model)
+        diffuse_temperature!(p, model)
+        propagate!(p, model)
     end
     model.tick += 1
     solar_activity!(model)
@@ -225,15 +225,15 @@ function daisyworld(;
     fill_space!(Land, model, 0.0) # zero starting temperature
 
     ## Populate with daisies: each cell has only one daisy (black or white)
-    white_nodes = StatsBase.sample(1:nv(space), Int(init_white * nv(space)); replace = false)
-    for n in white_nodes
-        wd = Daisy(nextid(model), vertex2coord(n, space), :white, rand(0:max_age), albedo_white)
+    white_positions = StatsBase.sample(1:nv(space), Int(init_white * nv(space)); replace = false)
+    for wp in white_positions
+        wd = Daisy(nextid(model), wp, :white, rand(0:max_age), albedo_white)
         add_agent_pos!(wd, model)
     end
-    allowed = setdiff(1:nv(space), white_nodes)
-    black_nodes = StatsBase.sample(allowed, Int(init_black * nv(space)); replace = false)
-    for n in black_nodes
-        wd = Daisy(nextid(model), vertex2coord(n, space), :black, rand(0:max_age), albedo_black)
+    allowed = setdiff(1:nv(space), white_positions)
+    black_positions = StatsBase.sample(allowed, Int(init_black * nv(space)); replace = false)
+    for bp in black_positions
+        wd = Daisy(nextid(model), bp, :black, rand(0:max_age), albedo_black)
         add_agent_pos!(wd, model)
     end
 

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -74,7 +74,7 @@ function suface_temperature!(node::Int, model::ABM{Daisy})
 end
 
 function diffuse_temperature!(node::Int, model::ABM{Daisy}; ratio = 0.5)
-    neighbors = node_neighbors(node, model)
+    neighbors = nearby_positions(node, model)
     model.temperature[node] =
         (1 - ratio) * model.temperature[node] +
         ## Each neighbor is giving up 1/8 of the diffused
@@ -163,7 +163,7 @@ function propagate!(node::Int, model::ABM{Daisy})
         if rand() < seed_threshold
             ## Collect all adjacent cells that are empty
             empty_neighbors = Vector{Int}(undef, 0)
-            neighbors = node_neighbors(node, model)
+            neighbors = nearby_positions(node, model)
             for n in neighbors
                 if isempty(get_node_contents(n, model))
                     push!(empty_neighbors, n)

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -161,7 +161,7 @@ function propagate!(pos::Tuple{Int,Int}, model::ABM{Daisy})
         ## Set optimum growth rate to 22.5C, with bounds of [5, 40]C
         seed_threshold = (0.1457 * temperature - 0.0032 * temperature^2) - 0.6443
         if rand() < seed_threshold
-            ## Collect all adjacent cells that are empty
+            ## Collect all adjacent position that are empty
             empty_neighbors = Vector{Int}(undef, 0)
             neighbors = nearby_positions(pos, model)
             for n in neighbors
@@ -170,7 +170,7 @@ function propagate!(pos::Tuple{Int,Int}, model::ABM{Daisy})
                 end
             end
             if !isempty(empty_neighbors)
-                ## Seed a new daisy in one of those cells
+                ## Seed a new daisy in one of those position
                 seeding_place = rand(empty_neighbors)
                 add_agent!(seeding_place, model, agent.breed, 0, agent.albedo)
             end

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -110,7 +110,7 @@ function daisyworld(;
         :ours, # The Sun's equivalent, achieving an equilibrium of daisies
     ]
 
-    space = GridSpace(griddims, moore = true, periodic = true)
+    space = GridSpace(griddims)
     luminosity = if scenario == :ramp
         0.8
     elseif scenario == :high

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -54,7 +54,7 @@ end
 # absorb or reflect the starlight -- altering the local temperature.
 
 function suface_temperature!(pos::Tuple{Int,Int}, model::ABM{Daisy})
-    ids = agents_in_pos(pos, model)
+    ids = ids_in_position(pos, model)
     absorbed_luminosity = if isempty(ids)
         ## Set luminosity via surface albedo
         (1 - model.surface_albedo) * model.solar_luminosity
@@ -154,7 +154,7 @@ nothing # hide
 # close to them.
 
 function propagate!(pos::Tuple{Int,Int}, model::ABM{Daisy})
-    agents = [model[a] for a in agents_in_pos(pos, model)]
+    agents = collect(agents_in_position(pos, model))
     if !isempty(agents)
         agent = agents[1]
         temperature = model.temperature[pos]
@@ -165,7 +165,7 @@ function propagate!(pos::Tuple{Int,Int}, model::ABM{Daisy})
             empty_neighbors = Vector{Int}(undef, 0)
             neighbors = nearby_positions(pos, model)
             for n in neighbors
-                if isempty(agents_in_pos(n, model))
+                if isempty(ids_in_position(n, model))
                     push!(empty_neighbors, n)
                 end
             end

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -54,7 +54,7 @@ end
 # absorb or reflect the starlight -- altering the local temperature.
 
 function suface_temperature!(node::Int, model::ABM{Daisy})
-    ids = get_node_contents(node, model)
+    ids = agents_in_pos(node, model)
     absorbed_luminosity = if isempty(ids)
         ## Set luminosity via surface albedo
         (1 - model.surface_albedo) * model.solar_luminosity
@@ -165,7 +165,7 @@ function propagate!(node::Int, model::ABM{Daisy})
             empty_neighbors = Vector{Int}(undef, 0)
             neighbors = nearby_positions(node, model)
             for n in neighbors
-                if isempty(get_node_contents(n, model))
+                if isempty(agents_in_pos(n, model))
                     push!(empty_neighbors, n)
                 end
             end

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -53,8 +53,8 @@ end
 # The surface temperature of the world is heated by its sun, but daisies growing upon it
 # absorb or reflect the starlight -- altering the local temperature.
 
-function suface_temperature!(node::Int, model::ABM{Daisy})
-    ids = agents_in_pos(node, model)
+function suface_temperature!(pos::Tuple{Int,Int}, model::ABM{Daisy})
+    ids = agents_in_pos(pos, model)
     absorbed_luminosity = if isempty(ids)
         ## Set luminosity via surface albedo
         (1 - model.surface_albedo) * model.solar_luminosity
@@ -70,13 +70,13 @@ function suface_temperature!(node::Int, model::ABM{Daisy})
         80
     end
     ## Surface temperature is the average of the current temperature and local heating.
-    model.temperature[node] = (model.temperature[node] + local_heating) / 2
+    model.temperature[pos] = (model.temperature[pos] + local_heating) / 2
 end
 
-function diffuse_temperature!(node::Int, model::ABM{Daisy}; ratio = 0.5)
-    neighbors = nearby_positions(node, model)
-    model.temperature[node] =
-        (1 - ratio) * model.temperature[node] +
+function diffuse_temperature!(pos::Int, model::ABM{Daisy}; ratio = 0.5)
+    neighbors = nearby_positions(pos, model)
+    model.temperature[pos] =
+        (1 - ratio) * model.temperature[pos] +
         ## Each neighbor is giving up 1/8 of the diffused
         ## amount to each of *its* neighbors
         sum(model.temperature[neighbors]) * 0.125 * ratio
@@ -138,8 +138,8 @@ function daisyworld(;
     for _ in 1:(init_black * nv(space) / 100)
         add_agent_single!(model, :black, rand(0:max_age), albedo_black)
     end
-    for n in nodes(model)
-        suface_temperature!(n, model)
+    for p in positions(model)
+        suface_temperature!(p, model)
     end
     return model
 end
@@ -153,17 +153,17 @@ nothing # hide
 # daisies compete for land and attempt to spawn a new plant of their `breed` in locations
 # close to them.
 
-function propagate!(node::Int, model::ABM{Daisy})
-    agents = get_node_agents(node, model)
+function propagate!(pos::Tuple{Int,Int}, model::ABM{Daisy})
+    agents = [model[a] for a in agents_in_pos(pos, model)]
     if !isempty(agents)
         agent = agents[1]
-        temperature = model.temperature[node]
+        temperature = model.temperature[pos]
         ## Set optimum growth rate to 22.5C, with bounds of [5, 40]C
         seed_threshold = (0.1457 * temperature - 0.0032 * temperature^2) - 0.6443
         if rand() < seed_threshold
             ## Collect all adjacent cells that are empty
             empty_neighbors = Vector{Int}(undef, 0)
-            neighbors = nearby_positions(node, model)
+            neighbors = nearby_positions(pos, model)
             for n in neighbors
                 if isempty(agents_in_pos(n, model))
                     push!(empty_neighbors, n)
@@ -195,10 +195,10 @@ function solar_activity!(model::ABM{Daisy})
 end
 
 function model_step!(model::ABM{Daisy})
-    for n in nodes(model)
-        suface_temperature!(n, model)
-        diffuse_temperature!(n, model)
-        propagate!(n, model)
+    for p in positions(model)
+        suface_temperature!(p, model)
+        diffuse_temperature!(p, model)
+        propagate!(p, model)
     end
     model.tick += 1
     solar_activity!(model)

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -75,7 +75,7 @@ nothing # hide
 # according to the three rules defined above.
 function agent_step!(bird, model)
     ## Obtain the ids of neighbors within the bird's visual distance
-    ids = space_neighbors(bird, model, bird.visual_distance)
+    ids = nearby_agents(bird, model, bird.visual_distance)
     ## Compute velocity based on rules defined above
     bird.vel =
         (

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -75,7 +75,7 @@ nothing # hide
 # according to the three rules defined above.
 function agent_step!(bird, model)
     ## Obtain the ids of neighbors within the bird's visual distance
-    ids = nearby_agents(bird, model, bird.visual_distance)
+    ids = nearby_ids(bird, model, bird.visual_distance)
     ## Compute velocity based on rules defined above
     bird.vel =
         (

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -3,11 +3,11 @@
 # ![](forest.gif)
 
 # The forest fire model is defined as a cellular automaton on a grid.
-# A cell can be empty, occupied by a tree, or burning.
+# A position can be empty, occupied by a tree, or burning.
 # The model of [Drossel and Schwabl (1992)](https://en.wikipedia.org/wiki/Forest-fire_model)
 # is defined by four rules which are executed simultaneously:
 #
-# 1. A burning cell turns into an empty cell
+# 1. A burning position turns into an empty position
 # 1. A tree will burn if at least one neighbor is burning
 # 1. A tree ignites with probability `f` even if no neighbor is burning
 # 1. An empty space fills with a tree with probability `p`

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -39,7 +39,7 @@ nothing # hide
 # We then make a setup function that initializes the model.
 function model_initiation(; f = 0.02, d = 0.8, p = 0.01, griddims = (100, 100), seed = 111)
     Random.seed!(seed)
-    space = GridSpace(griddims, moore = true)
+    space = GridSpace(griddims, periodic = false)
     properties = Dict(:f => f, :d => d, :p => p)
     forest = AgentBasedModel(Tree, space; properties = properties)
 
@@ -60,7 +60,7 @@ forest = model_initiation(f = 0.05, d = 0.8, p = 0.05, griddims = (20, 20), seed
 # stepping function for the model
 
 function forest_step!(forest)
-    for position in positions(forest, by = :random)
+    for position in positions(forest, :random)
         np = ids_in_position(position, forest)
         ## the position is empty, maybe a tree grows here
         if length(np) == 0
@@ -103,7 +103,7 @@ forest
 # Now we can do some data collection as well using an aggregate function `percentage`:
 
 forest = model_initiation(griddims = (20, 20), seed = 2)
-percentage(x) = count(x) / nv(forest)
+percentage(x) = count(x) / length(positions(forest))
 adata = [(:status, percentage)]
 
 data, _ = run!(forest, dummystep, forest_step!, 10; adata = adata)

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -43,11 +43,11 @@ function model_initiation(; f = 0.02, d = 0.8, p = 0.01, griddims = (100, 100), 
     properties = Dict(:f => f, :d => d, :p => p)
     forest = AgentBasedModel(Tree, space; properties = properties)
 
-    ## create and add trees to each node with probability d,
+    ## create and add trees to each position with probability d,
     ## which determines the density of the forest
-    for node in nodes(forest)
+    for position in positions(forest)
         if rand() ≤ forest.d
-            add_agent!(node, forest, true)
+            add_agent!(position, forest, true)
         end
     end
     return forest
@@ -60,11 +60,11 @@ forest = model_initiation(f = 0.05, d = 0.8, p = 0.05, griddims = (20, 20), seed
 # stepping function for the model
 
 function forest_step!(forest)
-    for node in nodes(forest, by = :random)
-        np = agents_in_pos(node, forest)
+    for position in positions(forest, by = :random)
+        np = agents_in_pos(position, forest)
         ## the position is empty, maybe a tree grows here
         if length(np) == 0
-            rand() ≤ forest.p && add_agent!(node, forest, true)
+            rand() ≤ forest.p && add_agent!(position, forest, true)
         else
             tree = forest[np[1]] # by definition only 1 agent per position
             if tree.status == false  # if it is has been burning, remove it.
@@ -73,7 +73,7 @@ function forest_step!(forest)
                 if rand() ≤ forest.f  # the tree ignites spontaneously
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
-                    for pos in nearby_positions(node, forest)
+                    for pos in nearby_positions(position, forest)
                         neighbors = agents_in_pos(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -73,8 +73,8 @@ function forest_step!(forest)
                 if rand() ≤ forest.f  # the tree ignites spontaneously
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
-                    for cell in node_neighbors(node, forest)
-                        neighbors = get_node_contents(cell, forest)
+                    for pos in nearby_positions(node, forest)
+                        neighbors = get_node_contents(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)
                             tree.status = false

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -61,12 +61,12 @@ forest = model_initiation(f = 0.05, d = 0.8, p = 0.05, griddims = (20, 20), seed
 
 function forest_step!(forest)
     for node in nodes(forest, by = :random)
-        nc = get_node_contents(node, forest)
-        ## the cell is empty, maybe a tree grows here
-        if length(nc) == 0
+        np = agents_in_pos(node, forest)
+        ## the position is empty, maybe a tree grows here
+        if length(np) == 0
             rand() ≤ forest.p && add_agent!(node, forest, true)
         else
-            tree = forest[nc[1]] # by definition only 1 agent per node
+            tree = forest[np[1]] # by definition only 1 agent per position
             if tree.status == false  # if it is has been burning, remove it.
                 kill_agent!(tree, forest)
             else
@@ -74,7 +74,7 @@ function forest_step!(forest)
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
                     for pos in nearby_positions(node, forest)
-                        neighbors = get_node_contents(pos, forest)
+                        neighbors = agents_in_pos(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)
                             tree.status = false

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -61,7 +61,7 @@ forest = model_initiation(f = 0.05, d = 0.8, p = 0.05, griddims = (20, 20), seed
 
 function forest_step!(forest)
     for position in positions(forest, by = :random)
-        np = agents_in_pos(position, forest)
+        np = ids_in_position(position, forest)
         ## the position is empty, maybe a tree grows here
         if length(np) == 0
             rand() ≤ forest.p && add_agent!(position, forest, true)
@@ -74,7 +74,7 @@ function forest_step!(forest)
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
                     for pos in nearby_positions(position, forest)
-                        neighbors = agents_in_pos(pos, forest)
+                        neighbors = ids_in_position(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)
                             tree.status = false

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -41,11 +41,11 @@ function build_model(; rules::Tuple, dims = (100, 100), Moore = true)
     space = GridSpace(dims, moore = Moore)
     properties = Dict(:rules => rules)
     model = ABM(Cell, space; properties = properties)
-    node_idx = 1
+    idx = 1
     for x in 1:dims[1]
         for y in 1:dims[2]
-            add_agent_pos!(Cell(node_idx, (x, y), false), model)
-            node_idx += 1
+            add_agent_pos!(Cell(idx, (x, y), false), model)
+            idx += 1
         end
     end
     return model

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -72,7 +72,7 @@ end
 
 function nlive_neighbors(agent, model)
     neighbor_positions = nearby_positions(agent, model)
-    all_neighbors = Iterators.flatten(agents_in_pos(np,model) for np in neighbor_positions)
+    all_neighbors = Iterators.flatten(ids_in_position(np,model) for np in neighbor_positions)
     sum(model[i].status == true for i in all_neighbors)
 end
 nothing # hide

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -71,10 +71,10 @@ function ca_step!(model)
 end
 
 function nlive_neighbors(ag, model)
-    neighbors_coords = node_neighbors(ag, model)
+    neighbor_positions = nearby_positions(ag, model)
     nlive = 0
-    for nc in neighbors_coords
-        nag = model.agents[Agents.coord2vertex((nc[2], nc[1]), model)]
+    for np in neighbor_positions
+        nag = model.agents[Agents.coord2vertex((np[2], np[1]), model)]
         if nag.status == true
             nlive += 1
         end

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -74,7 +74,7 @@ function nlive_neighbors(ag, model)
     neighbor_positions = nearby_positions(ag, model)
     nlive = 0
     for np in neighbor_positions
-        nag = model.agents[Agents.coord2vertex((np[2], np[1]), model)]
+        nag = model.agents[(np[2], np[1])]
         if nag.status == true
             nlive += 1
         end

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -49,7 +49,7 @@ end
 # ### 2. Stepping functions
 
 function adopt!(agent, model)
-    neighbor = rand(space_neighbors(agent, model))
+    neighbor = rand(nearby_agents(agent, model))
     matches = model[neighbor].opinion .== agent.opinion
     nmatches = count(matches)
     if nmatches < model.nopinions && rand() < nmatches / model.nopinions

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -49,7 +49,7 @@ end
 # ### 2. Stepping functions
 
 function adopt!(agent, model)
-    neighbor = rand(collect(nearby_agents(agent, model)))
+    neighbor = rand(collect(nearby_ids(agent, model)))
     matches = model[neighbor].opinion .== agent.opinion
     nmatches = count(matches)
     if nmatches < model.nopinions && rand() < nmatches / model.nopinions

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -34,9 +34,9 @@ function create_model(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
         scheduler = random_activation,
         properties = properties,
     )
-    for cell in 1:nv(model)
+    for pos in positions(model)
         add_agent!(
-            vertex2coord(cell,model),
+            pos
             model,
             false,
             rand(1:levels_per_opinion, nopinions),

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -36,7 +36,7 @@ function create_model(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
     )
     for pos in positions(model)
         add_agent!(
-            pos
+            pos,
             model,
             false,
             rand(1:levels_per_opinion, nopinions),
@@ -84,8 +84,7 @@ levels_per_opinion = 4
 model = create_model(nopinions = 3, levels_per_opinion = levels_per_opinion)
 
 "run the model until all agents stabilize"
-rununtil(model, s) =
-    count(getproperty.(values(model.agents), :stabilized)) == prod(model.space.dimensions)
+rununtil(model, s) = count(a->a.stabilized, allagents(model)) == length(positions(model))
 
 agentdata, _ = run!(model, agent_step!, dummystep, rununtil, adata = [(:stabilized, count)])
 

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -26,7 +26,7 @@ mutable struct Citizen <: AbstractAgent
 end
 
 function create_model(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
-    space = GridSpace(dims, periodic = true, moore = true)
+    space = GridSpace(dims)
     properties = Dict(:nopinions => nopinions)
     model = AgentBasedModel(
         Citizen,
@@ -49,7 +49,7 @@ end
 # ### 2. Stepping functions
 
 function adopt!(agent, model)
-    neighbor = rand(nearby_agents(agent, model))
+    neighbor = rand(collect(nearby_agents(agent, model)))
     matches = model[neighbor].opinion .== agent.opinion
     nmatches = count(matches)
     if nmatches < model.nopinions && rand() < nmatches / model.nopinions

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -93,12 +93,12 @@ function initialize_model(;
         wolf = Wolf(id, (0, 0), energy, wolf_reproduce, Δenergy_wolf)
         add_agent!(wolf, model)
     end
-    for n in nodes(model)
+    for p in positions(model)
         id += 1
         fully_grown = rand(Bool)
         countdown = fully_grown ? regrowth_time : rand(1:regrowth_time) - 1
         grass = Grass(id, (0, 0), fully_grown, regrowth_time, countdown)
-        add_agent!(grass, vertex2coord(n,model), model)
+        add_agent!(grass, p, model)
     end
     return model
 end
@@ -113,7 +113,7 @@ nothing # hide
 function agent_step!(sheep::Sheep, model)
     move!(sheep, model)
     sheep.energy -= 1
-    agents = get_node_agents(sheep.pos, model)
+    agents = [model[a] for a in agents_in_pos(sheep.pos, model)]
     dinner = filter!(x -> isa(x, Grass), agents)
     eat!(sheep, dinner, model)
     if sheep.energy < 0
@@ -128,7 +128,7 @@ end
 function agent_step!(wolf::Wolf, model)
     move!(wolf, model)
     wolf.energy -= 1
-    agents = get_node_agents(wolf.pos, model)
+    agents = [model[a] for a in agents_in_pos(wolf.pos, model)]
     dinner = filter!(x -> isa(x, Sheep), agents)
     eat!(wolf, dinner, model)
     if wolf.energy < 0

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -22,7 +22,7 @@
 # in this model, with a probability given by `reproduction_prob`. The property `Δenergy`
 # controls how much energy is acquired after consuming a food source.
 
-# Grass is a replenishing resource that occupies every cell in the grid space. Grass can be
+# Grass is a replenishing resource that occupies every position in the grid space. Grass can be
 # consumed only if it is `fully_grown`. Once the grass has been consumed, it replenishes
 # after a delay specified by the property `regrowth_time`. The property `countdown` tracks
 # the delay between being consumed and the regrowth time.
@@ -106,7 +106,7 @@ nothing # hide
 
 # The function `agent_step!` is dispatched on each subtype in order to produce
 # type-specific behavior. The `agent_step!` is similar for sheep and wolves: both lose 1
-# energy unit by moving to an adjacent cell and both consume a food source if available.
+# energy unit by moving to an adjacent position and both consume a food source if available.
 # If their energy level is below zero, an agent dies. Otherwise, the agent lives and
 # reproduces with some probability.
 
@@ -157,11 +157,11 @@ function agent_step!(grass::Grass, model)
 end
 nothing # hide
 
-# Sheep and wolves move to a random adjacent cell with the `move!` function.
+# Sheep and wolves move to a random adjacent position with the `move!` function.
 function move!(agent, model)
     neighbors = nearby_positions(agent, model)
-    cell = rand(collect(neighbors))
-    move_agent!(agent, cell, model)
+    position = rand(collect(neighbors))
+    move_agent!(agent, position, model)
 end
 nothing # hide
 

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -60,7 +60,7 @@ nothing # hide
 
 # The function `initialize_model` returns a new model containing sheep, wolves, and grass
 # using a set of pre-defined values (which can be overwritten). The environment is a two
-# dimensional grid space with `moore = true`, which enables animals to walk in all
+# dimensional grid space, which enables animals to walk in all
 # directions. Heterogeneous agents are specified in the model as a `Union`. Agents are
 # scheduled `by_type`, which randomizes the order of agents with the constraint that agents
 # of a particular type are scheduled consecutively.
@@ -75,7 +75,7 @@ function initialize_model(;
     sheep_reproduce = 0.04,
     wolf_reproduce = 0.05,
 )
-    space = GridSpace(dims, moore = true)
+    space = GridSpace(dims, periodic = false)
     model =
         ABM(Union{Sheep,Wolf,Grass}, space, scheduler = by_type(true, true), warn = false)
     id = 0

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -159,7 +159,7 @@ nothing # hide
 
 # Sheep and wolves move to a random adjacent cell with the `move!` function.
 function move!(agent, model)
-    neighbors = node_neighbors(agent, model)
+    neighbors = nearby_positions(agent, model)
     cell = rand(collect(neighbors))
     move_agent!(agent, cell, model)
 end

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -113,7 +113,7 @@ nothing # hide
 function agent_step!(sheep::Sheep, model)
     move!(sheep, model)
     sheep.energy -= 1
-    agents = [model[a] for a in agents_in_pos(sheep.pos, model)]
+    agents = collect(agents_in_position(sheep.pos, model))
     dinner = filter!(x -> isa(x, Grass), agents)
     eat!(sheep, dinner, model)
     if sheep.energy < 0
@@ -128,7 +128,7 @@ end
 function agent_step!(wolf::Wolf, model)
     move!(wolf, model)
     wolf.energy -= 1
-    agents = [model[a] for a in agents_in_pos(wolf.pos, model)]
+    agents = collect(agents_in_position(wolf.pos, model))
     dinner = filter!(x -> isa(x, Sheep), agents)
     eat!(wolf, dinner, model)
     if wolf.energy < 0

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -7,7 +7,7 @@
 # the following definition of Schelling's segregation model:
 
 # * Agents belong to one of two groups (0 or 1).
-# * The agents live in a two-dimensional Moore grid (8 neighbors per position).
+# * The agents live in a two-dimensional Chebyshev grid (8 neighbors per position).
 # * If an agent is in the same group with at least three neighbors, then it is happy.
 # * If an agent is unhappy, it keeps moving to new locations until it is happy.
 
@@ -38,9 +38,9 @@ end
 
 # ## Creating a space
 
-# For this example, we will be using a Moore 2D grid, e.g.
+# For this example, we will be using a Chebyshev 2D grid, e.g.
 
-space = GridSpace((10, 10), moore = true)
+space = GridSpace((10, 10), periodic = false)
 
 # ## Creating an ABM
 
@@ -77,7 +77,7 @@ schelling2 = ABM(
 # it will be of further use in [`paramscan`](@ref) below.
 
 function initialize(; numagents = 320, griddims = (20, 20), min_to_be_happy = 3)
-    space = GridSpace(griddims, moore = true)
+    space = GridSpace(griddims, periodic = false)
     properties = Dict(:min_to_be_happy => min_to_be_happy)
     model = ABM(SchellingAgent, space;
                 properties = properties, scheduler = random_activation)

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -109,11 +109,11 @@ function agent_step!(agent, model)
     ## For each neighbor, get group and compare to current agent's group
     ## and increment count_neighbors_same_group as appropriately.
     for neighbor_pos in neighbor_positions
-        node_contents = get_node_contents(neighbor_pos, model)
+        pos_contents = agents_in_pos(neighbor_pos, model)
         ## Skip iteration if the node is empty.
-        length(node_contents) == 0 && continue
+        length(pos_contents) == 0 && continue
         ## Otherwise, get the first agent in the position...
-        agent_id = node_contents[1]
+        agent_id = pos_contents[1]
         ## ...and increment count_neighbors_same_group if the neighbor's group is
         ## the same.
         neighbor_agent_group = model[agent_id].group
@@ -138,7 +138,7 @@ nothing # hide
 
 # When defining `agent_step!`, we used some of the built-in functions of Agents.jl,
 # such as [`nearby_positions`](@ref) that returns the neighboring position of the
-# position on which the agent resides, [`get_node_contents`](@ref) that returns the
+# position on which the agent resides, [`agents_in_pos`](@ref) that returns the
 # IDs of the agents on a given position, and [`move_agent_single!`](@ref) which moves
 # agents to random empty position on the grid. A full list of built-in functions
 # and their explanations are available in the [API](@ref) page.

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -7,7 +7,7 @@
 # the following definition of Schelling's segregation model:
 
 # * Agents belong to one of two groups (0 or 1).
-# * The agents live in a two-dimensional Moore grid (8 neighbors per node).
+# * The agents live in a two-dimensional Moore grid (8 neighbors per position).
 # * If an agent is in the same group with at least three neighbors, then it is happy.
 # * If an agent is unhappy, it keeps moving to new locations until it is happy.
 
@@ -25,7 +25,7 @@ gr() # hide
 mutable struct SchellingAgent <: AbstractAgent
     id::Int # The identifier number of the agent
     pos::Tuple{Int,Int} # The x, y location of the agent on a 2D grid
-    mood::Bool # whether the agent is happy in its node. (true = happy)
+    mood::Bool # whether the agent is happy in its position. (true = happy)
     group::Int # The group of the agent,  determines mood as it interacts with neighbors
 end
 
@@ -104,15 +104,15 @@ nothing # hide
 function agent_step!(agent, model)
     agent.mood == true && return # do nothing if already happy
     minhappy = model.min_to_be_happy
-    neighbor_cells = node_neighbors(agent, model)
+    neighbor_positions = nearby_positions(agent, model)
     count_neighbors_same_group = 0
     ## For each neighbor, get group and compare to current agent's group
     ## and increment count_neighbors_same_group as appropriately.
-    for neighbor_cell in neighbor_cells
-        node_contents = get_node_contents(neighbor_cell, model)
+    for neighbor_pos in neighbor_positions
+        node_contents = get_node_contents(neighbor_pos, model)
         ## Skip iteration if the node is empty.
         length(node_contents) == 0 && continue
-        ## Otherwise, get the first agent in the node...
+        ## Otherwise, get the first agent in the position...
         agent_id = node_contents[1]
         ## ...and increment count_neighbors_same_group if the neighbor's group is
         ## the same.
@@ -123,7 +123,7 @@ function agent_step!(agent, model)
     end
     ## After counting the neighbors, decide whether or not to move the agent.
     ## If count_neighbors_same_group is at least the min_to_be_happy, set the
-    ## mood to true. Otherwise, move the agent to a random node.
+    ## mood to true. Otherwise, move the agent to a random position.
     if count_neighbors_same_group ≥ minhappy
         agent.mood = true
     else
@@ -137,10 +137,10 @@ nothing # hide
 # we only need an agent step function.
 
 # When defining `agent_step!`, we used some of the built-in functions of Agents.jl,
-# such as [`node_neighbors`](@ref) that returns the neighboring nodes of the
-# node on which the agent resides, [`get_node_contents`](@ref) that returns the
-# IDs of the agents on a given node, and [`move_agent_single!`](@ref) which moves
-# agents to random empty nodes on the grid. A full list of built-in functions
+# such as [`nearby_positions`](@ref) that returns the neighboring position of the
+# position on which the agent resides, [`get_node_contents`](@ref) that returns the
+# IDs of the agents on a given position, and [`move_agent_single!`](@ref) which moves
+# agents to random empty position on the grid. A full list of built-in functions
 # and their explanations are available in the [API](@ref) page.
 
 # ## Stepping the model

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -109,7 +109,7 @@ function agent_step!(agent, model)
     ## For each neighbor, get group and compare to current agent's group
     ## and increment count_neighbors_same_group as appropriately.
     for neighbor_pos in neighbor_positions
-        pos_contents = agents_in_pos(neighbor_pos, model)
+        pos_contents = ids_in_position(neighbor_pos, model)
         ## Skip iteration if the position is empty.
         length(pos_contents) == 0 && continue
         ## Otherwise, get the first agent in the position...
@@ -138,7 +138,7 @@ nothing # hide
 
 # When defining `agent_step!`, we used some of the built-in functions of Agents.jl,
 # such as [`nearby_positions`](@ref) that returns the neighboring position
-# on which the agent resides, [`agents_in_pos`](@ref) that returns the
+# on which the agent resides, [`ids_in_position`](@ref) that returns the
 # IDs of the agents on a given position, and [`move_agent_single!`](@ref) which moves
 # agents to random empty position on the grid. A full list of built-in functions
 # and their explanations are available in the [API](@ref) page.

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -110,7 +110,7 @@ function agent_step!(agent, model)
     ## and increment count_neighbors_same_group as appropriately.
     for neighbor_pos in neighbor_positions
         pos_contents = agents_in_pos(neighbor_pos, model)
-        ## Skip iteration if the node is empty.
+        ## Skip iteration if the position is empty.
         length(pos_contents) == 0 && continue
         ## Otherwise, get the first agent in the position...
         agent_id = pos_contents[1]

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -137,8 +137,8 @@ nothing # hide
 # we only need an agent step function.
 
 # When defining `agent_step!`, we used some of the built-in functions of Agents.jl,
-# such as [`nearby_positions`](@ref) that returns the neighboring position of the
-# position on which the agent resides, [`agents_in_pos`](@ref) that returns the
+# such as [`nearby_positions`](@ref) that returns the neighboring position
+# on which the agent resides, [`agents_in_pos`](@ref) that returns the
 # IDs of the agents on a given position, and [`move_agent_single!`](@ref) which moves
 # agents to random empty position on the grid. A full list of built-in functions
 # and their explanations are available in the [API](@ref) page.

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -216,10 +216,10 @@ function agent_step!(agent, model)
 end
 
 function migrate!(agent, model)
-    nodeid = agent.pos
-    d = DiscreteNonParametric(1:(model.C), model.migration_rates[nodeid, :])
+    pid = agent.pos
+    d = DiscreteNonParametric(1:(model.C), model.migration_rates[pid, :])
     m = rand(d)
-    if m ≠ nodeid
+    if m ≠ pid
         move_agent!(agent, m, model)
     end
 end

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -1,7 +1,8 @@
 # # SIR model for the spread of COVID-19
 # ![](covid_evolution.gif)
+#
 # This example illustrates how to use `GraphSpace` and how to model agents on an graph
-# (network) where the transition probabilities between each node is not constant.
+# (network) where the transition probabilities between each node (position) is not constant.
 # ## SIR model
 
 # A SIR model tracks the ratio of Susceptible, Infected, and Recovered individuals within a population.

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -101,7 +101,7 @@ function model_initiation(;
     end
     ## add infected individuals
     for city in 1:C
-        inds = get_node_contents(city, model)
+        inds = agents_in_pos(city, model)
         for n in 1:Is[city]
             agent = model[inds[n]]
             agent.status = :I # Infected
@@ -236,7 +236,7 @@ function transmit!(agent, model)
     n = rand(d)
     n == 0 && return
 
-    for contactID in get_node_contents(agent, model)
+    for contactID in agents_in_pos(agent, model)
         contact = model[contactID]
         if contact.status == :S ||
            (contact.status == :R && rand() ≤ model.reinfection_probability)

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -301,7 +301,7 @@ p = plot(
     log10.(data[:, aggname(:status, infected)]),
     label = "infected",
     xlabel = "steps",
-    ylabel = "log(count)",
+    ylabel = "log10(count)",
 )
 plot!(p, x, log10.(data[:, aggname(:status, recovered)]), label = "recovered")
 dead = log10.(N .- data[:, aggname(:status, length)])

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -102,7 +102,7 @@ function model_initiation(;
     end
     ## add infected individuals
     for city in 1:C
-        inds = agents_in_pos(city, model)
+        inds = ids_in_position(city, model)
         for n in 1:Is[city]
             agent = model[inds[n]]
             agent.status = :I # Infected
@@ -237,7 +237,7 @@ function transmit!(agent, model)
     n = rand(d)
     n == 0 && return
 
-    for contactID in agents_in_pos(agent, model)
+    for contactID in ids_in_position(agent, model)
         contact = model[contactID]
         if contact.status == :S ||
            (contact.status == :R && rand() ≤ model.reinfection_probability)

--- a/examples/siroptim.jl
+++ b/examples/siroptim.jl
@@ -59,7 +59,7 @@ function model_initiation(;
     end
     # add infected individuals
     for city in 1:C
-        inds = get_node_contents(city, model)
+        inds = agents_in_pos(city, model)
         for n in 1:Is[city]
             agent = model[inds[n]]
             agent.status = :I # Infected
@@ -97,7 +97,7 @@ function transmit!(agent, model)
     n = rand(d)
     n == 0 && return
 
-    for contactID in get_node_contents(agent, model)
+    for contactID in agents_in_pos(agent, model)
         contact = model[contactID]
         if contact.status == :S ||
            (contact.status == :R && rand() ≤ model.reinfection_probability)

--- a/examples/siroptim.jl
+++ b/examples/siroptim.jl
@@ -59,7 +59,7 @@ function model_initiation(;
     end
     # add infected individuals
     for city in 1:C
-        inds = agents_in_pos(city, model)
+        inds = ids_in_position(city, model)
         for n in 1:Is[city]
             agent = model[inds[n]]
             agent.status = :I # Infected
@@ -97,7 +97,7 @@ function transmit!(agent, model)
     n = rand(d)
     n == 0 && return
 
-    for contactID in agents_in_pos(agent, model)
+    for contactID in ids_in_position(agent, model)
         contact = model[contactID]
         if contact.status == :S ||
            (contact.status == :R && rand() ≤ model.reinfection_probability)

--- a/examples/siroptim.jl
+++ b/examples/siroptim.jl
@@ -77,10 +77,10 @@ function agent_step!(agent, model)
 end
 
 function migrate!(agent, model)
-    nodeid = agent.pos
-    d = DiscreteNonParametric(1:(model.C), model.migration_rates[nodeid, :])
+    pid = agent.pos
+    d = DiscreteNonParametric(1:(model.C), model.migration_rates[pid, :])
     m = rand(d)
-    if m ≠ nodeid
+    if m ≠ pid
         move_agent!(agent, m, model)
     end
 end

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -55,7 +55,7 @@ model = ball_model()
 
 # We took advantage of the functionality of [`add_agent!`](@ref) that creates the
 # agents automatically. For now all agents have the same absolute `speed`, and `mass`.
-# We `index!` the model, to make finding space neighbors faster.
+# We `index!` the model, to make finding nearby agents faster.
 
 # The agent step function for now is trivial. It is just [`move_agent!`](@ref) in
 # continuous space

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -246,7 +246,7 @@ sir_model = sir_initiation()
 
 sir_colors(a) = a.status == :S ? "#2b2b33" : a.status == :I ? "#bf2642" : "#338c54"
 
-e = model.space.extend
+e = sir_model.space.extend
 plotabm(
     sir_model;
     ac = sir_colors,
@@ -316,7 +316,7 @@ nothing # hide
 
 sir_model = sir_initiation()
 
-e = model.space.extend
+e = sir_model.space.extend
 anim = @animate for i in 1:2:100
     p1 = plotabm(
         sir_model;
@@ -382,7 +382,7 @@ p
 
 sir_model = sir_initiation(isolated = 0.8)
 
-e = model.space.extend
+e = sir_model.space.extend
 anim = @animate for i in 0:2:1000
     p1 = plotabm(
         sir_model;

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -169,14 +169,14 @@ function movement!(agent, model)
     newsite = agent.pos
     ## find all unoccupied position within vision
     neighbors = nearby_positions(agent.pos, model, agent.vision)
-    empty_positions = [i for i in neighbors if isempty(i, model)]
-    if length(empty_positions) > 0
+    empty = collect(empty_positions(model))
+    if length(empty) > 0
         ## identify the one(s) with greatest amount of sugar
-        available_sugar = (model.sugar_values[x,y] for (x, y) in empty_positions)
+        available_sugar = (model.sugar_values[x,y] for (x, y) in empty)
         maxsugar = maximum(available_sugar)
         if maxsugar > 0
             sugary_sites_inds = findall(x -> x == maxsugar, collect(available_sugar))
-            sugary_sites = empty_positions[sugary_sites_inds]
+            sugary_sites = empty[sugary_sites_inds]
             ## select the nearest one (randomly if more than one)
             for dia in 1:(agent.vision)
                 np = nearby_positions(agent.pos, model, dia)

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -14,34 +14,34 @@
 
 # ### Environment
 
-# The environment is a 50×50 grid that wraps around forming a torus. Grid cells have both a sugar level and a sugar capacity c. A cell's sugar level is the number of units of sugar in the cell (potentially none), and its sugar capacity c is the maximum value the sugar level can take on that cell. Sugar capacity is fixed for each individual cell and may be different for different cells. The spatial distribution of sugar capacities depicts a sugar topography consisting of two peaks (with sugar capacity c = 4) separated by a valley, and surrounded by a desert region of sugarless cells (see Figure 1) - note, however, that the grid wraps around in both directions–.
+# The environment is a 50×50 grid that wraps around forming a torus. Grid positions have both a sugar level and a sugar capacity c. A cell's sugar level is the number of units of sugar in the cell (potentially none), and its sugar capacity c is the maximum value the sugar level can take on that cell. Sugar capacity is fixed for each individual cell and may be different for different cells. The spatial distribution of sugar capacities depicts a sugar topography consisting of two peaks (with sugar capacity c = 4) separated by a valley, and surrounded by a desert region of sugarless cells (see Figure 1) - note, however, that the grid wraps around in both directions–.
 
 # ![Fig. 1: Spatial distribution of sugar capacities in the Sugarscape. Cells are coloured according to their sugar capacity.](capacities.jpg)
 
 # The Sugarscape obbeys the following rule:
 
 # Sugarscape growback rule G$\alpha$:
-#     At each cell, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
+#     At each position, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
 
 # ### Agents
 
 # Every agent is endowed with individual (life-long) characteristics that condition her skills and capacities to survive in the Sugarscape. These individual attributes are:
 
-# * A vision _v_, which is the maximum number of cells the agent can see in each of the four principal lattice directions: north, south, east and west.
+# * A vision _v_, which is the maximum number of positions the agent can see in each of the four principal lattice directions: north, south, east and west.
 # * A metabolic rate _m_, which represents the units of sugar the agent burns per time-step.
 # * A maximum age _max-age_, which is the maximum number of time-steps the agent can live.
 
-# Agents also have the capacity to accumulate sugar wealth _w_. An agent's sugar wealth is incremented at the end of each time-step by the sugar collected and decremented by the agent's metabolic rate. __Two agents are not allowed to occupy the same cell in the grid.__
+# Agents also have the capacity to accumulate sugar wealth _w_. An agent's sugar wealth is incremented at the end of each time-step by the sugar collected and decremented by the agent's metabolic rate. __Two agents are not allowed to occupy the same position in the grid.__
 
 # The agents' behaviour is determined by the following two rules:
 
 # #### Agent movement rule _M_:
 
-# Consider the set of unoccupied cells within your vision (including the one you are standing on), identify the one(s) with the greatest amount of sugar, select the nearest one (randomly if there is more than one), move there and collect all the sugar in it. At this point, the agent's accumulated sugar wealth is incremented by the sugar collected and decremented by the agent's metabolic rate _m_. If at this moment the agent's sugar wealth is not greater than zero, then the agent dies.
+# Consider the set of unoccupied positions within your vision (including the one you are standing on), identify the one(s) with the greatest amount of sugar, select the nearest one (randomly if there is more than one), move there and collect all the sugar in it. At this point, the agent's accumulated sugar wealth is incremented by the sugar collected and decremented by the agent's metabolic rate _m_. If at this moment the agent's sugar wealth is not greater than zero, then the agent dies.
 
 # #### Agent replacement rule _R_:
 
-# Whenever an agent dies it is replaced by a new agent of age 0 placed on a randomly chosen unoccupied cell, having random attributes _v_, _m_ and _max-age_, and random initial wealth w0. All random numbers are drawn from uniform distributions with ranges specified in Table 1 below.
+# Whenever an agent dies it is replaced by a new agent of age 0 placed on a randomly chosen unoccupied position, having random attributes _v_, _m_ and _max-age_, and random initial wealth w0. All random numbers are drawn from uniform distributions with ranges specified in Table 1 below.
 
 # ### Scheduling of events
 
@@ -51,7 +51,7 @@
 
 # Our analysis corresponds to a model used by Epstein & Axtell (1996, pg. 33) to study the emergent wealth distribution in the agent population. This model is parameterised as indicated in Table 1 below (where U[a,b] denotes a uniform distribution with range [a,b]).
 
-# Initially, each cell of the Sugarscape contains a sugar level equal to its sugar capacity c, and the 250 agents are created at a random unoccupied initial location and with random attributes (using the uniform distributions indicated in Table 1).
+# Initially, each position of the Sugarscape contains a sugar level equal to its sugar capacity c, and the 250 agents are created at a random unoccupied initial location and with random attributes (using the uniform distributions indicated in Table 1).
 
 # __Table 1__
 
@@ -158,7 +158,7 @@ savefig("capacities.jpg")
 #
 
 function env!(model)
-    ## At each cell, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
+    ## At each position, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
     togrow = findall(
         x -> model.sugar_values[x] < model.sugar_capacities[x],
         1:prod(model.space.dimensions),
@@ -169,8 +169,8 @@ end
 function movement!(agent, model)
     posvertex = coord2vertex(agent.pos, model)
     newsite = posvertex
-    ## find all unoccupied cells within vision
-    neighbors = nearby_positions(coord2vertex(agent.pos, model), model, agent.vision)
+    ## find all unoccupied position within vision
+    neighbors = nearby_positions(agent.pos, model, agent.vision)
     empty_positions = [i for i in neighbors if isempty(i, model)]
     if length(empty_positions) > 0
         ## identify the one(s) with greatest amount of sugar

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -153,7 +153,6 @@ model = sugarscape()
 # Fig. 1: Spatial distribution of sugar capacities in the Sugarscape. Cells are coloured according to their sugar capacity.
 
 heatmap(model.sugar_capacities)
-savefig("capacities.jpg")
 
 #
 
@@ -161,26 +160,26 @@ function env!(model)
     ## At each position, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
     togrow = findall(
         x -> model.sugar_values[x] < model.sugar_capacities[x],
-        1:prod(model.space.dimensions),
+        1:length(positions(model)),
     )
     model.sugar_values[togrow] .+= model.growth_rate
 end
 
 function movement!(agent, model)
-    posvertex = coord2vertex(agent.pos, model)
-    newsite = posvertex
+    newsite = agent.pos
     ## find all unoccupied position within vision
     neighbors = nearby_positions(agent.pos, model, agent.vision)
     empty_positions = [i for i in neighbors if isempty(i, model)]
     if length(empty_positions) > 0
         ## identify the one(s) with greatest amount of sugar
-        maxsugar = maximum(model.sugar_values[empty_positions])
+        available_sugar = (model.sugar_values[x,y] for (x, y) in empty_positions)
+        maxsugar = maximum(available_sugar)
         if maxsugar > 0
-            sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_positions])
+            sugary_sites_inds = findall(x -> x == maxsugar, collect(available_sugar))
             sugary_sites = empty_positions[sugary_sites_inds]
             ## select the nearest one (randomly if more than one)
             for dia in 1:(agent.vision)
-                np = nearby_positions(posvertex, model, dia)
+                np = nearby_positions(agent.pos, model, dia)
                 suitable = intersect(np, sugary_sites)
                 if length(suitable) > 0
                     newsite = rand(suitable)
@@ -188,12 +187,12 @@ function movement!(agent, model)
                 end
             end
             ## move there and collect all the sugar in it
-            newsite != posvertex && move_agent!(agent, newsite, model)
+            newsite != agent.pos && move_agent!(agent, newsite, model)
         end
     end
     ## update wealth (collected - consumed)
-    agent.wealth += (model.sugar_values[newsite] - agent.metabolic_rate)
-    model.sugar_values[newsite] = 0
+    agent.wealth += (model.sugar_values[newsite...] - agent.metabolic_rate)
+    model.sugar_values[newsite...] = 0
     ## age
     agent.age += 1
 end
@@ -246,6 +245,7 @@ anim2 = @animate for i in 0:20
         title = "step $i",
     )
 end
+nothing # hide
 
 # We see that the distribution of wealth shifts from a more or less uniform distribution to a skewed distribution.
 

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -1,4 +1,5 @@
-# # Sugarscape: growing artificial societies
+# # Sugarscape
+# **Growing Artificial Societies**
 
 # ![](sugar.gif)
 

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -118,7 +118,7 @@ function sugarscape(;
 )
     sugar_capacities = sugar_caps(dims, sugar_peaks, max_sugar, 6)
     sugar_values = deepcopy(sugar_capacities)
-    space = GridSpace(dims, periodic = true, moore = true)
+    space = GridSpace(dims)
     properties = Dict(
         :growth_rate => growth_rate,
         :N => N,

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -170,18 +170,18 @@ function movement!(agent, model)
     posvertex = coord2vertex(agent.pos, model)
     newsite = posvertex
     ## find all unoccupied cells within vision
-    neighbors = node_neighbors(coord2vertex(agent.pos, model), model, agent.vision)
-    empty_nodes = [i for i in neighbors if isempty(i, model)]
-    if length(empty_nodes) > 0
+    neighbors = nearby_positions(coord2vertex(agent.pos, model), model, agent.vision)
+    empty_positions = [i for i in neighbors if isempty(i, model)]
+    if length(empty_positions) > 0
         ## identify the one(s) with greatest amount of sugar
-        maxsugar = maximum(model.sugar_values[empty_nodes])
+        maxsugar = maximum(model.sugar_values[empty_positions])
         if maxsugar > 0
-            sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_nodes])
-            sugary_sites = empty_nodes[sugary_sites_inds]
+            sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_positions])
+            sugary_sites = empty_positions[sugary_sites_inds]
             ## select the nearest one (randomly if more than one)
             for dia in 1:(agent.vision)
-                nn = node_neighbors(posvertex, model, dia)
-                suitable = intersect(nn, sugary_sites)
+                np = nearby_positions(posvertex, model, dia)
+                suitable = intersect(np, sugary_sites)
                 if length(suitable) > 0
                     newsite = rand(suitable)
                     break

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -102,8 +102,8 @@ function agent_step_2d!(agent, model)
     agent_node = coord2vertex(agent.pos, model)
     neighboring_positions = nearby_positions(agent_node, model)
     push!(neighboring_positions, agent_node) # also consider current position
-    rnode = rand(neighboring_positions) # the position that we will exchange with
-    available_ids = get_node_contents(rnode, model)
+    rpos = rand(neighboring_positions) # the position that we will exchange with
+    available_ids = agents_in_pos(rpos, model)
     if length(available_ids) > 0
         random_neighbor_agent = model[rand(available_ids)]
         agent.wealth -= 1

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -102,7 +102,7 @@ function agent_step_2d!(agent, model)
     neighboring_positions = collect(nearby_positions(agent.pos, model))
     push!(neighboring_positions, agent.pos) # also consider current position
     rpos = rand(neighboring_positions) # the position that we will exchange with
-    available_ids = agents_in_pos(rpos, model)
+    available_ids = ids_in_position(rpos, model)
     if length(available_ids) > 0
         random_neighbor_agent = model[rand(available_ids)]
         agent.wealth -= 1

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -85,7 +85,7 @@ end
 function wealth_model_2D(; dims = (25, 25), wealth = 1, M = 1000)
     space = GridSpace(dims, periodic = true)
     model = ABM(WealthInSpace, space; scheduler = random_activation)
-    for i in 1:M # add agents in random nodes
+    for i in 1:M # add agents in random positions
         add_agent!(model, wealth)
     end
     return model
@@ -95,13 +95,12 @@ model2D = wealth_model_2D()
 
 # The agent actions are a just a bit more complicated in this example.
 # Now the agents can only give wealth to agents that exist on the same or
-# neighboring nodes (their "neighbors").
+# neighboring positions (their "neighbors").
 
 function agent_step_2d!(agent, model)
     agent.wealth == 0 && return # do nothing
-    agent_node = coord2vertex(agent.pos, model)
-    neighboring_positions = nearby_positions(agent_node, model)
-    push!(neighboring_positions, agent_node) # also consider current position
+    neighboring_positions = nearby_positions(agent.pos, model)
+    push!(neighboring_positions, agent.pos) # also consider current position
     rpos = rand(neighboring_positions) # the position that we will exchange with
     available_ids = agents_in_pos(rpos, model)
     if length(available_ids) > 0

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -99,7 +99,7 @@ model2D = wealth_model_2D()
 
 function agent_step_2d!(agent, model)
     agent.wealth == 0 && return # do nothing
-    neighboring_positions = nearby_positions(agent.pos, model)
+    neighboring_positions = collect(nearby_positions(agent.pos, model))
     push!(neighboring_positions, agent.pos) # also consider current position
     rpos = rand(neighboring_positions) # the position that we will exchange with
     available_ids = agents_in_pos(rpos, model)

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -100,9 +100,9 @@ model2D = wealth_model_2D()
 function agent_step_2d!(agent, model)
     agent.wealth == 0 && return # do nothing
     agent_node = coord2vertex(agent.pos, model)
-    neighboring_nodes = node_neighbors(agent_node, model)
-    push!(neighboring_nodes, agent_node) # also consider current node
-    rnode = rand(neighboring_nodes) # the node that we will exchange with
+    neighboring_positions = nearby_positions(agent_node, model)
+    push!(neighboring_positions, agent_node) # also consider current position
+    rnode = rand(neighboring_positions) # the position that we will exchange with
     available_ids = get_node_contents(rnode, model)
     if length(available_ids) > 0
         random_neighbor_agent = model[rand(available_ids)]

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -27,6 +27,7 @@ include("simulations/sample.jl")
 
 # 4.0 Depreciations
 @deprecate space_neighbors nearby_agents
+@deprecate node_neighbors nearby_positions
 
 # Predefined models
 include("models/Models.jl")

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -25,6 +25,9 @@ include("simulations/collect.jl")
 include("simulations/paramscan.jl")
 include("simulations/sample.jl")
 
+# 4.0 Depreciations
+@deprecate space_neighbors nearby_agents
+
 # Predefined models
 include("models/Models.jl")
 export Models

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -28,7 +28,8 @@ include("simulations/sample.jl")
 # 4.0 Depreciations
 @deprecate space_neighbors nearby_ids
 @deprecate node_neighbors nearby_positions
-@deprecate get_node_contents agents_in_pos
+@deprecate get_node_contents ids_in_position
+@deprecate get_node_agents agents_in_position
 @deprecate pick_empty random_empty
 @deprecate find_empty_nodes empty_positions
 @deprecate has_empty_nodes has_empty_positions

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -28,6 +28,7 @@ include("simulations/sample.jl")
 # 4.0 Depreciations
 @deprecate space_neighbors nearby_agents
 @deprecate node_neighbors nearby_positions
+@deprecate get_node_contents agents_in_pos
 
 # Predefined models
 include("models/Models.jl")

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -26,7 +26,7 @@ include("simulations/paramscan.jl")
 include("simulations/sample.jl")
 
 # 4.0 Depreciations
-@deprecate space_neighbors nearby_agents
+@deprecate space_neighbors nearby_ids
 @deprecate node_neighbors nearby_positions
 @deprecate get_node_contents agents_in_pos
 @deprecate pick_empty random_empty

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -30,6 +30,8 @@ include("simulations/sample.jl")
 @deprecate node_neighbors nearby_positions
 @deprecate get_node_contents agents_in_pos
 @deprecate pick_empty random_empty
+@deprecate find_empty_nodes empty_positions
+@deprecate has_empty_nodes has_empty_positions
 
 # Predefined models
 include("models/Models.jl")

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -32,6 +32,7 @@ include("simulations/sample.jl")
 @deprecate pick_empty random_empty
 @deprecate find_empty_nodes empty_positions
 @deprecate has_empty_nodes has_empty_positions
+@deprecate nodes positions
 
 # Predefined models
 include("models/Models.jl")

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -29,6 +29,7 @@ include("simulations/sample.jl")
 @deprecate space_neighbors nearby_agents
 @deprecate node_neighbors nearby_positions
 @deprecate get_node_contents agents_in_pos
+@deprecate pick_empty random_empty
 
 # Predefined models
 include("models/Models.jl")

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -82,7 +82,7 @@ to agents. Use `model[id]` to get the agent with the given `id`.
 
 `space` is a subtype of `AbstractSpace`: [`GraphSpace`](@ref), [`GridSpace`](@ref) or
 [`ContinuousSpace`](@ref).
-If it is ommited then all agents are virtually in one node and have no spatial structure.
+If it is ommited then all agents are virtually in one position and have no spatial structure.
 
 **Note:** Spaces are mutable objects and are not designed to be shared between models.
 Create a fresh instance of a space with the same properties if you need to do this.

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -84,14 +84,13 @@ neighbors depending on the underlying graph directionality type.
 nearby_ids(position, model, r=1) = notimplemented(model)
 
 """
-    nearby_agents(agent, model::ABM, r=1; kwargs...) -> agent
+    nearby_agents(agent, model::ABM, args...; kwargs...) -> agent
 
-Return an iterable of the agents within the "radius" `r` of the position of the given
-`agent`.
+Return an iterable of the agents near the position of the given `agent`.
 
-The value of `r` and possible keywords operate identically to [`nearby_ids`](@ref).
+The value of the argument `r` and possible keywords operate identically to [`nearby_ids`](@ref).
 """
-nearby_agents(a, model, r=1) = (model[id] for id in nearby_ids(a, model, r))
+nearby_agents(a, model, args...; kwargs...) = (model[id] for id in nearby_ids(a, model, args...; kwargs...))
 
 """
     nearby_positions(position, model::ABM, r=1; kwargs...) → positions

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -16,6 +16,7 @@ export move_agent!,
     genocide!,
     random_position,
     nearby_positions,
+    nearby_ids,
     nearby_agents
 
 notimplemented(model) = error("Not implemented for space type $(nameof(typeof(model.space)))")
@@ -59,7 +60,7 @@ remove_agent_from_space!(agent, model) = notimplemented(model)
 # %% IMPLEMENT: Neighbors and stuff
 #######################################################################################
 """
-    nearby_agents(position, model::ABM, r=1; kwargs...) → ids
+    nearby_ids(position, model::ABM, r=1; kwargs...) → ids
 
 Return an iterable of the ids of the agents within "radius" `r` of the given `position`
 (which must match type with the spatial structure of the `model`).
@@ -80,8 +81,17 @@ neighbors depending on the underlying graph directionality type.
 - `:in` returns incoming vertex neighbors.
 - `:out` returns outgoing vertex neighbors.
 """
-nearby_agents(position, model, r=1) = notimplemented(model)
+nearby_ids(position, model, r=1) = notimplemented(model)
 
+"""
+    nearby_agents(agent, model::ABM, r=1; kwargs...) -> agent
+
+Return an iterable of the agents within the "radius" `r` of the position of the given
+`agent`.
+
+The value of `r` and possible keywords operate identically to [`nearby_ids`](@ref).
+"""
+nearby_agents(a, model, r=1) = (model[id] for id in nearby_ids(a, model, r))
 
 """
     nearby_positions(position, model::ABM, r=1; kwargs...) → positions
@@ -90,7 +100,7 @@ Return an iterable of all positions within "radius" `r` of the given `position`
 (which excludes given `position`).
 The `position` must match type with the spatial structure of the `model`).
 
-The value of `r` and possible keywords operate identically to [`nearby_agents`](@ref).
+The value of `r` and possible keywords operate identically to [`nearby_ids`](@ref).
 """
 nearby_positions(position, model, r=1) = notimplemented(model)
 
@@ -249,15 +259,14 @@ end
 # %% Space agnostic neighbors
 #######################################################################################
 """
-    nearby_agents(agent::AbstractAgent, model::ABM, r=1)
+    nearby_ids(agent::AbstractAgent, model::ABM, r=1)
 
-Same as `nearby_agents(agent.pos, model, r)` but the iterable *excludes* the given
+Same as `nearby_ids(agent.pos, model, r)` but the iterable *excludes* the given
 `agent`'s id.
 """
-function nearby_agents(agent::A, model::ABM{A}, args...; kwargs...) where {A<:AbstractAgent}
-    all = nearby_agents(agent.pos, model, args...; kwargs...)
-    id::Int = agent.id
-    Iterators.filter(i -> i ≠ id, all)
+function nearby_ids(agent::A, model::ABM{A}, args...; kwargs...) where {A<:AbstractAgent}
+    all = nearby_ids(agent.pos, model, args...; kwargs...)
+    Iterators.filter(i -> i ≠ agent.id, all)
 end
 
 """

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -224,7 +224,7 @@ model = ABM(Agent, GraphSpace(complete_digraph(5)))
 
 add_agent!(model, 1, 0.5, true) # incorrect: id/pos is set internally
 add_agent!(model, 0.5, true) # correct: w becomes 0.5
-add_agent!(5, model, 0.5, true) # add at node 5, w becomes 0.5
+add_agent!(5, model, 0.5, true) # add at position 5, w becomes 0.5
 add_agent!(model; w = 0.5) # use keywords: w becomes 0.5, k becomes false
 ```
 """

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -16,7 +16,7 @@ export move_agent!,
     genocide!,
     random_position,
     node_neighbors,
-    space_neighbors
+    nearby_agents
 
 notimplemented(model) = error("Not implemented for space type $(nameof(typeof(model.space)))")
 
@@ -59,7 +59,7 @@ remove_agent_from_space!(agent, model) = notimplemented(model)
 # %% IMPLEMENT: Neighbors and stuff
 #######################################################################################
 """
-    space_neighbors(position, model::ABM, r=1; kwargs...) → ids
+    nearby_agents(position, model::ABM, r=1; kwargs...) → ids
 
 Return an iterator of the ids of the agents within "radius" `r` of the given `position`
 (which must match type with the spatial structure of the `model`).
@@ -80,7 +80,7 @@ neighbors depending on the underlying graph directionality type.
 - `:in` returns incoming vertex neighbors.
 - `:out` returns outgoing vertex neighbors.
 """
-space_neighbors(position, model, r=1) = notimplemented(model)
+nearby_agents(position, model, r=1) = notimplemented(model)
 
 
 """
@@ -90,7 +90,7 @@ Return an iterator of all positions within "radius" `r` of the given `position`
 (which excludes given `position`).
 The `position` must match type with the spatial structure of the `model`).
 
-The value of `r` and possible keywords operate identically to [`space_neighbors`](@ref).
+The value of `r` and possible keywords operate identically to [`nearby_agents`](@ref).
 """
 node_neighbors(position, model, r=1) = notimplemented(model)
 
@@ -249,13 +249,13 @@ end
 # %% Space agnostic neighbors
 #######################################################################################
 """
-    space_neighbors(agent::AbstractAgent, model::ABM, r=1)
+    nearby_agents(agent::AbstractAgent, model::ABM, r=1)
 
-Same as `space_neighbors(agent.pos, model, r)` but the iterator *excludes* the given
+Same as `nearby_agents(agent.pos, model, r)` but the iterator *excludes* the given
 `agent`'s id.
 """
-function space_neighbors(agent::A, model::ABM{A}, args...; kwargs...) where {A<:AbstractAgent}
-    all = space_neighbors(agent.pos, model, args...; kwargs...)
+function nearby_agents(agent::A, model::ABM{A}, args...; kwargs...) where {A<:AbstractAgent}
+    all = nearby_agents(agent.pos, model, args...; kwargs...)
     id::Int = agent.id
     Iterators.filter(i -> i ≠ id, all)
 end

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -74,7 +74,7 @@ What the "radius" means depends on the space type:
 Keyword arguments are space-specific.
 For `GraphSpace` the keyword `neighbor_type=:default` can be used to select differing
 neighbors depending on the underlying graph directionality type.
-- `:default` returns neighbors of a vertex. If graph is directed, this is equivalent
+- `:default` returns neighbors of a vertex (position). If graph is directed, this is equivalent
   to `:out`. For undirected graphs, all options are equivalent to `:out`.
 - `:all` returns both `:in` and `:out` neighbors.
 - `:in` returns incoming vertex neighbors.

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -15,7 +15,7 @@ export move_agent!,
     kill_agents!,
     genocide!,
     random_position,
-    node_neighbors,
+    nearby_positions,
     nearby_agents
 
 notimplemented(model) = error("Not implemented for space type $(nameof(typeof(model.space)))")
@@ -84,7 +84,7 @@ nearby_agents(position, model, r=1) = notimplemented(model)
 
 
 """
-    node_neighbors(position, model::ABM, r=1; kwargs...) → positions
+    nearby_positions(position, model::ABM, r=1; kwargs...) → positions
 
 Return an iterator of all positions within "radius" `r` of the given `position`
 (which excludes given `position`).
@@ -92,7 +92,7 @@ The `position` must match type with the spatial structure of the `model`).
 
 The value of `r` and possible keywords operate identically to [`nearby_agents`](@ref).
 """
-node_neighbors(position, model, r=1) = notimplemented(model)
+nearby_positions(position, model, r=1) = notimplemented(model)
 
 
 
@@ -261,10 +261,10 @@ function nearby_agents(agent::A, model::ABM{A}, args...; kwargs...) where {A<:Ab
 end
 
 """
-    node_neighbors(agent::AbstractAgent, model::ABM, r=1)
+    nearby_positions(agent::AbstractAgent, model::ABM, r=1)
 
-Same as `node_neighbors(agent.pos, model, r)`.
+Same as `nearby_positions(agent.pos, model, r)`.
 """
-function node_neighbors(agent::A, model::ABM{A}, args...; kwargs...) where {A<:AbstractAgent}
-    node_neighbors(agent.pos, model, args...; kwargs...)
+function nearby_positions(agent::A, model::ABM{A}, args...; kwargs...) where {A<:AbstractAgent}
+    nearby_positions(agent.pos, model, args...; kwargs...)
 end

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -111,7 +111,7 @@ end
 
 function diffuse_temperature!(node::Int, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
-    ids = space_neighbors(node, model)
+    ids = nearby_agents(node, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
     land = model[get_node_contents(node, model)[1]] # land at current node
     ## Each neighbor land patch is giving up 1/8 of the diffused

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -71,10 +71,10 @@ function daisyworld(;
         scheduler = daisysched, properties = properties, warn = false
     )
 
-    ## fill model with `Land`: every grid cell has 1 land instance
+    ## fill model with `Land`: every grid position has 1 land instance
     fill_space!(Land, model, 0.0) # zero starting temperature
 
-    ## Populate with daisies: each cell has only one daisy (black or white)
+    ## Populate with daisies: each position has only one daisy (black or white)
     white_positions = StatsBase.sample(1:nv(space), Int(init_white * nv(space)); replace = false)
     for wp in white_positions
         wd = Daisy(nextid(model), wp, :white, rand(0:max_age), albedo_white)
@@ -127,7 +127,7 @@ function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
         ## Set optimum growth rate to 22.5 ᵒC, with bounds of [5, 40]
         seed_threshold = (0.1457 * temperature - 0.0032 * temperature^2) - 0.6443
         if rand() < seed_threshold
-            ## Collect all adjacent cells that have no daisies
+            ## Collect all adjacent position that have no daisies
             empty_neighbors = Int[]
             neighbors = nearby_positions(pos, model)
             for n in neighbors
@@ -136,8 +136,8 @@ function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
                 end
             end
             if !isempty(empty_neighbors)
-                ## Seed a new daisy in one of those cells
-                seeding_place = vertex2coord(rand(empty_neighbors), model)
+                ## Seed a new daisy in one of those position
+                seeding_place = rand(empty_neighbors)
                 a = Daisy(nextid(model), seeding_place, daisy.breed, 0, daisy.albedo)
                 add_agent_pos!(a, model)
             end

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -129,7 +129,7 @@ function propagate!(node::Int, model::DaisyWorld)
         if rand() < seed_threshold
             ## Collect all adjacent cells that have no daisies
             empty_neighbors = Int[]
-            neighbors = node_neighbors(node, model)
+            neighbors = nearby_positions(node, model)
             for n in neighbors
                 if length(get_node_contents(n, model)) == 1
                     push!(empty_neighbors, n)

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -93,7 +93,7 @@ function daisyworld(;
 end
 
 function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
-    ids = agents_in_pos(pos, model)
+    ids = ids_in_position(pos, model)
     ## All grid positions have at least one agent (the land)
     absorbed_luminosity = if length(ids) == 1
         ## Set luminosity via surface albedo
@@ -115,14 +115,14 @@ function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
     ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
-    land = model[agents_in_pos(pos, model)[1]] # land at current position
+    land = model[ids_in_position(pos, model)[1]] # land at current position
     ## Each neighbor land patch is giving up 1/8 of the diffused
     ## amount to each of *its* neighbors
     land.temperature = (1 - ratio)*land.temperature + ratio*meantemp
 end
 
 function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
-    ids = agents_in_pos(pos, model)
+    ids = ids_in_position(pos, model)
     if length(ids) > 1
         daisy = model[ids[2]]
         temperature = model[ids[1]].temperature
@@ -133,7 +133,7 @@ function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
             empty_neighbors = Tuple{Int,Int}[]
             neighbors = nearby_positions(pos, model)
             for n in neighbors
-                if length(agents_in_pos(n, model)) == 1
+                if length(ids_in_position(n, model)) == 1
                     push!(empty_neighbors, n)
                 end
             end

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -113,7 +113,7 @@ end
 
 function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
-    ids = nearby_agents(pos, model)
+    ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
     land = model[agents_in_pos(pos, model)[1]] # land at current position
     ## Each neighbor land patch is giving up 1/8 of the diffused

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -91,8 +91,8 @@ function daisyworld(;
 end
 
 function update_surface_temperature!(node::Int, model::DaisyWorld)
-    ids = get_node_contents(node, model)
-    ## All grid points have at least one agent (the land)
+    ids = agents_in_pos(node, model)
+    ## All grid positions have at least one agent (the land)
     absorbed_luminosity = if length(ids) == 1
         ## Set luminosity via surface albedo
         (1 - model.surface_albedo) * model.solar_luminosity
@@ -113,14 +113,14 @@ function diffuse_temperature!(node::Int, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
     ids = nearby_agents(node, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
-    land = model[get_node_contents(node, model)[1]] # land at current node
+    land = model[agents_in_pos(node, model)[1]] # land at current position
     ## Each neighbor land patch is giving up 1/8 of the diffused
     ## amount to each of *its* neighbors
     land.temperature = (1 - ratio)*land.temperature + ratio*meantemp
 end
 
 function propagate!(node::Int, model::DaisyWorld)
-    ids = get_node_contents(node, model)
+    ids = agents_in_pos(node, model)
     if length(ids) > 1
         daisy = model[ids[2]]
         temperature = model[ids[1]].temperature
@@ -131,7 +131,7 @@ function propagate!(node::Int, model::DaisyWorld)
             empty_neighbors = Int[]
             neighbors = nearby_positions(node, model)
             for n in neighbors
-                if length(get_node_contents(n, model)) == 1
+                if length(agents_in_pos(n, model)) == 1
                     push!(empty_neighbors, n)
                 end
             end

--- a/src/models/flocking.jl
+++ b/src/models/flocking.jl
@@ -59,7 +59,7 @@ end
 
 function flocking_agent_step!(bird, model)
     ## Obtain the ids of neighbors within the bird's visual distance
-    ids = nearby_agents(bird, model, bird.visual_distance)
+    ids = nearby_ids(bird, model, bird.visual_distance)
     ## Compute velocity based on rules defined above
     bird.vel =
         (

--- a/src/models/flocking.jl
+++ b/src/models/flocking.jl
@@ -59,7 +59,7 @@ end
 
 function flocking_agent_step!(bird, model)
     ## Obtain the ids of neighbors within the bird's visual distance
-    ids = space_neighbors(bird, model, bird.visual_distance)
+    ids = nearby_agents(bird, model, bird.visual_distance)
     ## Compute velocity based on rules defined above
     bird.vel =
         (

--- a/src/models/forestfire.jl
+++ b/src/models/forestfire.jl
@@ -22,22 +22,22 @@ function forest_fire(; f = 0.02, d = 0.8, p = 0.01, griddims = (100, 100), seed 
     properties = Dict(:f => f, :d => d, :p => p)
     forest = AgentBasedModel(Tree, space; properties = properties)
 
-    ## create and add trees to each node with probability d,
+    ## create and add trees to each position with probability d,
     ## which determines the density of the forest
-    for node in nodes(forest)
+    for position in positions(forest)
         if rand() ≤ forest.d
-            add_agent!(node, forest, true)
+            add_agent!(position, forest, true)
         end
     end
     return forest, dummystep, forest_model_step!
 end
 
 function forest_model_step!(forest)
-    for node in nodes(forest, :random)
-        np = agents_in_pos(node, forest)
+    for position in positions(forest, :random)
+        np = agents_in_pos(position, forest)
         ## the position is empty, maybe a tree grows here
         if length(np) == 0
-            rand() ≤ forest.p && add_agent!(node, forest, true)
+            rand() ≤ forest.p && add_agent!(position, forest, true)
         else
             tree = forest[np[1]] # by definition only 1 agent per position
             if tree.status == false  # if it is has been burning, remove it.
@@ -46,7 +46,7 @@ function forest_model_step!(forest)
                 if rand() ≤ forest.f  # the tree ignites spontaneously
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
-                    for pos in nearby_positions(node, forest)
+                    for pos in nearby_positions(position, forest)
                         neighbors = agents_in_pos(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)

--- a/src/models/forestfire.jl
+++ b/src/models/forestfire.jl
@@ -18,7 +18,7 @@ Same as in [Forest fire model](@ref).
 """
 function forest_fire(; f = 0.02, d = 0.8, p = 0.01, griddims = (100, 100), seed = 111)
     Random.seed!(seed)
-    space = GridSpace(griddims)
+    space = GridSpace(griddims; periodic = false)
     properties = Dict(:f => f, :d => d, :p => p)
     forest = AgentBasedModel(Tree, space; properties = properties)
 

--- a/src/models/forestfire.jl
+++ b/src/models/forestfire.jl
@@ -34,12 +34,12 @@ end
 
 function forest_model_step!(forest)
     for position in positions(forest, :random)
-        np = agents_in_pos(position, forest)
+        ids = ids_in_position(position, forest)
         ## the position is empty, maybe a tree grows here
-        if length(np) == 0
+        if length(ids) == 0
             rand() ≤ forest.p && add_agent!(position, forest, true)
         else
-            tree = forest[np[1]] # by definition only 1 agent per position
+            tree = forest[ids[1]] # by definition only 1 agent per position
             if tree.status == false  # if it is has been burning, remove it.
                 kill_agent!(tree, forest)
             else
@@ -47,7 +47,7 @@ function forest_model_step!(forest)
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
                     for pos in nearby_positions(position, forest)
-                        neighbors = agents_in_pos(pos, forest)
+                        neighbors = ids_in_position(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)
                             tree.status = false

--- a/src/models/forestfire.jl
+++ b/src/models/forestfire.jl
@@ -46,8 +46,8 @@ function forest_model_step!(forest)
                 if rand() ≤ forest.f  # the tree ignites spontaneously
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
-                    for cell in node_neighbors(node, forest)
-                        neighbors = get_node_contents(cell, forest)
+                    for pos in nearby_positions(node, forest)
+                        neighbors = get_node_contents(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)
                             tree.status = false

--- a/src/models/forestfire.jl
+++ b/src/models/forestfire.jl
@@ -34,12 +34,12 @@ end
 
 function forest_model_step!(forest)
     for node in nodes(forest, :random)
-        nc = get_node_contents(node, forest)
-        ## the cell is empty, maybe a tree grows here
-        if length(nc) == 0
+        np = agents_in_pos(node, forest)
+        ## the position is empty, maybe a tree grows here
+        if length(np) == 0
             rand() ≤ forest.p && add_agent!(node, forest, true)
         else
-            tree = forest[nc[1]] # by definition only 1 agent per node
+            tree = forest[np[1]] # by definition only 1 agent per position
             if tree.status == false  # if it is has been burning, remove it.
                 kill_agent!(tree, forest)
             else
@@ -47,7 +47,7 @@ function forest_model_step!(forest)
                     tree.status = false
                 else  # if any neighbor is on fire, set this tree on fire too
                     for pos in nearby_positions(node, forest)
-                        neighbors = get_node_contents(pos, forest)
+                        neighbors = agents_in_pos(pos, forest)
                         length(neighbors) == 0 && continue
                         if any(n -> !forest.agents[n].status, neighbors)
                             tree.status = false

--- a/src/models/game_of_life.jl
+++ b/src/models/game_of_life.jl
@@ -15,8 +15,8 @@ game_of_life(;
 Same as in [Conway's game of life](@ref).
 """
 function game_of_life(;
-    rules::Tuple = (2, 3, 3, 3), 
-    dims = (100, 100), 
+    rules::Tuple = (2, 3, 3, 3),
+    dims = (100, 100),
     Moore = true
 )
     space = GridSpace(dims, moore = Moore)
@@ -52,7 +52,7 @@ function nlive_neighbors(ag, model)
     neighbor_positions = nearby_positions(ag, model)
     nlive = 0
     for np in neighbor_positions
-        nag = model.agents[Agents.coord2vertex((np[2], np[1]), model)]
+        nag = model.agents[(np[2], np[1])]
         if nag.status == true
             nlive += 1
         end

--- a/src/models/game_of_life.jl
+++ b/src/models/game_of_life.jl
@@ -22,11 +22,11 @@ function game_of_life(;
     space = GridSpace(dims, moore = Moore)
     properties = Dict(:rules => rules)
     model = ABM(Cell, space; properties = properties)
-    node_idx = 1
+    idx = 1
     for x in 1:dims[1]
         for y in 1:dims[2]
-            add_agent_pos!(Cell(node_idx, (x, y), false), model)
-            node_idx += 1
+            add_agent_pos!(Cell(idx, (x, y), false), model)
+            idx += 1
         end
     end
     return model, dummystep, game_of_life_model_step!

--- a/src/models/game_of_life.jl
+++ b/src/models/game_of_life.jl
@@ -50,6 +50,6 @@ end
 
 function nlive_neighbors(agent, model)
     neighbor_positions = nearby_positions(agent, model)
-    all_neighbors = Iterators.flatten(agents_in_pos(np,model) for np in neighbor_positions)
+    all_neighbors = Iterators.flatten(ids_in_position(np,model) for np in neighbor_positions)
     sum(model[i].status == true for i in all_neighbors)
 end

--- a/src/models/game_of_life.jl
+++ b/src/models/game_of_life.jl
@@ -49,10 +49,10 @@ function game_of_life_model_step!(model)
 end
 
 function nlive_neighbors(ag, model)
-    neighbors_coords = node_neighbors(ag, model)
+    neighbor_positions = nearby_positions(ag, model)
     nlive = 0
-    for nc in neighbors_coords
-        nag = model.agents[Agents.coord2vertex((nc[2], nc[1]), model)]
+    for np in neighbor_positions
+        nag = model.agents[Agents.coord2vertex((np[2], np[1]), model)]
         if nag.status == true
             nlive += 1
         end

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -22,9 +22,9 @@ function opinion(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
         scheduler = random_activation,
         properties = properties,
     )
-    for cell in 1:nv(model)
+    for pos in positions(model)
         add_agent!(
-            vertex2coord(cell,model),
+            pos,
             model,
             false,
             rand(1:levels_per_opinion, nopinions),

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -35,7 +35,7 @@ function opinion(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
 end
 
 function adopt!(agent, model)
-    neighbor = rand(space_neighbors(agent, model))
+    neighbor = rand(nearby_agents(agent, model))
     matches = model[neighbor].opinion .== agent.opinion
     nmatches = count(matches)
     # Adopt a different opinion w/ calculated probability

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -35,7 +35,7 @@ function opinion(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
 end
 
 function adopt!(agent, model)
-    neighbor = rand(collect(nearby_agents(agent, model)))
+    neighbor = rand(collect(nearby_ids(agent, model)))
     matches = model[neighbor].opinion .== agent.opinion
     nmatches = count(matches)
     # Adopt a different opinion w/ calculated probability

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -14,7 +14,7 @@ end
 Same as in [Opinion spread](@ref).
 """
 function opinion(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
-    space = GridSpace(dims, periodic = true, moore = true)
+    space = GridSpace(dims)
     properties = Dict(:nopinions => nopinions)
     model = AgentBasedModel(
         Citizen,
@@ -35,7 +35,7 @@ function opinion(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
 end
 
 function adopt!(agent, model)
-    neighbor = rand(nearby_agents(agent, model))
+    neighbor = rand(collect(nearby_agents(agent, model)))
     matches = model[neighbor].opinion .== agent.opinion
     nmatches = count(matches)
     # Adopt a different opinion w/ calculated probability

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -124,7 +124,7 @@ function predator_prey_agent_step!(grass::Grass, model)
 end
 
 function move!(agent, model)
-    neighbors = node_neighbors(agent, model)
+    neighbors = nearby_positions(agent, model)
     cell = rand(collect(neighbors))
     move_agent!(agent, cell, model)
 end

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -26,7 +26,7 @@ end
 
 """
 ``` julia
-predator_prey(; 
+predator_prey(;
     n_sheep = 100,
     n_wolves = 50,
     dims = (20, 20),
@@ -72,12 +72,12 @@ function predator_prey(;
         wolf = Wolf(id, (0, 0), energy, wolf_reproduce, Δenergy_wolf)
         add_agent!(wolf, model)
     end
-    for n in nodes(model)
+    for p in positions(model)
         id += 1
         fully_grown = rand(Bool)
         countdown = fully_grown ? regrowth_time : rand(1:regrowth_time) - 1
         grass = Grass(id, (0, 0), fully_grown, regrowth_time, countdown)
-        add_agent!(grass, vertex2coord(n, model), model)
+        add_agent!(grass, p, model)
     end
     return model, predator_prey_agent_step!, dummystep
 end
@@ -85,7 +85,7 @@ end
 function predator_prey_agent_step!(sheep::Sheep, model)
     move!(sheep, model)
     sheep.energy -= 1
-    agents = get_node_agents(sheep.pos, model)
+    agents = [model[a] for a in agents_in_pos(sheep.pos, model)]
     dinner = filter!(x -> isa(x, Grass), agents)
     eat!(sheep, dinner, model)
     if sheep.energy < 0
@@ -100,7 +100,7 @@ end
 function predator_prey_agent_step!(wolf::Wolf, model)
     move!(wolf, model)
     wolf.energy -= 1
-    agents = get_node_agents(wolf.pos, model)
+    agents = [model[a] for a in agents_in_pos(wolf.pos, model)]
     dinner = filter!(x -> isa(x, Sheep), agents)
     eat!(wolf, dinner, model)
     if wolf.energy < 0

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -85,7 +85,7 @@ end
 function predator_prey_agent_step!(sheep::Sheep, model)
     move!(sheep, model)
     sheep.energy -= 1
-    agents = [model[a] for a in agents_in_pos(sheep.pos, model)]
+    agents = collect(agents_in_position(sheep.pos, model))
     dinner = filter!(x -> isa(x, Grass), agents)
     eat!(sheep, dinner, model)
     if sheep.energy < 0
@@ -100,7 +100,7 @@ end
 function predator_prey_agent_step!(wolf::Wolf, model)
     move!(wolf, model)
     wolf.energy -= 1
-    agents = [model[a] for a in agents_in_pos(wolf.pos, model)]
+    agents = collect(agents_in_position(wolf.pos, model))
     dinner = filter!(x -> isa(x, Sheep), agents)
     eat!(wolf, dinner, model)
     if wolf.energy < 0

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -125,8 +125,8 @@ end
 
 function move!(agent, model)
     neighbors = nearby_positions(agent, model)
-    cell = rand(collect(neighbors))
-    move_agent!(agent, cell, model)
+    position = rand(collect(neighbors))
+    move_agent!(agent, position, model)
 end
 
 function eat!(sheep::Sheep, grass_array, model)

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -54,7 +54,7 @@ function predator_prey(;
     sheep_reproduce = 0.04,
     wolf_reproduce = 0.05,
 )
-    space = GridSpace(dims, moore = true)
+    space = GridSpace(dims, periodic = false)
     model =
         ABM(Union{Sheep,Wolf,Grass}, space, scheduler = by_type(true, true), warn = false)
     id = 0

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -1,7 +1,7 @@
 mutable struct SchellingAgent <: AbstractAgent
     id::Int # The identifier number of the agent
     pos::Tuple{Int,Int} # The x, y location of the agent on a 2D grid
-    mood::Bool # whether the agent is happy in its node. (true = happy)
+    mood::Bool # whether the agent is happy in its position. (true = happy)
     group::Int # The group of the agent,  determines mood as it interacts with neighbors
 end
 
@@ -53,7 +53,7 @@ function schelling_agent_step!(agent, model)
     end
     ## After counting the neighbors, decide whether or not to move the agent.
     ## If count_neighbors_same_group is at least the min_to_be_happy, set the
-    ## mood to true. Otherwise, move the agent to a random node.
+    ## mood to true. Otherwise, move the agent to a random position.
     if count_neighbors_same_group ≥ minhappy
         agent.mood = true
     else

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -39,7 +39,7 @@ function schelling_agent_step!(agent, model)
     ## For each neighbor, get group and compare to current agent's group
     ## and increment count_neighbors_same_group as appropriately.
     for neighbor_pos in neighbor_positions
-        pos_contents = agents_in_pos(neighbor_pos, model)
+        pos_contents = ids_in_position(neighbor_pos, model)
         ## Skip iteration if the position is empty.
         length(pos_contents) == 0 && continue
         ## Otherwise, get the first agent in the position...

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -17,7 +17,7 @@ Same as in [Schelling's segregation model](@ref).
 """
 function schelling(; numagents = 320, griddims = (20, 20), min_to_be_happy = 3)
     @assert numagents < prod(griddims)
-    space = GridSpace(griddims, moore = true)
+    space = GridSpace(griddims, periodic = false)
     properties = Dict(:min_to_be_happy => min_to_be_happy)
     model =
         ABM(SchellingAgent, space; properties = properties, scheduler = random_activation)

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -34,12 +34,12 @@ end
 function schelling_agent_step!(agent, model)
     agent.mood == true && return # do nothing if already happy
     minhappy = model.min_to_be_happy
-    neighbor_cells = node_neighbors(agent, model)
+    neighbor_positions = nearby_positions(agent, model)
     count_neighbors_same_group = 0
     ## For each neighbor, get group and compare to current agent's group
     ## and increment count_neighbors_same_group as appropriately.
-    for neighbor_cell in neighbor_cells
-        node_contents = get_node_contents(neighbor_cell, model)
+    for neighbor_pos in neighbor_positions
+        node_contents = get_node_contents(neighbor_pos, model)
         ## Skip iteration if the node is empty.
         length(node_contents) == 0 && continue
         ## Otherwise, get the first agent in the node...

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -39,11 +39,11 @@ function schelling_agent_step!(agent, model)
     ## For each neighbor, get group and compare to current agent's group
     ## and increment count_neighbors_same_group as appropriately.
     for neighbor_pos in neighbor_positions
-        node_contents = get_node_contents(neighbor_pos, model)
-        ## Skip iteration if the node is empty.
-        length(node_contents) == 0 && continue
-        ## Otherwise, get the first agent in the node...
-        agent_id = node_contents[1]
+        pos_contents = agents_in_pos(neighbor_pos, model)
+        ## Skip iteration if the position is empty.
+        length(pos_contents) == 0 && continue
+        ## Otherwise, get the first agent in the position...
+        agent_id = pos_contents[1]
         ## ...and increment count_neighbors_same_group if the neighbor's group is
         ## the same.
         neighbor_agent_group = model[agent_id].group

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -101,15 +101,15 @@ end
 function movement!(agent, model)
     newsite = agent.pos
     # find all unoccupied position within vision
-    neighbors = nearby_positions(coord2vertex(agent.pos, model), model, agent.vision)
-    empty_positions = [i for i in neighbors if isempty(i, model)]
-    if length(empty_positions) > 0
+    neighbors = nearby_positions(agent.pos, model, agent.vision)
+    empty = collect(empty_positions(model))
+    if length(empty) > 0
         # identify the one(s) with greatest amount of sugar
-        available_sugar = (model.sugar_values[x,y] for (x, y) in empty_positions)
+        available_sugar = (model.sugar_values[x,y] for (x, y) in empty)
         maxsugar = maximum(available_sugar)
         if maxsugar > 0
             sugary_sites_inds = findall(x -> x == maxsugar, collect(available_sugar))
-            sugary_sites = empty_positions[sugary_sites_inds]
+            sugary_sites = empty[sugary_sites_inds]
             # select the nearest one (randomly if more than one)
             for dia in 1:(agent.vision)
                 np = nearby_positions(agent.pos, model, dia)

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -59,7 +59,7 @@ function sugarscape(;
 )
     sugar_capacities = sugar_caps(dims, sugar_peaks, max_sugar, 6)
     sugar_values = deepcopy(sugar_capacities)
-    space = GridSpace(dims, periodic = true, moore = true)
+    space = GridSpace(dims)
     properties = Dict(
         :growth_rate => growth_rate,
         :N => N,

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -90,7 +90,7 @@ function sugarscape(;
 end
 
 function sugarscape_env!(model)
-    # At each cell, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
+    # At each position, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
     togrow = findall(
         x -> model.sugar_values[x] < model.sugar_capacities[x],
         1:prod(model.space.dimensions),
@@ -101,7 +101,7 @@ end
 function movement!(agent, model)
     posvertex = coord2vertex(agent.pos, model)
     newsite = posvertex
-    # find all unoccupied cells within vision
+    # find all unoccupied position within vision
     neighbors = nearby_positions(coord2vertex(agent.pos, model), model, agent.vision)
     empty_positions = [i for i in neighbors if isempty(i, model)]
     if length(empty_positions) > 0

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -102,18 +102,18 @@ function movement!(agent, model)
     posvertex = coord2vertex(agent.pos, model)
     newsite = posvertex
     # find all unoccupied cells within vision
-    neighbors = node_neighbors(coord2vertex(agent.pos, model), model, agent.vision)
-    empty_nodes = [i for i in neighbors if isempty(i, model)]
-    if length(empty_nodes) > 0
+    neighbors = nearby_positions(coord2vertex(agent.pos, model), model, agent.vision)
+    empty_positions = [i for i in neighbors if isempty(i, model)]
+    if length(empty_positions) > 0
         # identify the one(s) with greatest amount of sugar
-        maxsugar = maximum(model.sugar_values[empty_nodes])
+        maxsugar = maximum(model.sugar_values[empty_positions])
         if maxsugar > 0
-            sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_nodes])
-            sugary_sites = empty_nodes[sugary_sites_inds]
+            sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_positions])
+            sugary_sites = empty_positions[sugary_sites_inds]
             # select the nearest one (randomly if more than one)
             for dia in 1:(agent.vision)
-                nn = node_neighbors(posvertex, model, dia)
-                suitable = intersect(nn, sugary_sites)
+                np = nearby_positions(posvertex, model, dia)
+                suitable = intersect(np, sugary_sites)
                 if length(suitable) > 0
                     newsite = rand(suitable)
                     break

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -93,26 +93,26 @@ function sugarscape_env!(model)
     # At each position, sugar grows back at a rate of $\alpha$ units per time-step up to the cell's capacity c.
     togrow = findall(
         x -> model.sugar_values[x] < model.sugar_capacities[x],
-        1:prod(model.space.dimensions),
+        1:length(positions(model)),
     )
     model.sugar_values[togrow] .+= model.growth_rate
 end
 
 function movement!(agent, model)
-    posvertex = coord2vertex(agent.pos, model)
-    newsite = posvertex
+    newsite = agent.pos
     # find all unoccupied position within vision
     neighbors = nearby_positions(coord2vertex(agent.pos, model), model, agent.vision)
     empty_positions = [i for i in neighbors if isempty(i, model)]
     if length(empty_positions) > 0
         # identify the one(s) with greatest amount of sugar
-        maxsugar = maximum(model.sugar_values[empty_positions])
+        available_sugar = (model.sugar_values[x,y] for (x, y) in empty_positions)
+        maxsugar = maximum(available_sugar)
         if maxsugar > 0
-            sugary_sites_inds = findall(x -> x == maxsugar, model.sugar_values[empty_positions])
+            sugary_sites_inds = findall(x -> x == maxsugar, collect(available_sugar))
             sugary_sites = empty_positions[sugary_sites_inds]
             # select the nearest one (randomly if more than one)
             for dia in 1:(agent.vision)
-                np = nearby_positions(posvertex, model, dia)
+                np = nearby_positions(agent.pos, model, dia)
                 suitable = intersect(np, sugary_sites)
                 if length(suitable) > 0
                     newsite = rand(suitable)
@@ -120,12 +120,12 @@ function movement!(agent, model)
                 end
             end
             # move there and collect all the sugar in it
-            newsite != posvertex && move_agent!(agent, newsite, model)
+            newsite != agent.pos && move_agent!(agent, newsite, model)
         end
     end
     # update wealth (collected - consumed)
-    agent.wealth += (model.sugar_values[newsite] - agent.metabolic_rate)
-    model.sugar_values[newsite] = 0
+    agent.wealth += (model.sugar_values[newsite...] - agent.metabolic_rate)
+    model.sugar_values[newsite...] = 0
     agent.age += 1
 end
 

--- a/src/models/wealth_distribution.jl
+++ b/src/models/wealth_distribution.jl
@@ -17,7 +17,7 @@ Same as in [Wealth distribution model](@ref).
 function wealth_distribution(; dims = (25, 25), wealth = 1, M = 1000)
     space = GridSpace(dims, periodic = true)
     model = ABM(WealthInSpace, space; scheduler = random_activation)
-    for i in 1:M # add agents in random nodes
+    for i in 1:M # add agents in random positions
         add_agent!(model, wealth)
     end
     return model, wealth_distribution_agent_step!, dummystep
@@ -25,9 +25,8 @@ end
 
 function wealth_distribution_agent_step!(agent, model)
     agent.wealth == 0 && return # do nothing
-    agent_node = coord2vertex(agent.pos, model)
-    neighboring_positions = nearby_positions(agent_node, model)
-    push!(neighboring_positions, agent_node) # also consider current position
+    neighboring_positions = nearby_positions(agent.pos, model)
+    push!(neighboring_positions, agent.pos) # also consider current position
     rpos = rand(neighboring_positions) # the position that we will exchange with
     available_ids = agents_in_pos(rpos, model)
     if length(available_ids) > 0

--- a/src/models/wealth_distribution.jl
+++ b/src/models/wealth_distribution.jl
@@ -26,9 +26,9 @@ end
 function wealth_distribution_agent_step!(agent, model)
     agent.wealth == 0 && return # do nothing
     agent_node = coord2vertex(agent.pos, model)
-    neighboring_nodes = node_neighbors(agent_node, model)
-    push!(neighboring_nodes, agent_node) # also consider current node
-    rnode = rand(neighboring_nodes) # the node that we will exchange with
+    neighboring_positions = nearby_positions(agent_node, model)
+    push!(neighboring_positions, agent_node) # also consider current position
+    rnode = rand(neighboring_positions) # the position that we will exchange with
     available_ids = get_node_contents(rnode, model)
     if length(available_ids) > 0
         random_neighbor_agent = model[rand(available_ids)]

--- a/src/models/wealth_distribution.jl
+++ b/src/models/wealth_distribution.jl
@@ -28,7 +28,7 @@ function wealth_distribution_agent_step!(agent, model)
     neighboring_positions = collect(nearby_positions(agent.pos, model))
     push!(neighboring_positions, agent.pos) # also consider current position
     rpos = rand(neighboring_positions) # the position that we will exchange with
-    available_ids = agents_in_pos(rpos, model)
+    available_ids = ids_in_position(rpos, model)
     if length(available_ids) > 0
         random_neighbor_agent = model[rand(available_ids)]
         agent.wealth -= 1

--- a/src/models/wealth_distribution.jl
+++ b/src/models/wealth_distribution.jl
@@ -25,7 +25,7 @@ end
 
 function wealth_distribution_agent_step!(agent, model)
     agent.wealth == 0 && return # do nothing
-    neighboring_positions = nearby_positions(agent.pos, model)
+    neighboring_positions = collect(nearby_positions(agent.pos, model))
     push!(neighboring_positions, agent.pos) # also consider current position
     rpos = rand(neighboring_positions) # the position that we will exchange with
     available_ids = agents_in_pos(rpos, model)

--- a/src/models/wealth_distribution.jl
+++ b/src/models/wealth_distribution.jl
@@ -28,8 +28,8 @@ function wealth_distribution_agent_step!(agent, model)
     agent_node = coord2vertex(agent.pos, model)
     neighboring_positions = nearby_positions(agent_node, model)
     push!(neighboring_positions, agent_node) # also consider current position
-    rnode = rand(neighboring_positions) # the position that we will exchange with
-    available_ids = get_node_contents(rnode, model)
+    rpos = rand(neighboring_positions) # the position that we will exchange with
+    available_ids = agents_in_pos(rpos, model)
     if length(available_ids) > 0
         random_neighbor_agent = model[rand(available_ids)]
         agent.wealth -= 1

--- a/src/spaces/continuous_space.jl
+++ b/src/spaces/continuous_space.jl
@@ -219,7 +219,7 @@ end
 #######################################################################################
 # neighboring agents
 #######################################################################################
-function space_neighbors(pos::Tuple, model::ABM{A, <:ContinuousSpace}, r::Real) where {A}
+function nearby_agents(pos::Tuple, model::ABM{A, <:ContinuousSpace}, r::Real) where {A}
   left = pos .- r
   right = pos .+ r
   res = interlace(left, right)
@@ -230,7 +230,7 @@ function space_neighbors(pos::Tuple, model::ABM{A, <:ContinuousSpace}, r::Real) 
   ids
 end
 
-function space_neighbors(agent::A, model::ABM{A, <:ContinuousSpace}, r::Real) where {A<:AbstractAgent}
+function nearby_agents(agent::A, model::ABM{A, <:ContinuousSpace}, r::Real) where {A<:AbstractAgent}
   left = agent.pos .- r
   right = agent.pos .+ r
   res = interlace(left, right)
@@ -261,7 +261,7 @@ space's metric. Valid only in continuous space.
 Return `nothing` if no agent is within distance `r`.
 """
 function nearest_neighbor(agent, model, r)
-  n = space_neighbors(agent, model, r)
+  n = nearby_agents(agent, model, r)
   length(n) == 0 && return nothing
   d, j = Inf, 1
   for i in 1:length(n)
@@ -390,7 +390,7 @@ end
 
 function all_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM, r::Real)
     for a in allagents(model)
-        for nid in space_neighbors(a, model, r)
+        for nid in nearby_agents(a, model, r)
             # Sort the pair to overcome any uniqueness issues
             new_pair = isless(a.id, nid) ? (a.id, nid) : (nid, a.id)
             new_pair ∉ pairs && push!(pairs, new_pair)
@@ -428,7 +428,7 @@ function type_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM, r::Real, schedul
     # We don't know ahead of time what types the scheduler will provide. Get a list.
     available_types = unique(typeof(model[id]) for id in scheduler(model))
     for id in scheduler(model)
-        for nid in space_neighbors(model[id], model, r)
+        for nid in nearby_agents(model[id], model, r)
             neigbor_type = typeof(model[nid])
             if neigbor_type ∈ available_types && neigbor_type !== typeof(model[id])
                 # Sort the pair to overcome any uniqueness issues

--- a/src/spaces/continuous_space.jl
+++ b/src/spaces/continuous_space.jl
@@ -219,7 +219,7 @@ end
 #######################################################################################
 # neighboring agents
 #######################################################################################
-function nearby_agents(pos::Tuple, model::ABM{A, <:ContinuousSpace}, r::Real) where {A}
+function nearby_ids(pos::Tuple, model::ABM{A, <:ContinuousSpace}, r::Real) where {A}
   left = pos .- r
   right = pos .+ r
   res = interlace(left, right)
@@ -230,7 +230,7 @@ function nearby_agents(pos::Tuple, model::ABM{A, <:ContinuousSpace}, r::Real) wh
   ids
 end
 
-function nearby_agents(agent::A, model::ABM{A, <:ContinuousSpace}, r::Real) where {A<:AbstractAgent}
+function nearby_ids(agent::A, model::ABM{A, <:ContinuousSpace}, r::Real) where {A<:AbstractAgent}
   left = agent.pos .- r
   right = agent.pos .+ r
   res = interlace(left, right)
@@ -261,7 +261,7 @@ space's metric. Valid only in continuous space.
 Return `nothing` if no agent is within distance `r`.
 """
 function nearest_neighbor(agent, model, r)
-  n = nearby_agents(agent, model, r)
+  n = nearby_ids(agent, model, r)
   length(n) == 0 && return nothing
   d, j = Inf, 1
   for i in 1:length(n)
@@ -390,7 +390,7 @@ end
 
 function all_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM, r::Real)
     for a in allagents(model)
-        for nid in nearby_agents(a, model, r)
+        for nid in nearby_ids(a, model, r)
             # Sort the pair to overcome any uniqueness issues
             new_pair = isless(a.id, nid) ? (a.id, nid) : (nid, a.id)
             new_pair ∉ pairs && push!(pairs, new_pair)
@@ -428,7 +428,7 @@ function type_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM, r::Real, schedul
     # We don't know ahead of time what types the scheduler will provide. Get a list.
     available_types = unique(typeof(model[id]) for id in scheduler(model))
     for id in scheduler(model)
-        for nid in nearby_agents(model[id], model, r)
+        for nid in nearby_ids(model[id], model, r)
             neigbor_type = typeof(model[nid])
             if neigbor_type ∈ available_types && neigbor_type !== typeof(model[id])
                 # Sort the pair to overcome any uniqueness issues

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -7,7 +7,7 @@ All these functions are granted "for free" to discrete spaces by simply extendin
 - agents_in_pos(position, model)
 =#
 
-export nodes, agents_in_pos, find_empty_nodes, random_empty, has_empty_nodes
+export nodes, agents_in_pos, empty_positions, random_empty, has_empty_positions
 
 """
     nodes(model::ABM{A, <:DiscreteSpace}) → ns
@@ -34,7 +34,7 @@ function nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace}, by::Symbol)
 end
 
 # TODO: Does this really have to be collecting...?
-function find_empty_nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace})
+function empty_positions(model::ABM{<:AbstractAgent,<:DiscreteSpace})
     collect(Iterators.filter(i -> length(agents_in_pos(i, model)) == 0, nodes(model)))
 end
 
@@ -46,12 +46,11 @@ Base.isempty(pos, model::ABM) = isempty(agents_in_pos(pos, model))
 
 
 """
-    has_empty_nodes(model::ABM{A, <:DiscreteSpace})
+    has_empty_positions(model::ABM{A, <:DiscreteSpace})
 Return `true` if there are any positions in the model without agents.
 """
-function has_empty_nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace})
-    s = model.space.s
-    return any(i -> length(i) == 0, s)
+function has_empty_positions(model::ABM{<:AbstractAgent,<:DiscreteSpace})
+    return any(i -> length(i) == 0, model.space.s)
 end
 
 """
@@ -59,9 +58,9 @@ end
 Return a random position without any agents, or `nothing` if no such positions exist.
 """
 function random_empty(model::ABM{<:AbstractAgent,<:DiscreteSpace})
-    empty_nodes = find_empty_nodes(model)
-    isempty(empty_nodes) && return nothing
-    rand(empty_nodes)
+    empty = empty_positions(model)
+    isempty(empty) && return nothing
+    rand(empty)
 end
 
 #######################################################################################
@@ -93,9 +92,9 @@ function add_agent_single!(
     properties...;
     kwargs...,
 ) where {A<:AbstractAgent}
-    empty_positions = find_empty_nodes(model)
-    if length(empty_positions) > 0
-        add_agent!(rand(empty_positions), model, properties...; kwargs...)
+    empty = empty_positions(model)
+    if length(empty) > 0
+        add_agent!(rand(empty), model, properties...; kwargs...)
     end
 end
 
@@ -163,17 +162,16 @@ end
 """
     move_agent_single!(agent::A, model::ABM{A, <:DiscreteSpace}) → agentt
 
-Move agent to a random node while respecting a maximum of one agent
-per node. If there are no empty nodes, the agent won't move.
+Move agent to a random position while respecting a maximum of one agent
+per position. If there are no empty positions, the agent won't move.
 """
 function move_agent_single!(
         agent::A,
         model::ABM{A,<:DiscreteSpace},
     ) where {A<:AbstractAgent}
-    empty_positions = find_empty_nodes(model)
-    if length(empty_positions) > 0
-        random_node = rand(empty_positions)
-        move_agent!(agent, random_node, model)
+    empty = empty_positions(model)
+    if length(empty) > 0
+        move_agent!(agent, rand(empty), model)
     end
     return agent
 end

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -3,25 +3,25 @@ This file implements functions shared by all discrete spaces.
 Discrete spaces are by definition spaces with a finite amount of possible positions.
 
 All these functions are granted "for free" to discrete spaces by simply extending:
-- nodes(model)
+- positions(model)
 - agents_in_pos(position, model)
 =#
 
-export nodes, agents_in_pos, empty_positions, random_empty, has_empty_positions
+export positions, agents_in_pos, empty_positions, random_empty, has_empty_positions
 
 """
-    nodes(model::ABM{A, <:DiscreteSpace}) → ns
-Return an iterator over all positions of a model with a discrete space (called nodes).
+    positions(model::ABM{A, <:DiscreteSpace}) → ns
+Return an iterator over all positions of a model with a discrete space.
 
-    nodes(model::ABM{A, <:DiscreteSpace}, by::Symbol) → ns
-Return all positions of a model with a discrete space (called nodes), sorting them
+    positions(model::ABM{A, <:DiscreteSpace}, by::Symbol) → ns
+Return all positions of a model with a discrete space, sorting them
 using the argument `by` which can be:
 * `:random` - randomly sorted
 * `:population` - positions are sorted depending on how many agents they accommodate.
   The more populated positions are first.
 """
-function nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace}, by::Symbol)
-    n = collect(nodes(model))
+function positions(model::ABM{<:AbstractAgent,<:DiscreteSpace}, by::Symbol)
+    n = collect(positions(model))
     itr = reshape(n, length(n))
     if by == :random
         shuffle!(itr)
@@ -35,7 +35,7 @@ end
 
 # TODO: Does this really have to be collecting...?
 function empty_positions(model::ABM{<:AbstractAgent,<:DiscreteSpace})
-    collect(Iterators.filter(i -> length(agents_in_pos(i, model)) == 0, nodes(model)))
+    collect(Iterators.filter(i -> length(agents_in_pos(i, model)) == 0, positions(model)))
 end
 
 """
@@ -72,7 +72,7 @@ export add_agent_single!, fill_space!, move_agent_single!
     add_agent_single!(agent::A, model::ABM{A, <: DiscreteSpace}) → agent
 
 Add the `agent` to a random position in the space while respecting a maximum of one agent
-per node position. This function does nothing if there aren't any empty positions.
+per position. This function does nothing if there aren't any empty positions.
 """
 function add_agent_single!(agent::A, model::ABM{A,<:DiscreteSpace}) where {A<:AbstractAgent}
     position = random_empty(model)
@@ -101,11 +101,11 @@ end
 """
     fill_space!([A ,] model::ABM{A, <:DiscreteSpace}, args...; kwargs...)
     fill_space!([A ,] model::ABM{A, <:DiscreteSpace}, f::Function; kwargs...)
-Add one agent to each node in the model's space. Similarly with [`add_agent!`](@ref),
+Add one agent to each position in the model's space. Similarly with [`add_agent!`](@ref),
 the function creates the necessary agents and
 the `args...; kwargs...` are propagated into agent creation.
 If instead of `args...` a function `f` is provided, then `args = f(pos)` is the result of
-applying `f` where `pos` is each position (tuple for grid, node index for graph).
+applying `f` where `pos` is each position (tuple for grid, index for graph).
 
 An optional first argument is an agent **type** to be created, and targets mixed agent
 models where the agent constructor cannot be deduced (since it is a union).
@@ -138,9 +138,9 @@ function fill_space!(
     args...;
     kwargs...,
 ) where {A<:AbstractAgent,U<:AbstractAgent}
-    for n in nodes(model)
+    for p in positions(model)
         id = nextid(model)
-        add_agent_pos!(A(id, n, args...; kwargs...), model)
+        add_agent_pos!(A(id, p, args...; kwargs...), model)
     end
     return model
 end
@@ -151,10 +151,10 @@ function fill_space!(
     f::Function;
     kwargs...,
 ) where {A<:AbstractAgent,U<:AbstractAgent}
-    for n in nodes(model)
+    for p in positions(model)
         id = nextid(model)
-        args = f(n)
-        add_agent_pos!(A(id, n, args...; kwargs...), model)
+        args = f(p)
+        add_agent_pos!(A(id, p, args...; kwargs...), model)
     end
     return model
 end

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -7,7 +7,7 @@ All these functions are granted "for free" to discrete spaces by simply extendin
 - agents_in_pos(position, model)
 =#
 
-export nodes, agents_in_pos, find_empty_nodes, pick_empty, has_empty_nodes
+export nodes, agents_in_pos, find_empty_nodes, random_empty, has_empty_nodes
 
 """
     nodes(model::ABM{A, <:DiscreteSpace}) → ns
@@ -55,10 +55,10 @@ function has_empty_nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace})
 end
 
 """
-    pick_empty(model::ABM{A, <:DiscreteSpace})
+    random_empty(model::ABM{A, <:DiscreteSpace})
 Return a random position without any agents, or `nothing` if no such positions exist.
 """
-function pick_empty(model::ABM{<:AbstractAgent,<:DiscreteSpace})
+function random_empty(model::ABM{<:AbstractAgent,<:DiscreteSpace})
     empty_nodes = find_empty_nodes(model)
     isempty(empty_nodes) && return nothing
     rand(empty_nodes)
@@ -76,9 +76,9 @@ Add the `agent` to a random position in the space while respecting a maximum of 
 per node position. This function does nothing if there aren't any empty positions.
 """
 function add_agent_single!(agent::A, model::ABM{A,<:DiscreteSpace}) where {A<:AbstractAgent}
-    node = pick_empty(model)
-    isnothing(node) && return agent
-    agent.pos = node
+    position = random_empty(model)
+    isnothing(position) && return agent
+    agent.pos = position
     add_agent_pos!(agent, model)
     return agent
 end

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -4,10 +4,10 @@ Discrete spaces are by definition spaces with a finite amount of possible positi
 
 All these functions are granted "for free" to discrete spaces by simply extending:
 - positions(model)
-- agents_in_pos(position, model)
+- ids_in_position(position, model)
 =#
 
-export positions, agents_in_pos, empty_positions, random_empty, has_empty_positions
+export positions, ids_in_position, agents_in_position, empty_positions, random_empty, has_empty_positions
 
 """
     positions(model::ABM{A, <:DiscreteSpace}) → ns
@@ -26,23 +26,32 @@ function positions(model::ABM{<:AbstractAgent,<:DiscreteSpace}, by::Symbol)
     if by == :random
         shuffle!(itr)
     elseif by == :population
-        sort!(itr, by = i -> length(agents_in_pos(i, model)), rev = true)
+        sort!(itr, by = i -> length(ids_in_position(i, model)), rev = true)
     else
         error("unknown `by`")
     end
     return itr
 end
 
+"""
+    agents_in_position(position, model::ABM{A, <:DiscreteSpace})
+    agents_in_position(agent, model::ABM{A, <:DiscreteSpace})
+
+Return the agents in the position corresponding to `position` or position of `agent`.
+"""
+agents_in_position(agent::A, model) where {A<:AbstractAgent} = agents_in_position(agent.pos, model)
+agents_in_position(pos, model) = (model[id] for id in ids_in_position(pos, model))
+
 # TODO: Does this really have to be collecting...?
 function empty_positions(model::ABM{<:AbstractAgent,<:DiscreteSpace})
-    collect(Iterators.filter(i -> length(agents_in_pos(i, model)) == 0, positions(model)))
+    collect(Iterators.filter(i -> length(ids_in_position(i, model)) == 0, positions(model)))
 end
 
 """
     isempty(position, model::ABM{A, <:DiscreteSpace})
 Return `true` if there are no agents in `position`.
 """
-Base.isempty(pos, model::ABM) = isempty(agents_in_pos(pos, model))
+Base.isempty(pos, model::ABM) = isempty(ids_in_position(pos, model))
 
 
 """

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -4,10 +4,10 @@ Discrete spaces are by definition spaces with a finite amount of possible positi
 
 All these functions are granted "for free" to discrete spaces by simply extending:
 - nodes(model)
-- get_node_contents(position, model)
+- agents_in_pos(position, model)
 =#
 
-export nodes, get_node_contents, find_empty_nodes, pick_empty, has_empty_nodes
+export nodes, agents_in_pos, find_empty_nodes, pick_empty, has_empty_nodes
 
 """
     nodes(model::ABM{A, <:DiscreteSpace}) → ns
@@ -17,8 +17,8 @@ Return an iterator over all positions of a model with a discrete space (called n
 Return all positions of a model with a discrete space (called nodes), sorting them
 using the argument `by` which can be:
 * `:random` - randomly sorted
-* `:population` - nodes are sorted depending on how many agents they accommodate.
-  The more populated nodes are first.
+* `:population` - positions are sorted depending on how many agents they accommodate.
+  The more populated positions are first.
 """
 function nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace}, by::Symbol)
     n = collect(nodes(model))
@@ -26,7 +26,7 @@ function nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace}, by::Symbol)
     if by == :random
         shuffle!(itr)
     elseif by == :population
-        sort!(itr, by = i -> length(get_node_contents(i, model)), rev = true)
+        sort!(itr, by = i -> length(agents_in_pos(i, model)), rev = true)
     else
         error("unknown `by`")
     end
@@ -35,14 +35,14 @@ end
 
 # TODO: Does this really have to be collecting...?
 function find_empty_nodes(model::ABM{<:AbstractAgent,<:DiscreteSpace})
-    collect(Iterators.filter(i -> length(get_node_contents(i, model)) == 0, nodes(model)))
+    collect(Iterators.filter(i -> length(agents_in_pos(i, model)) == 0, nodes(model)))
 end
 
 """
     isempty(position, model::ABM{A, <:DiscreteSpace})
-Return `true` if there are no agents in `node`.
+Return `true` if there are no agents in `position`.
 """
-Base.isempty(pos, model::ABM) = isempty(get_node_contents(pos, model))
+Base.isempty(pos, model::ABM) = isempty(agents_in_pos(pos, model))
 
 
 """

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -123,7 +123,7 @@ mutable struct Land <: AbstractAgent
     pos::Tuple{Int, Int}
     temperature::Float64
 end
-space = GridSpace((10, 10), moore = true, periodic = true)
+space = GridSpace((10, 10))
 model = ABM(Union{Daisy, Land}, space)
 temperature(pos) = (pos[1]/10, ) # must be Tuple!
 fill_space!(Land, model, temperature)

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -34,6 +34,15 @@ function positions(model::ABM{<:AbstractAgent,<:DiscreteSpace}, by::Symbol)
 end
 
 """
+    ids_in_position(position, model::ABM{A, <:DiscreteSpace})
+    ids_in_position(agent, model::ABM{A, <:DiscreteSpace})
+
+Return the ids of agents in the position corresponding to `position` or position
+of `agent`.
+"""
+ids_in_position(agent::A, model) where {A<:AbstractAgent} = ids_in_position(agent.pos, model)
+
+"""
     agents_in_position(position, model::ABM{A, <:DiscreteSpace})
     agents_in_position(agent, model::ABM{A, <:DiscreteSpace})
 

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -51,9 +51,13 @@ Return the agents in the position corresponding to `position` or position of `ag
 agents_in_position(agent::A, model) where {A<:AbstractAgent} = agents_in_position(agent.pos, model)
 agents_in_position(pos, model) = (model[id] for id in ids_in_position(pos, model))
 
-# TODO: Does this really have to be collecting...?
+"""
+    empty_positions(model)
+
+Return a list of positions that currently have no agents on them.
+"""
 function empty_positions(model::ABM{<:AbstractAgent,<:DiscreteSpace})
-    collect(Iterators.filter(i -> length(ids_in_position(i, model)) == 0, positions(model)))
+    Iterators.filter(i -> length(ids_in_position(i, model)) == 0, positions(model))
 end
 
 """
@@ -78,7 +82,7 @@ Return a random position without any agents, or `nothing` if no such positions e
 function random_empty(model::ABM{<:AbstractAgent,<:DiscreteSpace})
     empty = empty_positions(model)
     isempty(empty) && return nothing
-    rand(empty)
+    rand(collect(empty))
 end
 
 #######################################################################################
@@ -110,7 +114,7 @@ function add_agent_single!(
     properties...;
     kwargs...,
 ) where {A<:AbstractAgent}
-    empty = empty_positions(model)
+    empty = collect(empty_positions(model))
     if length(empty) > 0
         add_agent!(rand(empty), model, properties...; kwargs...)
     end
@@ -187,7 +191,7 @@ function move_agent_single!(
         agent::A,
         model::ABM{A,<:DiscreteSpace},
     ) where {A<:AbstractAgent}
-    empty = empty_positions(model)
+    empty = collect(empty_positions(model))
     if length(empty) > 0
         move_agent!(agent, rand(empty), model)
     end

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -75,11 +75,6 @@ function add_agent_to_space!(
 end
 
 # The following two is for the discrete space API:
-"""
-    ids_in_position(position, model::ABM{A, <:DiscreteSpace})
-
-Return the ids of agents in the position corresponding to `position`.
-"""
 ids_in_position(n::Integer, model::ABM{A,<:GraphSpace}) where {A} = model.space.s[n]
 # NOTICE: The return type of `ids_in_position` must support `length` and `isempty`!
 

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -88,14 +88,14 @@ positions(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
 #######################################################################################
 # Neighbors
 #######################################################################################
-function nearby_agents(pos::Int, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A}
+function nearby_ids(pos::Int, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A}
     np = nearby_positions(pos, model, args...; kwargs...)
     # This call is faster than reduce(vcat, ..), or Iterators.flatten
     vcat(model.space.s[pos], model.space.s[np]...)
 end
 
-function nearby_agents(agent::A, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A<:AbstractAgent}
-    all = nearby_agents(agent.pos, model, args...; kwargs...)
+function nearby_ids(agent::A, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A<:AbstractAgent}
+    all = nearby_ids(agent.pos, model, args...; kwargs...)
     filter!(i -> i ≠ agent.id, all)
 end
 

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -48,8 +48,8 @@ function remove_agent_from_space!(
     model::ABM{A,<:GraphSpace},
 ) where {A<:AbstractAgent}
     agentpos = agent.pos
-    p = agents_in_pos(agentpos, model)
-    splice!(p, findfirst(a -> a == agent.id, p))
+    ids = ids_in_position(agentpos, model)
+    splice!(ids, findfirst(a -> a == agent.id, ids))
     return model
 end
 
@@ -59,10 +59,10 @@ function move_agent!(
     model::ABM{A,<:GraphSpace},
 ) where {A<:AbstractAgent}
     oldpos = agent.pos
-    p = agents_in_pos(oldpos, model)
-    splice!(p, findfirst(a -> a == agent.id, p))
+    ids = ids_in_position(oldpos, model)
+    splice!(ids, findfirst(a -> a == agent.id, ids))
     agent.pos = pos
-    push!(agents_in_pos(agent.pos, model), agent.id)
+    push!(ids_in_position(agent.pos, model), agent.id)
     return agent
 end
 
@@ -70,18 +70,18 @@ function add_agent_to_space!(
     agent::A,
     model::ABM{A,<:DiscreteSpace},
 ) where {A<:AbstractAgent}
-    push!(agents_in_pos(agent.pos, model), agent.id)
+    push!(ids_in_position(agent.pos, model), agent.id)
     return agent
 end
 
 # The following two is for the discrete space API:
 """
-    agents_in_pos(position, model::ABM{A, <:DiscreteSpace})
+    ids_in_position(position, model::ABM{A, <:DiscreteSpace})
 
 Return the ids of agents in the position corresponding to `position`.
 """
-agents_in_pos(n::Integer, model::ABM{A,<:GraphSpace}) where {A} = model.space.s[n]
-# NOTICE: The return type of `agents_in_pos` must support `length` and `isempty`!
+ids_in_position(n::Integer, model::ABM{A,<:GraphSpace}) where {A} = model.space.s[n]
+# NOTICE: The return type of `ids_in_position` must support `length` and `isempty`!
 
 positions(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
 

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -90,16 +90,16 @@ nodes(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
 # Neighbors
 #######################################################################################
 function nearby_agents(pos::Int, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A}
-    nn = node_neighbors(pos, model, args...; kwargs...)
+    np = nearby_positions(pos, model, args...; kwargs...)
     # TODO: Use flatten here or something for performance?
     # `model.space.s[nn]...` allocates, because it creates a new array!
     # Also `vcat` allocates a second time
     # We include the current node in the search since we are searching over space
-    vcat(model.space.s[pos], model.space.s[nn]...)
+    vcat(model.space.s[pos], model.space.s[np]...)
 end
 
-function node_neighbors(
-    node_number::Integer,
+function nearby_positions(
+    position::Integer,
     model::ABM{A,<:GraphSpace};
     neighbor_type::Symbol = :default,
 ) where {A}
@@ -113,33 +113,33 @@ function node_neighbors(
     else
         LightGraphs.all_neighbors
     end
-    neighborfn(model.space.graph, node_number)
+    neighborfn(model.space.graph, position)
 end
 
-function node_neighbors(
-    node_number::Integer,
+function nearby_positions(
+    position::Integer,
     model::ABM{A,<:GraphSpace},
     radius::Integer;
     kwargs...,
 ) where {A}
-    neighbor_nodes = Set(node_neighbors(node_number, model; kwargs...))
-    included_nodes = Set()
+    neighbor_positions = Set(nearby_positions(position, model; kwargs...))
+    included_positions = Set()
     for rad in 2:radius
         templist = Vector{Int}()
-        for nn in neighbor_nodes
-            if !in(nn, included_nodes)
-                newns = node_neighbors(nn, model; kwargs...)
-                for newn in newns
-                    push!(templist, newn)
+        for np in neighbor_positions
+            if !in(np, included_positions)
+                newns = nearby_positions(np, model; kwargs...)
+                for newnp in newnps
+                    push!(templist, newnp)
                 end
             end
         end
         for tt in templist
-            push!(neighbor_nodes, tt)
+            push!(neighbor_positions, tt)
         end
     end
-    nlist = collect(neighbor_nodes)
-    j = findfirst(a -> a == node_number, nlist)
+    nlist = collect(neighbor_positions)
+    j = findfirst(a -> a == position, nlist)
     if j != nothing
         deleteat!(nlist, j)
     end

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -89,7 +89,7 @@ nodes(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
 #######################################################################################
 # Neighbors
 #######################################################################################
-function space_neighbors(pos::Int, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A}
+function nearby_agents(pos::Int, model::ABM{A,<:GraphSpace}, args...; kwargs...) where {A}
     nn = node_neighbors(pos, model, args...; kwargs...)
     # TODO: Use flatten here or something for performance?
     # `model.space.s[nn]...` allocates, because it creates a new array!

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -48,8 +48,8 @@ function remove_agent_from_space!(
     agent::A,
     model::ABM{A,<:GraphSpace},
 ) where {A<:AbstractAgent}
-    agentnode = agent.pos
-    p = get_node_contents(agentnode, model)
+    agentpos = agent.pos
+    p = agents_in_pos(agentpos, model)
     splice!(p, findfirst(a -> a == agent.id, p))
     return model
 end
@@ -59,11 +59,11 @@ function move_agent!(
     pos::ValidPos,
     model::ABM{A,<:GraphSpace},
 ) where {A<:AbstractAgent}
-    oldnode = agent.pos
-    p = get_node_contents(oldnode, model)
+    oldpos = agent.pos
+    p = agents_in_pos(oldpos, model)
     splice!(p, findfirst(a -> a == agent.id, p))
     agent.pos = pos
-    push!(get_node_contents(agent.pos, model), agent.id)
+    push!(agents_in_pos(agent.pos, model), agent.id)
     return agent
 end
 
@@ -71,18 +71,18 @@ function add_agent_to_space!(
     agent::A,
     model::ABM{A,<:DiscreteSpace},
 ) where {A<:AbstractAgent}
-    push!(get_node_contents(agent.pos, model), agent.id)
+    push!(agents_in_pos(agent.pos, model), agent.id)
     return agent
 end
 
 # The following two is for the discrete space API:
 """
-    get_node_contents(position, model::ABM{A, <:DiscreteSpace})
+    agents_in_pos(position, model::ABM{A, <:DiscreteSpace})
 
-Return the ids of agents in the "node" corresponding to `position`.
+Return the ids of agents in the position corresponding to `position`.
 """
-get_node_contents(n::Integer, model::ABM{A,<:GraphSpace}) where {A} = model.space.s[n]
-# NOTICE: The return type of `get_node_contents` must support `length` and `isempty`!
+agents_in_pos(n::Integer, model::ABM{A,<:GraphSpace}) where {A} = model.space.s[n]
+# NOTICE: The return type of `agents_in_pos` must support `length` and `isempty`!
 
 nodes(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
 

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -21,7 +21,7 @@ end
 
 """
     nv(model::ABM)
-Return the number of nodes (vertices) in the `model` space.
+Return the number of positions (vertices) in the `model` space.
 """
 LightGraphs.nv(abm::ABM{<:Any,<:GraphSpace}) = LightGraphs.nv(abm.space.graph)
 
@@ -34,7 +34,7 @@ LightGraphs.ne(abm::ABM{<:Any,<:GraphSpace}) = LightGraphs.ne(abm.space.graph)
 function Base.show(io::IO, space::GraphSpace)
     print(
         io,
-        "$(nameof(typeof(space))) with $(nv(space.graph)) nodes and $(ne(space.graph)) edges",
+        "$(nameof(typeof(space))) with $(nv(space.graph)) positions and $(ne(space.graph)) edges",
     )
 end
 
@@ -84,7 +84,7 @@ Return the ids of agents in the position corresponding to `position`.
 agents_in_pos(n::Integer, model::ABM{A,<:GraphSpace}) where {A} = model.space.s[n]
 # NOTICE: The return type of `agents_in_pos` must support `length` and `isempty`!
 
-nodes(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
+positions(model::ABM{<:AbstractAgent,<:GraphSpace}) = 1:nv(model)
 
 #######################################################################################
 # Neighbors
@@ -94,7 +94,7 @@ function nearby_agents(pos::Int, model::ABM{A,<:GraphSpace}, args...; kwargs...)
     # TODO: Use flatten here or something for performance?
     # `model.space.s[nn]...` allocates, because it creates a new array!
     # Also `vcat` allocates a second time
-    # We include the current node in the search since we are searching over space
+    # We include the current position in the search since we are searching over space
     vcat(model.space.s[pos], model.space.s[np]...)
 end
 

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -27,7 +27,7 @@ end
     GridSpace(d::NTuple{D, Int}; periodic = true, metric = :chebyshev)
 Create a `GridSpace` that has size given by the tuple `d`, having `D ≥ 1` dimensions.
 Optionally decide whether the space will be periodic and what will be the distance metric
-used, which decides the behavior of e.g. [`space_neighbors`](@ref).
+used, which decides the behavior of e.g. [`nearby_agents`](@ref).
 The position type for this space is `NTuple{D, Int}` and valid nodes have indices
 in the range `1:d[i]` for the `i`th dimension.
 
@@ -162,7 +162,7 @@ grid_space_neighborhood(α, model::ABM, r) = grid_space_neighborhood(α, model.s
 ##########################################################################################
 # %% Extend neighbors API for spaces
 ##########################################################################################
-function space_neighbors(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}, r = 1)
+function nearby_agents(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}, r = 1)
     nn = grid_space_neighborhood(CartesianIndex(pos), model, r)
     s = model.space.s
     Iterators.flatten((s[i...] for i in nn))

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -181,7 +181,7 @@ function nodes(model::ABM{<:AbstractAgent,<:GridSpace})
     return (Tuple(y) for y in x)
 end
 
-function get_node_contents(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace})
+function agents_in_pos(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace})
     return model.space.s[pos...]
 end
 

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -121,10 +121,10 @@ end
 """
     grid_space_neighborhood(α::CartesianIndex, space::GridSpace, r::Real)
 
-Return an iterator over all nodes within distance `r` from `α` according to the `space`.
+Return an iterator over all positions within distance `r` from `α` according to the `space`.
 
-The only reason this function is not equivalent with `node_neighbors` is because
-`node_neighbors` skips the current position `α`, while `α` is always included in the
+The only reason this function is not equivalent with `nearby_positions` is because
+`nearby_positions` skips the current position `α`, while `α` is always included in the
 returned iterator (because the `0` index is always included in `βs`).
 
 This function re-uses the source code of TimeseriesPrediction.jl, along with the
@@ -168,7 +168,7 @@ function nearby_agents(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}, r
     Iterators.flatten((s[i...] for i in nn))
 end
 
-function node_neighbors(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}, r = 1)
+function nearby_positions(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}, r = 1)
     nn = grid_space_neighborhood(CartesianIndex(pos), model, r)
     Iterators.filter(!isequal(pos), nn)
 end

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -27,7 +27,7 @@ end
     GridSpace(d::NTuple{D, Int}; periodic = true, metric = :chebyshev)
 Create a `GridSpace` that has size given by the tuple `d`, having `D ≥ 1` dimensions.
 Optionally decide whether the space will be periodic and what will be the distance metric
-used, which decides the behavior of e.g. [`nearby_agents`](@ref).
+used, which decides the behavior of e.g. [`nearby_ids`](@ref).
 The position type for this space is `NTuple{D, Int}` and valid positions have indices
 in the range `1:d[i]` for the `i`th dimension.
 
@@ -164,7 +164,7 @@ grid_space_neighborhood(α, model::ABM, r) = grid_space_neighborhood(α, model.s
 ##########################################################################################
 # %% Extend neighbors API for spaces
 ##########################################################################################
-function nearby_agents(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}, r = 1)
+function nearby_ids(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}, r = 1)
     nn = grid_space_neighborhood(CartesianIndex(pos), model, r)
     s = model.space.s
     Iterators.flatten((s[i...] for i in nn))

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -7,7 +7,7 @@ end
 
 """
     Hood{D}
-Internal struct for efficiently finding neighboring nodes to a given node.
+Internal struct for efficiently finding neighboring positions to a given position.
 It contains pre-initialized neighbor cartesian indices and delimiters of when the
 neighboring indices would exceed the size of the underlying array.
 """
@@ -28,14 +28,16 @@ end
 Create a `GridSpace` that has size given by the tuple `d`, having `D ≥ 1` dimensions.
 Optionally decide whether the space will be periodic and what will be the distance metric
 used, which decides the behavior of e.g. [`nearby_agents`](@ref).
-The position type for this space is `NTuple{D, Int}` and valid nodes have indices
+The position type for this space is `NTuple{D, Int}` and valid positions have indices
 in the range `1:d[i]` for the `i`th dimension.
 
-`:chebyshev` metric means that the `r`-neighborhood of a node are all
-nodes within the hypercube having side length of `2*floor(r)` and being centered in the node.
+`:chebyshev` metric means that the `r`-neighborhood of a position are all
+positions within the hypercube having side length of `2*floor(r)` and being centered in
+the origin position.
 
-`:euclidean` metric means that the `r`-neighborhood of a node are all nodes whose cartesian
-indices have Euclidean distance `≤ r` from the cartesian index of the given node.
+`:euclidean` metric means that the `r`-neighborhood of a position are all positions whose
+cartesian indices have Euclidean distance `≤ r` from the cartesian index of the given
+position.
 """
 function GridSpace(
         d::NTuple{D,Int};
@@ -174,9 +176,9 @@ function nearby_positions(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace}
 end
 
 #######################################################################################
-# %% Further discrete space  functions
+# %% Further discrete space functions
 #######################################################################################
-function nodes(model::ABM{<:AbstractAgent,<:GridSpace})
+function positions(model::ABM{<:AbstractAgent,<:GridSpace})
     x = CartesianIndices(model.space.s)
     return (Tuple(y) for y in x)
 end

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -183,7 +183,7 @@ function positions(model::ABM{<:AbstractAgent,<:GridSpace})
     return (Tuple(y) for y in x)
 end
 
-function agents_in_pos(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace})
+function ids_in_position(pos::ValidPos, model::ABM{<:AbstractAgent,<:GridSpace})
     return model.space.s[pos...]
 end
 

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -308,6 +308,7 @@ end
   genocide!(model, a -> a.id > 5)
   @test nagents(model) == 5
 
+  Random.seed!(6465)
   # Testing genocide!(model::ABM, f::Function) when the function is invalid
   # (i.e. does not return a bool)
   for i in 1:20

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -148,7 +148,7 @@ end
       agent = Agent7(id, 2, attributes...)
       add_agent_single!(agent, model)
   end
-  @test length(find_empty_nodes(model)) == 0
+  @test !has_empty_positions(model)
   agent = Agent7(12,5, attributes...)
   add_agent_single!(agent, model)
   @test_throws KeyError model[12]

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -248,8 +248,8 @@ end
   add_agent!((1,3), model)
   add_agent!((5,2), model)
   @test nagents(model) == 3
-  for agent in copy(agents_in_pos((1,3), model))
-    kill_agent!(agent, model)
+  for id in copy(ids_in_position((1,3), model))
+    kill_agent!(id, model)
   end
   @test nagents(model) == 1
   # ContinuousSpace

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -248,7 +248,7 @@ end
   add_agent!((1,3), model)
   add_agent!((5,2), model)
   @test nagents(model) == 3
-  for agent in copy(get_node_contents((1,3), model))
+  for agent in copy(agents_in_pos((1,3), model))
     kill_agent!(agent, model)
   end
   @test nagents(model) == 1

--- a/test/benchmark/DynamicGrids/agents.jl
+++ b/test/benchmark/DynamicGrids/agents.jl
@@ -39,8 +39,8 @@ function forest_step!(forest)
         if rand() ≤ forest.properties[:f]  # the tree ignites spntaneously
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
-          for cell in node_neighbors(node, forest)
-            neighbors = get_node_contents(cell, forest)
+          for pos in nearby_positions(node, forest)
+            neighbors = get_node_contents(pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/DynamicGrids/agents.jl
+++ b/test/benchmark/DynamicGrids/agents.jl
@@ -10,8 +10,8 @@ function model_initiation(; f, p, griddims)
     space = GridSpace(griddims, moore = true)
     properties = Dict(:f => f, :p => p)
     forest = AgentBasedModel(Tree, space; properties=properties)
-    for node in nodes(forest)
-        add_agent!(node, forest, true)
+    for pos in positions(forest)
+        add_agent!(pos, forest, true)
     end
     return forest
 end
@@ -26,11 +26,11 @@ println("time to initialize model")
 # stepping function for the model
 
 function forest_step!(forest)
-  for node in nodes(forest, by = :random)
-    ap = agents_in_pos(node, forest)
+  for pos in positions(forest, by = :random)
+    ap = agents_in_pos(pos, forest)
     ## the position is empty, maybe a tree grows here
     if length(ap) == 0
-        rand() ≤ forest.properties[:p] && add_agent!(node, forest, true)
+        rand() ≤ forest.properties[:p] && add_agent!(pos, forest, true)
     else
       tree = forest[ap[1]] # by definition only 1 agent per position
       if tree.status == false  # if it is has been burning, remove it.
@@ -39,8 +39,8 @@ function forest_step!(forest)
         if rand() ≤ forest.properties[:f]  # the tree ignites spntaneously
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
-          for pos in nearby_positions(node, forest)
-            neighbors = agents_in_pos(pos, forest)
+          for n_pos in nearby_positions(pos, forest)
+            neighbors = agents_in_pos(n_pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/DynamicGrids/agents.jl
+++ b/test/benchmark/DynamicGrids/agents.jl
@@ -7,7 +7,7 @@ mutable struct Tree <: AbstractAgent
 end
 
 function model_initiation(; f, p, griddims)
-    space = GridSpace(griddims, moore = true)
+    space = GridSpace(griddims, periodic = false)
     properties = Dict(:f => f, :p => p)
     forest = AgentBasedModel(Tree, space; properties=properties)
     for pos in positions(forest)

--- a/test/benchmark/DynamicGrids/agents.jl
+++ b/test/benchmark/DynamicGrids/agents.jl
@@ -27,12 +27,12 @@ println("time to initialize model")
 
 function forest_step!(forest)
   for pos in positions(forest, by = :random)
-    ap = agents_in_pos(pos, forest)
+    ids = ids_in_position(pos, forest)
     ## the position is empty, maybe a tree grows here
-    if length(ap) == 0
+    if length(ids) == 0
         rand() ≤ forest.properties[:p] && add_agent!(pos, forest, true)
     else
-      tree = forest[ap[1]] # by definition only 1 agent per position
+      tree = forest[ids[1]] # by definition only 1 agent per position
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else
@@ -40,7 +40,7 @@ function forest_step!(forest)
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
           for n_pos in nearby_positions(pos, forest)
-            neighbors = agents_in_pos(n_pos, forest)
+            neighbors = ids_in_position(n_pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/DynamicGrids/agents.jl
+++ b/test/benchmark/DynamicGrids/agents.jl
@@ -27,12 +27,12 @@ println("time to initialize model")
 
 function forest_step!(forest)
   for node in nodes(forest, by = :random)
-    nc = get_node_contents(node, forest)
-    ## the cell is empty, maybe a tree grows here
-    if length(nc) == 0
+    ap = agents_in_pos(node, forest)
+    ## the position is empty, maybe a tree grows here
+    if length(ap) == 0
         rand() ≤ forest.properties[:p] && add_agent!(node, forest, true)
     else
-      tree = forest[nc[1]] # by definition only 1 agent per node
+      tree = forest[ap[1]] # by definition only 1 agent per position
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else
@@ -40,7 +40,7 @@ function forest_step!(forest)
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
           for pos in nearby_positions(node, forest)
-            neighbors = get_node_contents(pos, forest)
+            neighbors = agents_in_pos(pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/forestFire_defs.jl
+++ b/test/benchmark/forestFire_defs.jl
@@ -22,12 +22,12 @@ end
 
 function forest_step!(forest)
   for pos in positions(forest, by = :random)
-    ap = agents_in_pos(pos, forest)
+    ids = ids_in_position(pos, forest)
     ## the position is empty, maybe a tree grows here
-    if length(ap) == 0
+    if length(ids) == 0
         rand() ≤ forest.p && add_agent!(pos, forest, true)
     else
-      tree = forest[ap[1]] # by definition only 1 agent per position
+      tree = forest[ids[1]] # by definition only 1 agent per position
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else
@@ -35,7 +35,7 @@ function forest_step!(forest)
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
           for n_pos in nearby_positions(pos, forest)
-            neighbors = agents_in_pos(n_pos, forest)
+            neighbors = ids_in_position(n_pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/forestFire_defs.jl
+++ b/test/benchmark/forestFire_defs.jl
@@ -6,7 +6,7 @@ end
 
 function model_initiation(; f = 0.02, d = 0.8, p = 0.01, griddims=(100,100), seed = 111)
     Random.seed!(seed)
-    space = GridSpace(griddims, moore = true)
+    space = GridSpace(griddims, period = false)
     properties = Dict(:f => f, :d => d, :p => p)
     forest = AgentBasedModel(Tree, space; properties = properties)
 

--- a/test/benchmark/forestFire_defs.jl
+++ b/test/benchmark/forestFire_defs.jl
@@ -22,12 +22,12 @@ end
 
 function forest_step!(forest)
   for node in nodes(forest, by = :random)
-    nc = get_node_contents(node, forest)
+    ap = agents_in_pos(node, forest)
     ## the cell is empty, maybe a tree grows here
-    if length(nc) == 0
+    if length(ap) == 0
         rand() ≤ forest.p && add_agent!(node, forest, true)
     else
-      tree = forest[nc[1]] # by definition only 1 agent per node
+      tree = forest[ap[1]] # by definition only 1 agent per node
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else
@@ -35,7 +35,7 @@ function forest_step!(forest)
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
           for pos in nearby_positions(node, forest)
-            neighbors = get_node_contents(pos, forest)
+            neighbors = agents_in_pos(pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/forestFire_defs.jl
+++ b/test/benchmark/forestFire_defs.jl
@@ -23,7 +23,7 @@ end
 function forest_step!(forest)
   for pos in positions(forest, by = :random)
     ap = agents_in_pos(pos, forest)
-    ## the cell is empty, maybe a tree grows here
+    ## the position is empty, maybe a tree grows here
     if length(ap) == 0
         rand() ≤ forest.p && add_agent!(pos, forest, true)
     else

--- a/test/benchmark/forestFire_defs.jl
+++ b/test/benchmark/forestFire_defs.jl
@@ -34,8 +34,8 @@ function forest_step!(forest)
         if rand() ≤ forest.f  # the tree ignites spontaneously
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
-          for cell in node_neighbors(node, forest)
-            neighbors = get_node_contents(cell, forest)
+          for pos in nearby_positions(node, forest)
+            neighbors = get_node_contents(pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/forestFire_defs.jl
+++ b/test/benchmark/forestFire_defs.jl
@@ -10,32 +10,32 @@ function model_initiation(; f = 0.02, d = 0.8, p = 0.01, griddims=(100,100), see
     properties = Dict(:f => f, :d => d, :p => p)
     forest = AgentBasedModel(Tree, space; properties = properties)
 
-    ## create and add trees to each node with probability d,
+    ## create and add trees to each position with probability d,
     ## which determines the density of the forest
-    for node in nodes(forest)
+    for pos in positions(forest)
         if rand() ≤ forest.d
-            add_agent!(node, forest, true)
+            add_agent!(pos, forest, true)
         end
     end
     return forest
 end
 
 function forest_step!(forest)
-  for node in nodes(forest, by = :random)
-    ap = agents_in_pos(node, forest)
+  for pos in positions(forest, by = :random)
+    ap = agents_in_pos(pos, forest)
     ## the cell is empty, maybe a tree grows here
     if length(ap) == 0
-        rand() ≤ forest.p && add_agent!(node, forest, true)
+        rand() ≤ forest.p && add_agent!(pos, forest, true)
     else
-      tree = forest[ap[1]] # by definition only 1 agent per node
+      tree = forest[ap[1]] # by definition only 1 agent per position
       if tree.status == false  # if it is has been burning, remove it.
         kill_agent!(tree, forest)
       else
         if rand() ≤ forest.f  # the tree ignites spontaneously
           tree.status = false
         else  # if any neighbor is on fire, set this tree on fire too
-          for pos in nearby_positions(node, forest)
-            neighbors = agents_in_pos(pos, forest)
+          for n_pos in nearby_positions(pos, forest)
+            neighbors = agents_in_pos(n_pos, forest)
             length(neighbors) == 0 && continue
             if any(n -> !forest.agents[n].status, neighbors)
               tree.status = false

--- a/test/benchmark/mesa/boid/boid.jl
+++ b/test/benchmark/mesa/boid/boid.jl
@@ -37,7 +37,7 @@ end
 # according to the three rules defined above.
 function agent_step!(bird, model)
     # Obtain the ids of neibhors within the bird's visual distance
-    ids = space_neighbors(bird, model, bird.visual_distance)
+    ids = nearby_agents(bird, model, bird.visual_distance)
     # Compute velocity based on rules defined above
     bird.vel = (bird.vel .+ cohere(bird, model, ids) .+ seperate(bird, model, ids)
         .+ match(bird, model, ids))./2

--- a/test/benchmark/mesa/boid/boid.jl
+++ b/test/benchmark/mesa/boid/boid.jl
@@ -37,7 +37,7 @@ end
 # according to the three rules defined above.
 function agent_step!(bird, model)
     # Obtain the ids of neibhors within the bird's visual distance
-    ids = nearby_agents(bird, model, bird.visual_distance)
+    ids = space_neighbors(bird, model, bird.visual_distance)
     # Compute velocity based on rules defined above
     bird.vel = (bird.vel .+ cohere(bird, model, ids) .+ seperate(bird, model, ids)
         .+ match(bird, model, ids))./2

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -14,7 +14,7 @@ end
 function model_initiation(;d, griddims, seed)
   Random.seed!(seed)
 
-  space = GridSpace(griddims, moore = true)
+  space = GridSpace(griddims, periodic = false)
 
   properties = Dict(:d => d)
   forest = ABM(Tree, space; properties=properties, scheduler=random_activation)

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -38,9 +38,9 @@ end
 function tree_step!(tree, forest)
   if tree.status == 2
     tree.status = 3
-    neighbor_cells = node_neighbors(tree, forest)
-    for cell in neighbor_cells
-      treeid = get_node_contents(cell, forest)
+    neighbor_positions = nearby_positions(tree, forest)
+    for pos in neighbor_positions
+      treeid = get_node_contents(pos, forest)
       if length(treeid) != 0 # the cell is not empty
         treen = forest.agents[treeid[1]]
         if treen.status == 1

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -39,7 +39,7 @@ function tree_step!(tree, forest)
   if tree.status == 2
     tree.status = 3
     for pos in nearby_positions(tree, forest)
-      treeid = agents_in_pos(pos, forest)
+      treeid = ids_in_position(pos, forest)
       if length(treeid) != 0 # the position is not empty
         treen = forest.agents[treeid[1]]
         if treen.status == 1

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -19,17 +19,17 @@ function model_initiation(;d, griddims, seed)
   properties = Dict(:d => d)
   forest = ABM(Tree, space; properties=properties, scheduler=random_activation)
 
-  # create and add trees to each node with probability d, which determines the density of the forest
-  for node in 1:nv(forest)
+  # create and add trees to each position with probability d, which determines the density of the forest
+  for pos in positions(forest)
     pp = rand()
     if pp <= forest.properties[:d]
       # Set all trees in the first column on fire.
-      if Agents.vertex2coord(node, forest)[1] == 1
-        tree = Tree(node, (1,1), 2)
+      if pos[1] == 1
+        tree = Tree(pos, (1,1), 2)
       else
-        tree = Tree(node, (1,1), 1)
+        tree = Tree(pos, (1,1), 1)
       end
-      add_agent!(tree, node, forest)
+      add_agent!(tree, pos, forest)
     end
   end
   return forest
@@ -38,10 +38,9 @@ end
 function tree_step!(tree, forest)
   if tree.status == 2
     tree.status = 3
-    neighbor_cells = node_neighbors(tree, forest)
-    for cell in neighbor_cells
-      treeid = get_node_contents(cell, forest)
-      if length(treeid) != 0 # the cell is not empty
+    for pos in nearby_positions(tree, forest)
+      treeid = agents_in_pos(pos, forest)
+      if length(treeid) != 0 # the position is not empty
         treen = forest.agents[treeid[1]]
         if treen.status == 1
           treen.status = 2

--- a/test/benchmark/mesa/forest_fire.jl
+++ b/test/benchmark/mesa/forest_fire.jl
@@ -38,9 +38,9 @@ end
 function tree_step!(tree, forest)
   if tree.status == 2
     tree.status = 3
-    neighbor_positions = nearby_positions(tree, forest)
-    for pos in neighbor_positions
-      treeid = get_node_contents(pos, forest)
+    neighbor_cells = node_neighbors(tree, forest)
+    for cell in neighbor_cells
+      treeid = get_node_contents(cell, forest)
       if length(treeid) != 0 # the cell is not empty
         treen = forest.agents[treeid[1]]
         if treen.status == 1

--- a/test/benchmark/schelling_defs.jl
+++ b/test/benchmark/schelling_defs.jl
@@ -2,7 +2,7 @@
 mutable struct SchellingAgent <: AbstractAgent
   id::Int # The identifier number of the agent
   pos::Tuple{Int,Int} # The x, y location of the agent
-  mood::Bool # whether the agent is happy in its node. (true = happy)
+  mood::Bool # whether the agent is happy in its position. (true = happy)
   group::Int # The group of the agent,
              # determines mood as it interacts with neighbors
 end
@@ -46,7 +46,7 @@ function agent_step!(agent, model)
 
       # After counting the neighbors, decide whether or not to move the agent.
       # If count_neighbors_same_group is at least the min_to_be_happy, set the
-      # mood to true. Otherwise, move the agent to a random node.
+      # mood to true. Otherwise, move the agent to a random position.
       if count_neighbors_same_group ≥ minhappy
           agent.mood = true
       else

--- a/test/benchmark/schelling_defs.jl
+++ b/test/benchmark/schelling_defs.jl
@@ -26,12 +26,12 @@ function agent_step!(agent, model)
   agent.mood == true && return # do nothing if already happy
   minhappy = model.properties[:min_to_be_happy]
   # while agent.mood == false
-      neighbor_cells = node_neighbors(agent, model)
+      neighbor_positions = nearby_positions(agent, model)
       count_neighbors_same_group = 0
       # For each neighbor, get group and compare to current agent's group
       # and increment count_neighbors_same_group as appropriately.
-      for neighbor_cell in neighbor_cells
-          node_contents = get_node_contents(neighbor_cell, model)
+      for neighbor_pos in neighbor_positions
+          node_contents = get_node_contents(neighbor_pos, model)
           # Skip iteration if the node is empty.
           length(node_contents) == 0 && continue
           # Otherwise, get the first agent in the node...

--- a/test/benchmark/schelling_defs.jl
+++ b/test/benchmark/schelling_defs.jl
@@ -31,7 +31,7 @@ function agent_step!(agent, model)
       # For each neighbor, get group and compare to current agent's group
       # and increment count_neighbors_same_group as appropriately.
       for neighbor_pos in neighbor_positions
-          pos_contents = agents_in_pos(neighbor_pos, model)
+          pos_contents = ids_in_position(neighbor_pos, model)
           # Skip iteration if the position is empty.
           length(pos_contents) == 0 && continue
           # Otherwise, get the first agent in the position...

--- a/test/benchmark/schelling_defs.jl
+++ b/test/benchmark/schelling_defs.jl
@@ -10,7 +10,7 @@ end
 
 function instantiate_modelS(;numagents=320, griddims=(20, 20), min_to_be_happy=3)
 
-  space = GridSpace(griddims, moore = true)
+  space = GridSpace(griddims, periodic = false)
 
   properties = Dict(:min_to_be_happy => min_to_be_happy)
   schelling = ABM(SchellingAgent, space; properties = properties, scheduler=random_activation)

--- a/test/benchmark/schelling_defs.jl
+++ b/test/benchmark/schelling_defs.jl
@@ -31,11 +31,11 @@ function agent_step!(agent, model)
       # For each neighbor, get group and compare to current agent's group
       # and increment count_neighbors_same_group as appropriately.
       for neighbor_pos in neighbor_positions
-          node_contents = get_node_contents(neighbor_pos, model)
-          # Skip iteration if the node is empty.
-          length(node_contents) == 0 && continue
-          # Otherwise, get the first agent in the node...
-          agent_id = node_contents[1]
+          pos_contents = agents_in_pos(neighbor_pos, model)
+          # Skip iteration if the position is empty.
+          length(pos_contents) == 0 && continue
+          # Otherwise, get the first agent in the position...
+          agent_id = pos_contents[1]
           # ...and increment count_neighbors_same_group if the neighbor's group is
           # the same.
           neighbor_agent_group = model.agents[agent_id].group

--- a/test/continuousSpace_tests.jl
+++ b/test/continuousSpace_tests.jl
@@ -66,14 +66,14 @@
   agent2 = model1.agents[2]
   agent3 = Agent6(3, agent2.pos .+ 0.005, vel, dia)
   add_agent_pos!(agent3, model1)
-  n_ids = space_neighbors(agent2, model1, agent2.weight)
+  n_ids = nearby_agents(agent2, model1, agent2.weight)
   @test length(n_ids) == 1
   @test n_ids[1] == 3
-  n_ids = space_neighbors(agent2, model1, agent2.weight/10)
+  n_ids = nearby_agents(agent2, model1, agent2.weight/10)
   @test length(n_ids) == 0
 
   # test that it finds both
-  n_ids = space_neighbors(agent2.pos, model1, agent2.weight)
+  n_ids = nearby_agents(agent2.pos, model1, agent2.weight)
   @test sort!(n_ids) == [2, 3]
 
   # test various metrics
@@ -85,8 +85,8 @@
     add_agent_pos!(a, c)
     add_agent_pos!(a, e)
   end
-  @test length(space_neighbors((1, 1), c, r)) == 10
-  @test 4 < length(space_neighbors((1, 1), e, r)) < 10
+  @test length(nearby_agents((1, 1), c, r)) == 10
+  @test 4 < length(nearby_agents((1, 1), e, r)) < 10
 end
 
 mutable struct AgentU1 <: AbstractAgent

--- a/test/continuousSpace_tests.jl
+++ b/test/continuousSpace_tests.jl
@@ -66,14 +66,14 @@
   agent2 = model1.agents[2]
   agent3 = Agent6(3, agent2.pos .+ 0.005, vel, dia)
   add_agent_pos!(agent3, model1)
-  n_ids = nearby_agents(agent2, model1, agent2.weight)
+  n_ids = nearby_ids(agent2, model1, agent2.weight)
   @test length(n_ids) == 1
   @test n_ids[1] == 3
-  n_ids = nearby_agents(agent2, model1, agent2.weight/10)
+  n_ids = nearby_ids(agent2, model1, agent2.weight/10)
   @test length(n_ids) == 0
 
   # test that it finds both
-  n_ids = nearby_agents(agent2.pos, model1, agent2.weight)
+  n_ids = nearby_ids(agent2.pos, model1, agent2.weight)
   @test sort!(n_ids) == [2, 3]
 
   # test various metrics
@@ -85,8 +85,8 @@
     add_agent_pos!(a, c)
     add_agent_pos!(a, e)
   end
-  @test length(nearby_agents((1, 1), c, r)) == 10
-  @test 4 < length(nearby_agents((1, 1), e, r)) < 10
+  @test length(nearby_ids((1, 1), c, r)) == 10
+  @test 4 < length(nearby_ids((1, 1), e, r)) < 10
 end
 
 mutable struct AgentU1 <: AbstractAgent

--- a/test/model_access.jl
+++ b/test/model_access.jl
@@ -1,8 +1,6 @@
-# %% accessing model
 @testset "Model Access" begin
 @testset "Accessing model" begin
     model = ABM(Agent0; properties = Dict(:a => 2, :b => "test"))
-    # add 5 aents
     for i in 1:5
         add_agent!(model)
     end
@@ -16,7 +14,6 @@
     @test model.a == 2
     @test model.b == "test"
 
-
     newa = Agent0(6)
     model[6] = newa
     @test model[6] == newa
@@ -25,7 +22,6 @@
     prop2 = Agent2(1, 0.5)
     model2 = ABM(Agent0; properties = prop2)
     @test model2.weight == 0.5
-
 end
 
 @testset "model access typestability" begin
@@ -45,7 +41,7 @@ end
     @test Agents.agenttype(model) == Agent3
     @test Agents.spacetype(model) <: GridSpace
     @test size(model.space) == (5,5)
-    @test all(isempty(n, model) for n in nodes(model))
+    @test all(isempty(p, model) for p in positions(model))
 end
 
 @testset "Display" begin

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -76,15 +76,15 @@ end
     end
     # only positions (1,3) and (2,3) should be empty
     @test random_empty(model) ∈ [(1,3), (2,3)]
-    node_map = [(1, 1)  (1, 2)  (1, 3)
-                (2, 1)  (2, 2)  (2, 3)
-                (3, 1)  (3, 2)  (3, 3)]
-    @test collect(nodes(model)) == node_map
-    random_nodes = nodes(model, :random)
-    @test all(n ∈ node_map for n in random_nodes)
-    @test nodes(model, :population) == [node_map[i] for i in [1, 2, 3, 4, 5, 6, 9, 7, 8]]
+    pos_map = [(1, 1)  (1, 2)  (1, 3)
+               (2, 1)  (2, 2)  (2, 3)
+               (3, 1)  (3, 2)  (3, 3)]
+    @test collect(positions(model)) == pos_map
+    random_positions = positions(model, :random)
+    @test all(n ∈ pos_map for n in random_positions)
+    @test positions(model, :population) == [pos_map[i] for i in [1, 2, 3, 4, 5, 6, 9, 7, 8]]
     @test length(agents_in_pos(5, model)) > length(agents_in_pos(7, model))
-    @test_throws ErrorException nodes(model, :notreal)
+    @test_throws ErrorException positions(model, :notreal)
 end
 
 @testset "Neighbors" begin

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -100,9 +100,9 @@ end
     add_agent!(2, undirected, rand())
     add_agent!(3, undirected, rand())
     # We expect id 2 to be included for a grid based search
-    @test sort!(collect(space_neighbors(2, undirected))) == [1, 2, 3]
+    @test sort!(collect(nearby_agents(2, undirected))) == [1, 2, 3]
     # But to be excluded if we are looking around it.
-    @test sort!(collect(space_neighbors(undirected[2], undirected))) == [1, 3]
+    @test sort!(collect(nearby_agents(undirected[2], undirected))) == [1, 3]
 
     directed = ABM(Agent5, GraphSpace(path_digraph(5)))
     @test node_neighbors(3, directed) == [4]
@@ -116,36 +116,36 @@ end
     add_agent!(1, directed, rand())
     add_agent!(2, directed, rand())
     add_agent!(3, directed, rand())
-    @test sort!(space_neighbors(2, directed)) == [2, 3]
-    @test sort!(space_neighbors(2, directed; neighbor_type=:in)) == [1, 2]
-    @test sort!(space_neighbors(2, directed; neighbor_type=:all)) == [1, 2, 3]
-    @test collect(space_neighbors(directed[2], directed)) == [3]
-    @test collect(space_neighbors(directed[2], directed; neighbor_type=:in)) == [1]
-    @test sort!(collect(space_neighbors(directed[2], directed; neighbor_type=:all))) == [1, 3]
+    @test sort!(nearby_agents(2, directed)) == [2, 3]
+    @test sort!(nearby_agents(2, directed; neighbor_type=:in)) == [1, 2]
+    @test sort!(nearby_agents(2, directed; neighbor_type=:all)) == [1, 2, 3]
+    @test collect(nearby_agents(directed[2], directed)) == [3]
+    @test collect(nearby_agents(directed[2], directed; neighbor_type=:in)) == [1]
+    @test sort!(collect(nearby_agents(directed[2], directed; neighbor_type=:all))) == [1, 3]
 
     gridspace = ABM(Agent3, GridSpace((3, 3); metric = :euclidean, periodic = false))
     @test collect(node_neighbors((2, 2), gridspace)) == [(2, 1), (1, 2), (3, 2), (2, 3)]
     @test collect(node_neighbors((1, 1), gridspace)) == [(2, 1), (1, 2)]
     a = add_agent!((2, 2), gridspace, rand())
     add_agent!((3, 2), gridspace, rand())
-    @test collect(space_neighbors((1, 2), gridspace)) == [1]
-    @test sort!(collect(space_neighbors((1, 2), gridspace, 2))) == [1, 2]
-    @test sort!(collect(space_neighbors((2, 2), gridspace))) == [1, 2]
-    @test collect(space_neighbors(a, gridspace)) == [2]
+    @test collect(nearby_agents((1, 2), gridspace)) == [1]
+    @test sort!(collect(nearby_agents((1, 2), gridspace, 2))) == [1, 2]
+    @test sort!(collect(nearby_agents((2, 2), gridspace))) == [1, 2]
+    @test collect(nearby_agents(a, gridspace)) == [2]
 
     continuousspace = ABM(Agent6, ContinuousSpace(2; extend = (1, 1)))
     a = add_agent!((0.5, 0.5), continuousspace, (0.2, 0.1), 0.01)
     b = add_agent!((0.6, 0.5), continuousspace, (0.1, -0.1), 0.01)
     @test_throws ErrorException node_neighbors(1, continuousspace)
-    @test space_neighbors(a, continuousspace, 0.05) == []
-    @test space_neighbors(a, continuousspace, 0.1) == [2]
-    @test sort!(space_neighbors((0.55, 0.5), continuousspace, 0.05)) == [1, 2]
+    @test nearby_agents(a, continuousspace, 0.05) == []
+    @test nearby_agents(a, continuousspace, 0.1) == [2]
+    @test sort!(nearby_agents((0.55, 0.5), continuousspace, 0.05)) == [1, 2]
     move_agent!(a, continuousspace)
     move_agent!(b, continuousspace)
-    @test space_neighbors(a, continuousspace, 0.1) == []
+    @test nearby_agents(a, continuousspace, 0.1) == []
     # Checks for type instability #208
-    @test typeof(space_neighbors(a, continuousspace, 0.1)) <: Vector{Int}
-    @test typeof(space_neighbors((0.55, 0.5), continuousspace, 0.05)) <: Vector{Int}
+    @test typeof(nearby_agents(a, continuousspace, 0.1)) <: Vector{Int}
+    @test typeof(nearby_agents((0.55, 0.5), continuousspace, 0.05)) <: Vector{Int}
 end
 
 @testset "Discrete space mutability" begin

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -44,7 +44,7 @@ end
     @test d.metric == :euclidean
 end
 
-@testset "3D grid" begin
+@testset "3D grids" begin
     a = GridSpace((2, 3, 4))
     @test size(a) == (2, 3, 4)
     @test typeof(a.s) <: Array{Array{Int64,1},3}
@@ -87,7 +87,7 @@ end
     @test_throws ErrorException positions(model, :notreal)
 end
 
-@testset "Neighbors" begin
+@testset "Nearby Agents" begin
     undirected = ABM(Agent5, GraphSpace(path_graph(5)))
     @test nearby_positions(3, undirected) == [2, 4]
     @test nearby_positions(1, undirected) == [2]
@@ -100,9 +100,9 @@ end
     add_agent!(2, undirected, rand())
     add_agent!(3, undirected, rand())
     # We expect id 2 to be included for a grid based search
-    @test sort!(collect(nearby_agents(2, undirected))) == [1, 2, 3]
+    @test sort!(collect(nearby_ids(2, undirected))) == [1, 2, 3]
     # But to be excluded if we are looking around it.
-    @test sort!(collect(nearby_agents(undirected[2], undirected))) == [1, 3]
+    @test sort!(collect(nearby_ids(undirected[2], undirected))) == [1, 3]
 
     directed = ABM(Agent5, GraphSpace(path_digraph(5)))
     @test nearby_positions(3, directed) == [4]
@@ -116,36 +116,36 @@ end
     add_agent!(1, directed, rand())
     add_agent!(2, directed, rand())
     add_agent!(3, directed, rand())
-    @test sort!(nearby_agents(2, directed)) == [2, 3]
-    @test sort!(nearby_agents(2, directed; neighbor_type=:in)) == [1, 2]
-    @test sort!(nearby_agents(2, directed; neighbor_type=:all)) == [1, 2, 3]
-    @test collect(nearby_agents(directed[2], directed)) == [3]
-    @test collect(nearby_agents(directed[2], directed; neighbor_type=:in)) == [1]
-    @test sort!(collect(nearby_agents(directed[2], directed; neighbor_type=:all))) == [1, 3]
+    @test sort!(nearby_ids(2, directed)) == [2, 3]
+    @test sort!(nearby_ids(2, directed; neighbor_type=:in)) == [1, 2]
+    @test sort!(nearby_ids(2, directed; neighbor_type=:all)) == [1, 2, 3]
+    @test collect(nearby_ids(directed[2], directed)) == [3]
+    @test collect(nearby_ids(directed[2], directed; neighbor_type=:in)) == [1]
+    @test sort!(collect(nearby_ids(directed[2], directed; neighbor_type=:all))) == [1, 3]
 
     gridspace = ABM(Agent3, GridSpace((3, 3); metric = :euclidean, periodic = false))
     @test collect(nearby_positions((2, 2), gridspace)) == [(2, 1), (1, 2), (3, 2), (2, 3)]
     @test collect(nearby_positions((1, 1), gridspace)) == [(2, 1), (1, 2)]
     a = add_agent!((2, 2), gridspace, rand())
     add_agent!((3, 2), gridspace, rand())
-    @test collect(nearby_agents((1, 2), gridspace)) == [1]
-    @test sort!(collect(nearby_agents((1, 2), gridspace, 2))) == [1, 2]
-    @test sort!(collect(nearby_agents((2, 2), gridspace))) == [1, 2]
-    @test collect(nearby_agents(a, gridspace)) == [2]
+    @test collect(nearby_ids((1, 2), gridspace)) == [1]
+    @test sort!(collect(nearby_ids((1, 2), gridspace, 2))) == [1, 2]
+    @test sort!(collect(nearby_ids((2, 2), gridspace))) == [1, 2]
+    @test collect(nearby_ids(a, gridspace)) == [2]
 
     continuousspace = ABM(Agent6, ContinuousSpace(2; extend = (1, 1)))
     a = add_agent!((0.5, 0.5), continuousspace, (0.2, 0.1), 0.01)
     b = add_agent!((0.6, 0.5), continuousspace, (0.1, -0.1), 0.01)
     @test_throws ErrorException nearby_positions(1, continuousspace)
-    @test nearby_agents(a, continuousspace, 0.05) == []
-    @test nearby_agents(a, continuousspace, 0.1) == [2]
-    @test sort!(nearby_agents((0.55, 0.5), continuousspace, 0.05)) == [1, 2]
+    @test nearby_ids(a, continuousspace, 0.05) == []
+    @test nearby_ids(a, continuousspace, 0.1) == [2]
+    @test sort!(nearby_ids((0.55, 0.5), continuousspace, 0.05)) == [1, 2]
     move_agent!(a, continuousspace)
     move_agent!(b, continuousspace)
-    @test nearby_agents(a, continuousspace, 0.1) == []
+    @test nearby_ids(a, continuousspace, 0.1) == []
     # Checks for type instability #208
-    @test typeof(nearby_agents(a, continuousspace, 0.1)) <: Vector{Int}
-    @test typeof(nearby_agents((0.55, 0.5), continuousspace, 0.05)) <: Vector{Int}
+    @test typeof(nearby_ids(a, continuousspace, 0.1)) <: Vector{Int}
+    @test typeof(nearby_ids((0.55, 0.5), continuousspace, 0.05)) <: Vector{Int}
 end
 
 @testset "Discrete space mutability" begin

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -83,7 +83,7 @@ end
     random_nodes = nodes(model, :random)
     @test all(n ∈ node_map for n in random_nodes)
     @test nodes(model, :population) == [node_map[i] for i in [1, 2, 3, 4, 5, 6, 9, 7, 8]]
-    @test length(get_node_contents(5, model)) > length(get_node_contents(7, model))
+    @test length(agents_in_pos(5, model)) > length(agents_in_pos(7, model))
     @test_throws ErrorException nodes(model, :notreal)
 end
 
@@ -154,15 +154,15 @@ end
     agent = add_agent!((1,1), model1)
     @test agent.pos == (1, 1)
     @test agent.id == 1
-    pos1 = get_node_contents((1,1), model1)
+    pos1 = agents_in_pos((1,1), model1)
     @test length(pos1) == 1
     @test pos1[1] == 1
 
     move_agent!(agent, (2,2), model1)
     @test agent.pos == (2,2)
-    pos1 = get_node_contents((1,1), model1)
+    pos1 = agents_in_pos((1,1), model1)
     @test length(pos1) == 0
-    pos2 = get_node_contents((2,2), model1)
+    pos2 = agents_in_pos((2,2), model1)
     @test pos2[1] == 1
 
     # %% get/set testing

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -89,13 +89,13 @@ end
 
 @testset "Neighbors" begin
     undirected = ABM(Agent5, GraphSpace(path_graph(5)))
-    @test node_neighbors(3, undirected) == [2, 4]
-    @test node_neighbors(1, undirected) == [2]
-    @test node_neighbors(5, undirected) == [4]
-    @test node_neighbors(3, undirected; neighbor_type = :out) ==
-    node_neighbors(3, undirected; neighbor_type = :in) ==
-    node_neighbors(3, undirected; neighbor_type = :all) ==
-    node_neighbors(3, undirected; neighbor_type = :default)
+    @test nearby_positions(3, undirected) == [2, 4]
+    @test nearby_positions(1, undirected) == [2]
+    @test nearby_positions(5, undirected) == [4]
+    @test nearby_positions(3, undirected; neighbor_type = :out) ==
+    nearby_positions(3, undirected; neighbor_type = :in) ==
+    nearby_positions(3, undirected; neighbor_type = :all) ==
+    nearby_positions(3, undirected; neighbor_type = :default)
     add_agent!(1, undirected, rand())
     add_agent!(2, undirected, rand())
     add_agent!(3, undirected, rand())
@@ -105,14 +105,14 @@ end
     @test sort!(collect(nearby_agents(undirected[2], undirected))) == [1, 3]
 
     directed = ABM(Agent5, GraphSpace(path_digraph(5)))
-    @test node_neighbors(3, directed) == [4]
-    @test node_neighbors(1, directed) == [2]
-    @test node_neighbors(5, directed) == []
-    @test node_neighbors(3, directed; neighbor_type = :default) ==
-          node_neighbors(3, directed)
-    @test node_neighbors(3, directed; neighbor_type = :in) == [2]
-    @test node_neighbors(3, directed; neighbor_type = :out) == [4]
-    @test sort!(node_neighbors(3, directed; neighbor_type = :all)) == [2, 4]
+    @test nearby_positions(3, directed) == [4]
+    @test nearby_positions(1, directed) == [2]
+    @test nearby_positions(5, directed) == []
+    @test nearby_positions(3, directed; neighbor_type = :default) ==
+          nearby_positions(3, directed)
+    @test nearby_positions(3, directed; neighbor_type = :in) == [2]
+    @test nearby_positions(3, directed; neighbor_type = :out) == [4]
+    @test sort!(nearby_positions(3, directed; neighbor_type = :all)) == [2, 4]
     add_agent!(1, directed, rand())
     add_agent!(2, directed, rand())
     add_agent!(3, directed, rand())
@@ -124,8 +124,8 @@ end
     @test sort!(collect(nearby_agents(directed[2], directed; neighbor_type=:all))) == [1, 3]
 
     gridspace = ABM(Agent3, GridSpace((3, 3); metric = :euclidean, periodic = false))
-    @test collect(node_neighbors((2, 2), gridspace)) == [(2, 1), (1, 2), (3, 2), (2, 3)]
-    @test collect(node_neighbors((1, 1), gridspace)) == [(2, 1), (1, 2)]
+    @test collect(nearby_positions((2, 2), gridspace)) == [(2, 1), (1, 2), (3, 2), (2, 3)]
+    @test collect(nearby_positions((1, 1), gridspace)) == [(2, 1), (1, 2)]
     a = add_agent!((2, 2), gridspace, rand())
     add_agent!((3, 2), gridspace, rand())
     @test collect(nearby_agents((1, 2), gridspace)) == [1]
@@ -136,7 +136,7 @@ end
     continuousspace = ABM(Agent6, ContinuousSpace(2; extend = (1, 1)))
     a = add_agent!((0.5, 0.5), continuousspace, (0.2, 0.1), 0.01)
     b = add_agent!((0.6, 0.5), continuousspace, (0.1, -0.1), 0.01)
-    @test_throws ErrorException node_neighbors(1, continuousspace)
+    @test_throws ErrorException nearby_positions(1, continuousspace)
     @test nearby_agents(a, continuousspace, 0.05) == []
     @test nearby_agents(a, continuousspace, 0.1) == [2]
     @test sort!(nearby_agents((0.55, 0.5), continuousspace, 0.05)) == [1, 2]

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -74,8 +74,8 @@ end
     for n in [1, 5, 6, 9, 2, 3, 4]
         add_agent!(empty_nodes[n], model)
     end
-    # only nodes (1,3) and (2,3) should be empty
-    @test pick_empty(model) ∈ [(1,3), (2,3)]
+    # only positions (1,3) and (2,3) should be empty
+    @test random_empty(model) ∈ [(1,3), (2,3)]
     node_map = [(1, 1)  (1, 2)  (1, 3)
                 (2, 1)  (2, 2)  (2, 3)
                 (3, 1)  (3, 2)  (3, 3)]

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -83,7 +83,7 @@ end
     random_positions = positions(model, :random)
     @test all(n ∈ pos_map for n in random_positions)
     @test positions(model, :population) == [pos_map[i] for i in [1, 2, 3, 4, 5, 6, 9, 7, 8]]
-    @test length(agents_in_pos(5, model)) > length(agents_in_pos(7, model))
+    @test length(ids_in_position(5, model)) > length(ids_in_position(7, model))
     @test_throws ErrorException positions(model, :notreal)
 end
 
@@ -154,15 +154,15 @@ end
     agent = add_agent!((1,1), model1)
     @test agent.pos == (1, 1)
     @test agent.id == 1
-    pos1 = agents_in_pos((1,1), model1)
+    pos1 = ids_in_position((1,1), model1)
     @test length(pos1) == 1
     @test pos1[1] == 1
 
     move_agent!(agent, (2,2), model1)
     @test agent.pos == (2,2)
-    pos1 = agents_in_pos((1,1), model1)
+    pos1 = ids_in_position((1,1), model1)
     @test length(pos1) == 0
-    pos2 = agents_in_pos((2,2), model1)
+    pos2 = ids_in_position((2,2), model1)
     @test pos2[1] == 1
 
     # %% get/set testing

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -69,7 +69,7 @@ end
 @testset "Positions" begin
     space = GridSpace((3, 3))
     model = ABM(Agent1, space)
-    empty = empty_positions(model)
+    empty = collect(empty_positions(model))
     @test length(empty) > 0
     for n in [1, 5, 6, 9, 2, 3, 4]
         add_agent!(empty[n], model)

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -66,13 +66,13 @@ end
     @test d.metric == :euclidean
 end
 
-@testset "Nodes" begin
+@testset "Positions" begin
     space = GridSpace((3, 3))
     model = ABM(Agent1, space)
-    empty_nodes = find_empty_nodes(model)
-    @test length(empty_nodes) > 0
+    empty = empty_positions(model)
+    @test length(empty) > 0
     for n in [1, 5, 6, 9, 2, 3, 4]
-        add_agent!(empty_nodes[n], model)
+        add_agent!(empty[n], model)
     end
     # only positions (1,3) and (2,3) should be empty
     @test random_empty(model) ∈ [(1,3), (2,3)]


### PR DESCRIPTION
Closes #301 (when complete).

Note that `@deprecate` is silent from julia 1.5 and up, unless you run `julia --depwarn=yes`

- [x] space_neighbors -> nearby_agents
- [x] node_neighbors -> nearby_positions
- [x] get_node_contents -> agents_in_pos
- [x] Multi agent model -> mixed agent model (if it is somewhere) [Only in the old paper and old values in the CHANGELOG. Didn't touch them]
- [x] pick_empty -> random_empty
- [x] find_empty_nodes -> empty_nodes [**empty_positions** yeah?]
- [x] Replace all instances of the word "node" with the word "position" (and also nodes with positions). This will change both wording in documentation string but also function names, e.g. nodes -> positions. [Growing bacteria uses the word 'node' in a different context, so has been left in; SIR is speaking directly about graph plots, node stays when it context]
- [x] Check for *vertex*, *cell* and other graph/grid specific nomenclature and make it space agnostic [Sugarscape needs work. It's strongly coupled to the old ways. Ali, can you take a look at it?]
- [x] Complete read-through of documentation & examples to validate changes.
    - [x] Schelling
    - [x] Sugarscape
    - [x] SIR
    - [x] Social Distance
    - [x] Wealth Distribution
    - [x] Forest Fire
    - [x] Game of Life
    - [x] Wright-Fisher
    - [x] HK
    - [x] Flocking
    - [x] Daisyworld
    - [x] Wolf Sheep
    - [x] Bacteria Growth
    - [x] Opinion Spread
- [x] Verify tests still make sense
- [x] Make sure models run
