### PR TITLE
Allow mutable graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `GraphSpace` and `GridSpace` are completely separated entities, reducing complexity of source code dramatically, and removing unnecessary functions like `vertex2coord` and `coord2vertex`.
 - Many things have been renamed to have clearer name that indicates their meaning
   (see Breaking changes).
+- `GraphSpace` now allows to dynamically mutate the underlying graph via `add_node!`, `rem_node!`.
 - Performance increase of finding neighbors in GraphSpace with r > 1.
 - New wrapping function `nearby_agents` that returns an iterable of neighboring agents.
 

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -140,3 +140,11 @@ end
 #######################################################################################
 # Mutable graph functions
 #######################################################################################
+"""
+    rem_node!(n::Int, model::ABM{A, <: GraphSpace})
+Remove node `n` from the model's graph. All agents in that node are killed.
+"""
+function rem_node!(n::Int, model::ABM{<:AbstractAgent, <: GraphSpace})
+    for a ∈ agents_in_position(n, model); kill_agent!(a, model); end
+    # LightGraphs.rem_vertex!(model.space.graph)
+end

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -14,10 +14,9 @@ Create a `GraphSpace` instance that is underlined by an arbitrary graph from
 [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl).
 The position type for this space is `Int`.
 
-The nodes of the graph space can be altered with the functions [`add_node!`](@ref),
-[`rem_node!`](@ref) and [`add_edge`](@ref), assuming the used graph is mutable.
+The underlying graph can be altered using [`add_node!`](@ref) and [`rem_node!`](@ref).
 
-`GraphSpace` represents a space where each node of a graph can hold an arbitrary
+`GraphSpace` represents a space where each node (i.e. position) of a graph can hold an arbitrary
 amount of agents, and each agent can move between the nodes of the graph.
 If you want to model social networks, where each agent is equivalent with a node of
 a graph, you're better of using `nothing` (or other spaces) as the model space, and using
@@ -141,8 +140,10 @@ end
 #######################################################################################
 # Mutable graph functions
 #######################################################################################
+export rem_node!, add_node!, add_edge!
+
 """
-    rem_node!(n::Int, model::ABM{A, <: GraphSpace})
+    rem_node!(model::ABM{A, <: GraphSpace}, n::Int)
 Remove node (i.e. position) `n` from the model's graph. All agents in that node are killed.
 
 **Warning:** LightGraphs.jl (and thus Agents.jl) swaps the index of the last node with
@@ -150,8 +151,8 @@ that of the one to be removed, while every other node remains as is. This means 
 when doing `rem_node!(n, model)` the last node becomes the `n`-th node while the previous
 `n`-th node (and all its edges and agents) are deleted.
 """
-function rem_node!(n::Int, model::ABM{<:AbstractAgent, <: GraphSpace})
-    for a ∈ agents_in_position(n, model); kill_agent!(a, model); end
+function rem_node!(model::ABM{<:AbstractAgent, <: GraphSpace}, n::Int)
+    for id ∈ copy(ids_in_position(n, model)); kill_agent!(model[id], model); end
     V = nv(model)
     success = LightGraphs.rem_vertex!(model.space.graph, n)
     n ∉ 1:V && error("Node number exceeds amount of nodes in graph!")

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -142,9 +142,10 @@ end
 #######################################################################################
 """
     rem_node!(n::Int, model::ABM{A, <: GraphSpace})
-Remove node `n` from the model's graph. All agents in that node are killed.
+Remove node (i.e. position) `n` from the model's graph. All agents in that node are killed.
 """
 function rem_node!(n::Int, model::ABM{<:AbstractAgent, <: GraphSpace})
     for a ∈ agents_in_position(n, model); kill_agent!(a, model); end
-    # LightGraphs.rem_vertex!(model.space.graph)
+    deleteat!(model.space.s, n)
+    LightGraphs.rem_vertex!(model.space.graph, n)
 end

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -14,6 +14,9 @@ Create a `GraphSpace` instance that is underlined by an arbitrary graph from
 [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl).
 The position type for this space is `Int`.
 
+The nodes of the graph space can be altered with the functions [`add_node!`](@ref),
+[`rem_node!`](@ref) and [`add_edge`](@ref), assuming the used graph is mutable.
+
 `GraphSpace` represents a space where each node of a graph can hold an arbitrary
 amount of agents, and each agent can move between the nodes of the graph.
 If you want to model social networks, where each agent is equivalent with a node of
@@ -38,10 +41,10 @@ Return the number of edges in the `model` space.
 """
 LightGraphs.ne(abm::ABM{<:Any,<:GraphSpace}) = LightGraphs.ne(abm.space.graph)
 
-function Base.show(io::IO, space::GraphSpace)
+function Base.show(io::IO, s::GraphSpace)
     print(
         io,
-        "$(nameof(typeof(space))) with $(nv(space.graph)) positions and $(ne(space.graph)) edges",
+        "GraphSpace with $(nv(s.graph)) positions and $(ne(s.graph)) edges",
     )
 end
 
@@ -133,3 +136,7 @@ function nearby_positions(
     end
     filter!(i -> i != position, output)
 end
+
+#######################################################################################
+# Mutable graph functions
+#######################################################################################

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -13,6 +13,13 @@ end
 Create a `GraphSpace` instance that is underlined by an arbitrary graph from
 [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl).
 The position type for this space is `Int`.
+
+`GraphSpace` represents a space where each node of a graph can hold an arbitrary
+amount of agents, and each agent can move between the nodes of the graph.
+If you want to model social networks, where each agent is equivalent with a node of
+a graph, you're better of using `nothing` (or other spaces) as the model space, and using
+a graph from LightGraphs.jl directly in the model parameters, as shown in the
+[Social networks with LightGraphs.jl](@ref) integration example.
 """
 function GraphSpace(graph::G) where {G<:AbstractGraph}
     agent_positions = [Int[] for i in 1:LightGraphs.nv(graph)]
@@ -126,4 +133,3 @@ function nearby_positions(
     end
     filter!(i -> i != position, output)
 end
-

--- a/test/graph_tests.jl
+++ b/test/graph_tests.jl
@@ -1,0 +1,31 @@
+@testset "mutable graph" begin
+
+g = complete_digraph(5)
+abm = ABM(Agent5, GraphSpace(g))
+for n in 1:5
+    for _ in 1:5
+        add_agent!(n, abm, rand())
+    end
+end
+@test nv(abm) == 5
+@test abm.space.s[1] == 1:5
+@test abm.space.s[2] == 6:10
+
+rem_node!(abm, 2)
+@test nv(abm) == 4
+@test nagents(abm) == 20
+@test abm.space.s[2] == 21:25
+@test length(abm.space.s) == 4
+
+n = add_node!(abm)
+@test n == 5
+@test length(abm.space.s) == 5
+@test nv(abm) == 5
+add_edge!(abm, n, 2)
+
+
+a = add_agent!(n, abm, rand())
+ids = nearby_ids(a, abm)
+@test ids == 21:25
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,5 +74,6 @@ end
     include("collect_tests.jl")
     include("continuousSpace_tests.jl")
     include("collisions_tests.jl")
+    include("graph_tests.jl")
 
 end


### PR DESCRIPTION
Closes #264

I am having trouble because I don't know anything about LightGraphs and perhaps someone should help me here.

How does the order of node integers change in LightGraphs.jl when you add another one or remove one? If I do `rem_vertex!`, can I just do `deleteat!(model.space.s, n)` and then the correspondence between node numbers in the graph, and node numbers in `model.space.s` stays the same? 

And what about adding new nodes? If I add a new node in lightgraphs, is it automatically becoming the `nv(graph)+1` node? From the documentation of `add_vertex!` it looks like it.