### PR TITLE
Walk utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - New public `schedule` function for writing custom loops.
 - Mixed models are supported in data collection methods.
 - `random_agent(model, condition)` allows obtaining random agents that satisfy given condition.
+- A walk! utility for 2D `GridSpace`s, providing turtle-like agent movement.
 
 ## Breaking changes
 Most changes in this section (besides changes to default values) are deprecated and

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -81,6 +81,7 @@ sort!(collect(nearby_agents(a, model)))
 positions
 ids_in_position
 agents_in_position
+walk!
 fill_space!
 has_empty_positions
 empty_positions

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -1,4 +1,5 @@
-export edistance
+export edistance,
+    walk!, North, South, East, West, NorthEast, NorthWest, SouthEast, SouthWest
 
 #######################################################################################
 # %% (Mostly) space agnostic helper functions
@@ -41,7 +42,11 @@ function edistance(
     sqrt(total)
 end
 
-function edistance(p1::ValidPos, p2::ValidPos, model::ABM{A,<:GridSpace{D,true}}) where {A,D}
+function edistance(
+    p1::ValidPos,
+    p2::ValidPos,
+    model::ABM{A,<:GridSpace{D,true}},
+) where {A,D}
     total = 0.0
     for (a, b, d) in zip(p1, p2, size(model.space))
         delta = abs(b - a)
@@ -53,3 +58,194 @@ function edistance(p1::ValidPos, p2::ValidPos, model::ABM{A,<:GridSpace{D,true}}
     sqrt(total)
 end
 
+abstract type Direction end
+struct North <: Direction end
+struct South <: Direction end
+struct East <: Direction end
+struct West <: Direction end
+struct NorthWest <: Direction end
+struct SouthWest <: Direction end
+struct NorthEast <: Direction end
+struct SouthEast <: Direction end
+
+"""
+    walk!(agent, direction, model, distance=1)
+
+Move agent in the given `direction` one grid position (by default). Only possible on a 2D
+`GridSpace`, respects periodic boundary conditions. If `periodic = false`, agents will
+walk to, but not exceed the boundary value.
+
+Possible directions are `North`, `South`, `East`, `West`, as well as `NorthEast`,
+`SouthEast`, `SouthWest` and `NorthWest`.
+"""
+
+# Periodic
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{East},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (mod1(agent.pos[1] + distance, size(model.space)[1]), agent.pos[2])
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{West},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (mod1(agent.pos[1] - distance, size(model.space)[1]), agent.pos[2])
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{North},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (agent.pos[1], mod1(agent.pos[2] + distance, size(model.space)[2]))
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{South},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (agent.pos[1], mod1(agent.pos[2] - distance, size(model.space)[2]))
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{NorthEast},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (
+        mod1(agent.pos[1] + distance, size(model.space)[1]),
+        mod1(agent.pos[2] + distance, size(model.space)[2]),
+    )
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{NorthWest},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (
+        mod1(agent.pos[1] - distance, size(model.space)[1]),
+        mod1(agent.pos[2] + distance, size(model.space)[2]),
+    )
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{SouthEast},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (
+        mod1(agent.pos[1] + distance, size(model.space)[1]),
+        mod1(agent.pos[2] - distance, size(model.space)[2]),
+    )
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{SouthWest},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
+    distance::Int = 1,
+)
+    agent.pos = (
+        mod1(agent.pos[1] - distance, size(model.space)[1]),
+        mod1(agent.pos[2] - distance, size(model.space)[2]),
+    )
+end
+
+# Non-Periodic
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{East},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+    step = min(agent.pos[1] + distance, size(model.space)[1])
+    agent.pos = (step, agent.pos[2])
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{West},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+
+    step = max(agent.pos[1] - distance, 1)
+    agent.pos = (step, agent.pos[2])
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{North},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+    step = min(agent.pos[2] + distance, size(model.space)[2])
+    agent.pos = (agent.pos[1], step)
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{South},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+    step = max(agent.pos[2] - distance, 1)
+    agent.pos = (agent.pos[1], step)
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{NorthEast},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+    horiz = min(agent.pos[1] + distance, size(model.space)[1])
+    vert = min(agent.pos[2] + distance, size(model.space)[2])
+    agent.pos = (horiz, vert)
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{NorthWest},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+    horiz = max(agent.pos[1] - distance, 1)
+    vert = min(agent.pos[2] + distance, size(model.space)[2])
+    agent.pos = (horiz, vert)
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{SouthEast},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+    horiz = min(agent.pos[1] + distance, size(model.space)[1])
+    vert = max(agent.pos[2] - distance, 1)
+    agent.pos = (horiz, vert)
+end
+
+function walk!(
+    agent::AbstractAgent,
+    direction::Type{SouthWest},
+    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
+    distance::Int = 1,
+)
+    horiz = max(agent.pos[1] - distance, 1)
+    vert = max(agent.pos[2] - distance, 1)
+    agent.pos = (horiz, vert)
+end

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -87,8 +87,6 @@ walk to, but not exceed the boundary value.
 Possible directions are `North`, `South`, `East`, `West`, as well as `NorthEast`,
 `SouthEast`, `SouthWest` and `NorthWest`.
 """
-
-# Periodic
 function walk!(
     agent::AbstractAgent,
     direction::Type{<:Direction},

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -68,6 +68,15 @@ struct SouthWest <: Direction end
 struct NorthEast <: Direction end
 struct SouthEast <: Direction end
 
+unitvector(d::Type{North}) = (0, 1)
+unitvector(d::Type{South}) = (0, -1)
+unitvector(d::Type{East}) = (1, 0)
+unitvector(d::Type{West}) = (-1, 0)
+unitvector(d::Type{NorthEast}) = (1, 1)
+unitvector(d::Type{NorthWest}) = (-1, 1)
+unitvector(d::Type{SouthEast}) = (1, -1)
+unitvector(d::Type{SouthWest}) = (-1, -1)
+
 """
     walk!(agent, direction, model, distance=1)
 
@@ -82,170 +91,27 @@ Possible directions are `North`, `South`, `East`, `West`, as well as `NorthEast`
 # Periodic
 function walk!(
     agent::AbstractAgent,
-    direction::Type{East},
+    direction::Type{<:Direction},
     model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
     distance::Int = 1,
 )
-    agent.pos = (mod1(agent.pos[1] + distance, size(model.space)[1]), agent.pos[2])
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{West},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
-    distance::Int = 1,
-)
-    agent.pos = (mod1(agent.pos[1] - distance, size(model.space)[1]), agent.pos[2])
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{North},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
-    distance::Int = 1,
-)
-    agent.pos = (agent.pos[1], mod1(agent.pos[2] + distance, size(model.space)[2]))
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{South},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
-    distance::Int = 1,
-)
-    agent.pos = (agent.pos[1], mod1(agent.pos[2] - distance, size(model.space)[2]))
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{NorthEast},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
-    distance::Int = 1,
-)
+    (h, v) = unitvector(direction) .* distance
     agent.pos = (
-        mod1(agent.pos[1] + distance, size(model.space)[1]),
-        mod1(agent.pos[2] + distance, size(model.space)[2]),
-    )
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{NorthWest},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
-    distance::Int = 1,
-)
-    agent.pos = (
-        mod1(agent.pos[1] - distance, size(model.space)[1]),
-        mod1(agent.pos[2] + distance, size(model.space)[2]),
-    )
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{SouthEast},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
-    distance::Int = 1,
-)
-    agent.pos = (
-        mod1(agent.pos[1] + distance, size(model.space)[1]),
-        mod1(agent.pos[2] - distance, size(model.space)[2]),
-    )
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{SouthWest},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,true}},
-    distance::Int = 1,
-)
-    agent.pos = (
-        mod1(agent.pos[1] - distance, size(model.space)[1]),
-        mod1(agent.pos[2] - distance, size(model.space)[2]),
+        mod1(agent.pos[1] + h, size(model.space)[1]),
+        mod1(agent.pos[2] + v, size(model.space)[2]),
     )
 end
 
 # Non-Periodic
 function walk!(
     agent::AbstractAgent,
-    direction::Type{East},
+    direction::Type{<:Direction},
     model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
     distance::Int = 1,
 )
-    step = min(agent.pos[1] + distance, size(model.space)[1])
-    agent.pos = (step, agent.pos[2])
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{West},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
-    distance::Int = 1,
-)
-
-    step = max(agent.pos[1] - distance, 1)
-    agent.pos = (step, agent.pos[2])
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{North},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
-    distance::Int = 1,
-)
-    step = min(agent.pos[2] + distance, size(model.space)[2])
-    agent.pos = (agent.pos[1], step)
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{South},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
-    distance::Int = 1,
-)
-    step = max(agent.pos[2] - distance, 1)
-    agent.pos = (agent.pos[1], step)
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{NorthEast},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
-    distance::Int = 1,
-)
-    horiz = min(agent.pos[1] + distance, size(model.space)[1])
-    vert = min(agent.pos[2] + distance, size(model.space)[2])
-    agent.pos = (horiz, vert)
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{NorthWest},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
-    distance::Int = 1,
-)
-    horiz = max(agent.pos[1] - distance, 1)
-    vert = min(agent.pos[2] + distance, size(model.space)[2])
-    agent.pos = (horiz, vert)
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{SouthEast},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
-    distance::Int = 1,
-)
-    horiz = min(agent.pos[1] + distance, size(model.space)[1])
-    vert = max(agent.pos[2] - distance, 1)
-    agent.pos = (horiz, vert)
-end
-
-function walk!(
-    agent::AbstractAgent,
-    direction::Type{SouthWest},
-    model::ABM{<:AbstractAgent,<:GridSpace{2,false}},
-    distance::Int = 1,
-)
-    horiz = max(agent.pos[1] - distance, 1)
-    vert = max(agent.pos[2] - distance, 1)
-    agent.pos = (horiz, vert)
+    (h, v) = unitvector(direction) .* distance
+    agent.pos = (
+        min(max(agent.pos[1] + h, 1), size(model.space)[1]),
+        min(max(agent.pos[2] + v, 1), size(model.space)[2]),
+    )
 end


### PR DESCRIPTION
This is a solution to the discussion around #346.
Users coming from Netlogo will be used to [Turtles](https://ccl.northwestern.edu/netlogo/docs/programming.html#procedures), which have been historically used in a number of other places to represent movement on a grid. 

I've simplified the concept a bit here: rather than having a heading and a direction (which works fine for us right now in `ContinuousSpace`, and doesn't require any extra help from the framework), the `walk!` function moves agents on 2D grids, respecting boundary conditions where necessary. 

This should solve @mbruna's initial question, as well as providing a solution for future netlogo converts.  