### PR TITLE
Change step! and run! function order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ therefore are not "truly breaking".
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allow performance updates in the future that may change internals but not lead to breaking changes.
 - `vertex2coord, coord2vertex` do not exist anymore because they are unnecessary in the new design.
+- **`step!` and `run!` argument order has changed**. Now call `step!(model, model_step!, agent_step!, 1)`.
 - API simplification and renaming:
   - `space_neighbors` -> `nearby_ids`
   - `node_neighbors` -> `nearby_positions`

--- a/benchmark/compare/benchmark.jl
+++ b/benchmark/compare/benchmark.jl
@@ -3,8 +3,8 @@ using Agents.Models: Wolf, Sheep
 using BenchmarkTools
 using Test
 
-a = @benchmark step!(model, agent_step!, model_step!, 500) setup = (
-    (model, agent_step!, model_step!) = Models.predator_prey(
+a = @benchmark step!(model, model_step!, agent_step!, 500) setup = (
+    (model, model_step!, agent_step!) = Models.predator_prey(
         n_wolves = 40,
         n_sheep = 60,
         dims = (25, 25),
@@ -18,8 +18,8 @@ a = @benchmark step!(model, agent_step!, model_step!, 500) setup = (
        count(i -> i isa Wolf, allagents(model)) > 0)
 println("Agents.jl WolfSheep (ms): ", minimum(a.times) * 1e-6)
 
-a = @benchmark step!(model, agent_step!, model_step!, 100) setup = (
-    (model, agent_step!, model_step!) = Models.flocking(
+a = @benchmark step!(model, model_step!, agent_step!, 100) setup = (
+    (model, model_step!, agent_step!) = Models.flocking(
         n_birds = 300,
         separation = 1,
         cohere_factor = 0.03,
@@ -29,13 +29,13 @@ a = @benchmark step!(model, agent_step!, model_step!, 100) setup = (
 )
 println("Agents.jl Flocking (ms): ", minimum(a.times) * 1e-6)
 
-a = @benchmark step!(model, agent_step!, model_step!, 10) setup = (
-    (model, agent_step!, model_step!) =
+a = @benchmark step!(model, model_step!, agent_step!, 10) setup = (
+    (model, model_step!, agent_step!) =
         Models.schelling(griddims = (50, 50), numagents = 2000)
 ) samples = 100
 println("Agents.jl Schelling (ms): ", minimum(a.times) * 1e-6)
 
-a = @benchmark step!(model, agent_step!, model_step!, 100) setup =
-    ((model, agent_step!, model_step!) = Models.forest_fire())
+a = @benchmark step!(model, model_step!, agent_step!, 100) setup =
+    ((model, model_step!, agent_step!) = Models.forest_fire())
 println("Agents.jl ForestFire (ms): ", minimum(a.times) * 1e-6)
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -133,7 +133,7 @@ while until(s, n, model)
   if should_we_collect(s, model, when_model)
       collect_model_data!(df_model, model, mdata, s)
   end
-  step!(model, agent_step!, model_step!, 1)
+  step!(model, model_step!, agent_step!, 1)
   s += 1
 end
 return df_agent, df_model
@@ -173,7 +173,7 @@ end
 and pass it to e.g. `step!` by initializing it
 ```julia
 ms = MyScheduler(100, 0.5)
-run!(model, agentstep, modelstep, 100; scheduler = ms)
+run!(model, modelstep, agentstep, 100; scheduler = ms)
 ```
 
 ### Predefined schedulers

--- a/docs/src/interact.md
+++ b/docs/src/interact.md
@@ -24,7 +24,7 @@ using Agents, Random
 using Makie
 using InteractiveChaos
 
-model, agent_step!, model_step! = Models.forest_fire()
+model, model_step!, agent_step! = Models.forest_fire()
 
 alive(model) = count(a.status for a in allagents(model))
 burning(model) = count(!a.status for a in allagents(model))
@@ -39,6 +39,6 @@ params = Dict(
 ac(a) = a.status ? "#1f851a" : "#67091b"
 am = :rect
 
-p1 = interactive_abm(model, agent_step!, model_step!, params;
+p1 = interactive_abm(model, model_step!, agent_step!, params;
 ac = ac, as = 1, am = am, mdata = mdata, mlabels=mlabels)
 ```

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -1,10 +1,10 @@
 # Predefined Models
-Predefined agent based models exist in the `Models` submodule in the form of functions that return `model, agent_step!, model_step!` when called.
+Predefined agent based models exist in the `Models` submodule in the form of functions that return `model, model_step!, agent_step!` when called.
 
 They are accessed like:
 ```julia
 using Agents
-model, agent_step!, model_step! = Models.flocking(; kwargs...)
+model, model_step!, agent_step! = Models.flocking(; kwargs...)
 ```
 
 The Examples section of the docs outline how to use and interact with each model.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -52,14 +52,16 @@ For more functions visit the [API](@ref) page.
 ## 4. Evolving the model
 
 Any ABM model should have at least one and at most two step functions.
-An _agent step function_ is required by default.
-Such an agent step function defines what happens to an agent when it activates.
-Sometimes we also need a function that changes all agents at once, or changes a model property. In such cases, we can also provide a _model step function_.
-
-An agent step function should only accept two arguments: first, an agent object, and second, a model object.
-
+A _model step function_ is required by default.
 The model step function should accept only one argument, that is the model object.
-To use only a model step function, users can use the built-in [`dummystep`](@ref) as the agent step function.
+
+Optionally, we can also provide a _agent step function_, which defines what happens to
+an agent when it activates. An agent step function should only accept two arguments:
+first, an agent object, and second, a model object.
+
+Sometimes models are simple enough, that changing agent properties is all that's
+required. In these cases, users can use the built-in [`dummystep`](@ref) as the model
+step function, to ignore any dynamics here.
 
 After you have defined these two functions, you evolve your model with `step!`:
 ```@docs

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -289,7 +289,7 @@ plotkwargs = (
 p = plotabm(model; plotkwargs...)
 
 # And after a couple of steps
-step!(model, agent_step!, model_step!, 5)
+step!(model, model_step!, agent_step!, 5)
 p = plotabm(model; plotkwargs...)
 
 # Let's do some animation now
@@ -298,7 +298,7 @@ model = daisyworld()
 anim = @animate for i in 0:30
     p = plotabm(model; plotkwargs...)
     title!(p, "step $(i)")
-    step!(model, agent_step!, model_step!)
+    step!(model, model_step!, agent_step!)
 end
 gif(anim, "daisyworld.gif", fps = 3)
 
@@ -317,7 +317,7 @@ adata = [(black, count, daisies), (white, count, daisies)]
 Random.seed!(165) # hide
 model = daisyworld(; solar_luminosity = 1.0)
 
-agent_df, model_df = run!(model, agent_step!, model_step!, 1000; adata = adata)
+agent_df, model_df = run!(model, model_step!, agent_step!, 1000; adata = adata)
 
 p = plot(agent_df[!, :step], agent_df[!, :count_black_daisies], label = "black")
 plot!(p, agent_df[!, :step], agent_df[!, :count_white_daisies], label = "white")
@@ -340,7 +340,7 @@ mdata = [:solar_luminosity]
 Random.seed!(165) # hide
 model = daisyworld(solar_luminosity = 1.0, scenario = :ramp)
 agent_df, model_df =
-    run!(model, agent_step!, model_step!, 1000; adata = adata, mdata = mdata)
+    run!(model, model_step!, agent_step!, 1000; adata = adata, mdata = mdata)
 
 p = plot(agent_df[!, :step], agent_df[!, :count_black_daisies], label = "black")
 plot!(p, agent_df[!, :step], agent_df[!, :count_white_daisies], label = "white")
@@ -410,7 +410,7 @@ plot(p, p2, p3, layout = (3, 1), size = (600, 700))
 # landfirst = by_type((Land, Daisy), false)
 #
 # scene, agent_df, model_def = interactive_abm(
-#     model, agent_step!, model_step!, params;
+#     model, model_step!, agent_step!, params;
 #     ac = daisycolor, am = daisyshape, as = daisysize,
 #     mdata = mdata, adata = adata, alabels = alabels, mlabels = mlabels,
 #     scheduler = landfirst # crucial to change model scheduler!

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -217,7 +217,7 @@ nothing # hide
 cd(@__DIR__) #src
 Random.seed!(165) # hide
 model = daisyworld(scenario = :ours)
-step!(model, agent_step!, model_step!, 100)
+step!(model, model_step!, agent_step!, 100)
 daisycolor(a) = a.breed
 plotabm(model; ac = daisycolor, as = 5)
 
@@ -259,7 +259,7 @@ nothing # hide
 # Now we can evolve our model and observe what happens
 
 anim = @animate for t in 1:900
-    step!(model, agent_step!, model_step!, 1)
+    step!(model, model_step!, agent_step!, 1)
     collect_model_data!(model_df, model, mdata, t)
     collect_agent_data!(agent_df, model, adata, t)
     heatmap(

--- a/examples/diffeq.jl
+++ b/examples/diffeq.jl
@@ -103,7 +103,7 @@ nothing #hide
 Random.seed!(6549) #hide
 
 model = initialise()
-_, results = run!(model, agent_step!, model_step!, 20; mdata = [:stock])
+_, results = run!(model, model_step!, agent_step!, 20; mdata = [:stock])
 
 plot(results.stock; legend = false, ylabel = "Stock", xlabel = "Year")
 
@@ -168,7 +168,7 @@ Random.seed!(6549) #hide
 model = initialise()
 yearly(model, s) = s % 365 == 0
 _, results =
-    run!(model, agent_step!, model_step!, 20 * 365; mdata = [:stock], when = yearly)
+    run!(model, model_step!, agent_step!, 20 * 365; mdata = [:stock], when = yearly)
 
 plot(results.stock; legend = false, ylabel = "Stock", xlabel = "Year")
 
@@ -179,7 +179,7 @@ plot(results.stock; legend = false, ylabel = "Stock", xlabel = "Year")
 using BenchmarkTools
 
 Random.seed!(6549) #hide
-@btime Agents.step!(model, agent_step!, model_step!, 20 * 365) setup =
+@btime Agents.step!(model, model_step!, agent_step!, 20 * 365) setup =
     (model = initialise())
 
 # So this is fairly quick since the model is a simple one, but it's certainly not as efficient
@@ -272,14 +272,14 @@ nothing #hide
 
 Random.seed!(6549) #hide
 modeldeq = initialise_diffeq()
-_, resultsdeq = run!(modeldeq, agent_diffeq_step!, model_diffeq_step!, 20; mdata = [:stock])
+_, resultsdeq = run!(modeldeq, model_diffeq_step!, agent_diffeq_step!, 20; mdata = [:stock])
 
 plot(resultsdeq.stock; legend = false, ylabel = "Stock", xlabel = "Year")
 
 # The small complexity addition yields us a generous speed up of around 4.5x.
 
 Random.seed!(6549) #hide
-@btime Agents.step!(model, agent_diffeq_step!, model_diffeq_step!, 20) setup =
+@btime Agents.step!(model, model_diffeq_step!, agent_diffeq_step!, 20) setup =
     (model = initialise_diffeq())
 
 # Digging into the results a little more, we can see that the `DifferentialEquations`
@@ -343,7 +343,7 @@ import DiffEqCallbacks
 function fish!(integrator, model)
     integrator.p[2] = integrator.u[1] > model.min_threshold ?
         sum(a.yearly_catch for a in allagents(model)) : 0.0
-    Agents.step!(model, agent_cb_step!, 1)
+    Agents.step!(model, dummystep, agent_cb_step!, 1)
 end
 
 function fish_stock!(ds, s, p, t)

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -126,7 +126,7 @@ cd(@__DIR__) #src
 model = initialize_model()
 e = model.space.extent
 anim = @animate for i in 0:100
-    i > 0 && step!(model, agent_step!, 1)
+    i > 0 && step!(model, dummystep, agent_step!, 1)
     p1 = plotabm(
         model;
         am = bird_triangle,

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -71,12 +71,12 @@ nothing # hide
 
 # ## Running the model
 
-step!(forest, tree_step!, 1)
+step!(forest, dummystep, tree_step!, 1)
 count(t->t.status == :burnt, allagents(forest))
 
 #
 
-step!(forest, tree_step!, 10)
+step!(forest, dummystep, tree_step!, 10)
 count(t->t.status == :burnt, allagents(forest))
 
 # Now we can do some data collection as well using an aggregate function `percentage`:
@@ -86,13 +86,13 @@ forest = forest_fire(griddims = (20, 20))
 burnt_percentage(m) = count(t->t.status == :burnt, allagents(m)) / length(positions(m))
 mdata = [burnt_percentage]
 
-_, data = run!(forest, tree_step!, 10; mdata = mdata)
+_, data = run!(forest, dummystep, tree_step!, 10; mdata = mdata)
 data
 
 # Now let's plot the model. We use green for unburnt trees, red for burning and a
 # dark red for burnt.
 forest = forest_fire()
-step!(forest, tree_step!, 1)
+step!(forest, dummystep, tree_step!, 1)
 
 function treecolor(a)
     color = :green
@@ -110,7 +110,7 @@ plotabm(forest; ac = treecolor, ms = 5, msw = 0)
 cd(@__DIR__) #src
 forest = forest_fire(density = 0.6)
 anim = @animate for i in 0:10
-    i > 0 && step!(forest, tree_step!, 5)
+    i > 0 && step!(forest, dummystep, tree_step!, 5)
     p1 = plotabm(forest; ac = treecolor, ms = 5, msw = 0)
     title!(p1, "step $(i)")
 end

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -95,7 +95,7 @@ end
 cd(@__DIR__) #src
 ac(x) = x.status == true ? :black : :white
 anim = @animate for i in 0:100
-    i > 0 && step!(model, dummystep, ca_step!, 1)
+    i > 0 && step!(model, ca_step!, 1)
     p1 = plotabm(model; ac = ac, as = 3, am = :square, showaxis = false)
 end
 nothing # hide

--- a/examples/growing_bacteria.jl
+++ b/examples/growing_bacteria.jl
@@ -198,7 +198,7 @@ nothing # hide
 Random.seed!(1680)
 e = model.space.extent
 anim = @animate for i in 0:50:5000
-    step!(model, agent_step!, model_step!, 100)
+    step!(model, model_step!, agent_step!, 100)
     p1 = plotabm(
         model,
         am = cassini_oval,

--- a/examples/hk.jl
+++ b/examples/hk.jl
@@ -112,14 +112,14 @@ function terminate(model, s)
     end
 end
 
-step!(model, agent_step!, model_step!, terminate)
+step!(model, model_step!, agent_step!, terminate)
 model[1]
 
 # Alright, let's wrap everything in a function and do some data collection using [`run!`](@ref).
 
 function model_run(; kwargs...)
     model = hk_model(; kwargs...)
-    agent_data, _ = run!(model, agent_step!, model_step!, terminate; adata = [:new_opinion])
+    agent_data, _ = run!(model, model_step!, agent_step!, terminate; adata = [:new_opinion])
     return agent_data
 end
 
@@ -133,8 +133,8 @@ data[(end - 19):end, :]
 model = hk_model()
 agent_data, _ = run!(
     model,
-    agent_step!,
     model_step!,
+    agent_step!,
     terminate;
     adata = [:new_opinion],
     when = terminate,

--- a/examples/measurements.jl
+++ b/examples/measurements.jl
@@ -198,7 +198,7 @@ mdata = [:solar_luminosity]
 Random.seed!(19) # hide
 model = daisyworld(scenario = :ramp)
 agent_df, model_df =
-    run!(model, agent_step!, model_step!, 1000; adata = adata, mdata = mdata)
+    run!(model, model_step!, agent_step!, 1000; adata = adata, mdata = mdata)
 
 p1 = plot(
     agent_df.step,

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -86,7 +86,7 @@ model = create_model(nopinions = 3, levels_per_opinion = levels_per_opinion)
 "run the model until all agents stabilize"
 rununtil(model, s) = count(a->a.stabilized, allagents(model)) == length(positions(model))
 
-agentdata, _ = run!(model, agent_step!, dummystep, rununtil, adata = [(:stabilized, count)])
+agentdata, _ = run!(model, dummystep, agent_step!, rununtil, adata = [(:stabilized, count)])
 
 # ## Plotting
 
@@ -110,7 +110,7 @@ levels_per_opinion = 3
 ac(agent) = RGB((agent.opinion[1:3] ./ levels_per_opinion)...)
 model = create_model(nopinions = 3, levels_per_opinion = levels_per_opinion)
 anim = @animate for sp in 1:500
-    step!(model, agent_step!)
+    step!(model, dummystep, agent_step!)
     p = plotabm(model, ac = ac, as = 12, am = :square)
     title!(p, "Step $(sp)")
     if rununtil(model, 1)

--- a/examples/optim.jl
+++ b/examples/optim.jl
@@ -35,6 +35,7 @@ function cost(x)
 
     _, data = run!(
         model,
+        dummystep,
         agent_step!,
         50;
         mdata = [infected_fraction],
@@ -112,7 +113,7 @@ model = model_initiation(;
 )
 
 _, data =
-    run!(model, agent_step!, 50; mdata = [nagents], when_model = [50], replicates = 10)
+    run!(model, dummystep, agent_step!, 50; mdata = [nagents], when_model = [50], replicates = 10)
 
 mean(data.nagents)
 
@@ -140,6 +141,7 @@ function cost_multi(x)
 
     _, data = run!(
         model,
+        dummystep,
         agent_step!,
         50;
         mdata = [infected_fraction, n_fraction],

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -239,7 +239,7 @@ sheep(a) = typeof(a) == Sheep
 wolves(a) = typeof(a) == Wolf
 grass(a) = typeof(a) == Grass && a.fully_grown
 adata = [(sheep, count), (wolves, count), (grass, count)]
-results, _ = run!(model, agent_step!, n_steps; adata = adata)
+results, _ = run!(model, dummystep, agent_step!, n_steps; adata = adata)
 
 # The plot shows the population dynamics over time. Initially, wolves become extinct because they
 # consume the sheep too quickly. The few remaining sheep reproduce and gradually reach an
@@ -267,7 +267,7 @@ model = initialize_model(
     sheep_reproduce = 0.2,
     wolf_reproduce = 0.08,
 )
-results, _ = run!(model, agent_step!, n_steps; adata = adata)
+results, _ = run!(model, dummystep, agent_step!, n_steps; adata = adata)
 @df results plot(
     :step,
     :count_sheep,

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -142,10 +142,10 @@ nothing # hide
 model = initialize()
 
 # We can advance the model one step
-step!(model, agent_step!)
+step!(model, dummystep, agent_step!)
 
 # Or for three steps
-step!(model, agent_step!, 3)
+step!(model, dummystep, agent_step!, 3)
 
 # ## Running the model and collecting data
 
@@ -157,14 +157,14 @@ step!(model, agent_step!, 3)
 adata = [:pos, :mood, :group]
 
 model = initialize()
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, dummystep, agent_step!, 5; adata = adata)
 data[1:10, :] # print only a few rows
 
 # We could also use functions in `adata`, for example we can define
 x(agent) = agent.pos[1]
 model = initialize()
 adata = [x, :mood, :group]
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, dummystep, agent_step!, 5; adata = adata)
 data[1:10, :]
 
 # With the above `adata` vector, we collected all agent's data.
@@ -174,7 +174,7 @@ data[1:10, :]
 
 model = initialize();
 adata = [(:mood, sum), (x, maximum)]
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, dummystep, agent_step!, 5; adata = adata)
 data
 
 # Other examples in the documentation are more realistic, with a much more meaningful
@@ -199,7 +199,7 @@ model = initialize();
 anim = @animate for i in 0:10
     p1 = plotabm(model; ac = groupcolor, am = groupmarker, as = 4)
     title!(p1, "step $(i)")
-    step!(model, agent_step!, 1)
+    step!(model, dummystep, agent_step!, 1)
 end
 
 gif(anim, "schelling.gif", fps = 2)
@@ -210,7 +210,7 @@ gif(anim, "schelling.gif", fps = 2)
 # To that end, we only need to specify `replicates` in the `run!` function:
 
 model = initialize(numagents = 370, griddims = (20, 20), min_to_be_happy = 3)
-data, _ = run!(model, agent_step!, 5; adata = adata, replicates = 3)
+data, _ = run!(model, dummystep, agent_step!, 5; adata = adata, replicates = 3)
 data[(end - 10):end, :]
 
 # It is possible to run the replicates in parallel.
@@ -234,7 +234,7 @@ data[(end - 10):end, :]
 # Then we can tell the `run!` function to run replicates in parallel:
 
 # ```julia
-# data, _ = run!(model, agent_step!, 2, adata=adata,
+# data, _ = run!(model, dummystep, agent_step!, 2, adata=adata,
 #                replicates=5, parallel=true)
 # ```
 
@@ -318,7 +318,7 @@ model = initialize(; numagents = 300) # fresh model, noone happy
 
 # ```julia
 # scene, adf, modeldf =
-# interactive_abm(model, agent_step!, dummystep, parange;
+# interactive_abm(model, dummystep, agent_step!, parange;
 #                 ac = groupcolor, am = groupmarker, as = 1,
 #                 adata = adata, alabels = alabels)
 # ```

--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -135,7 +135,7 @@ end
 Random.seed!(6548) #hide
 model = schoolyard()
 anim = @animate for i in 0:30
-    i > 0 && step!(model, agent_step!, 1)
+    i > 0 && step!(model, dummystep, agent_step!, 1)
     p1 = plotabm(model; xlims = (0, 100), ylims = (0, 100), as = 7)
     scatter!(p1, [50], [50]; color = :red, legend = false) # Show position of teacher
     title!(p1, "step $(i)")

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -266,7 +266,7 @@ nothing # hide
 model = model_initiation(; params...)
 
 anim = @animate for i in 0:30
-    i > 0 && step!(model, agent_step!, 1)
+    i > 0 && step!(model, dummystep, agent_step!, 1)
     p1 = plotabm(model; ac = infected_fraction, plotargs...)
     title!(p1, "Day $(i)")
 end
@@ -288,7 +288,7 @@ nothing # hide
 model = model_initiation(; params...)
 
 to_collect = [(:status, f) for f in (infected, recovered, length)]
-data, _ = run!(model, agent_step!, 100; adata = to_collect)
+data, _ = run!(model, dummystep, agent_step!, 100; adata = to_collect)
 data[1:10, :]
 
 # We now plot how quantities evolved in time to show

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -75,7 +75,7 @@ anim = @animate for i in 1:2:100
     )
 
     title!(p1, "step $(i)")
-    step!(model, agent_step!, 2)
+    step!(model, dummystep, agent_step!, 2)
 end
 gif(anim, "socialdist1.gif", fps = 25)
 
@@ -110,7 +110,7 @@ anim = @animate for i in 1:2:100
         ylims = (0, e[2]),
     )
     title!(p1, "step $(i)")
-    step!(model2, agent_step!, model_step!, 2)
+    step!(model2, model_step!, agent_step!, 2)
 end
 gif(anim, "socialdist2.gif", fps = 25)
 
@@ -155,7 +155,7 @@ anim = @animate for i in 1:2:100
         ylims = (0, e[2]),
     )
     title!(p1, "step $(i)")
-    step!(model3, agent_step!, model_step!, 2)
+    step!(model3, model_step!, agent_step!, 2)
 end
 gif(anim, "socialdist3.gif", fps = 25)
 
@@ -326,7 +326,7 @@ anim = @animate for i in 1:2:100
         ylims = (0, e[2]),
     )
     title!(p1, "step $(i)")
-    step!(sir_model, sir_agent_step!, sir_model_step!, 2)
+    step!(sir_model, sir_model_step!, sir_agent_step!, 2)
 end
 gif(anim, "socialdist4.gif", fps = 25)
 
@@ -348,9 +348,9 @@ sir_model1 = sir_initiation(reinfection_probability = r1, βmin = β1)
 sir_model2 = sir_initiation(reinfection_probability = r2, βmin = β1)
 sir_model3 = sir_initiation(reinfection_probability = r1, βmin = β2)
 
-data1, _ = run!(sir_model1, sir_agent_step!, sir_model_step!, 2000; adata = adata)
-data2, _ = run!(sir_model2, sir_agent_step!, sir_model_step!, 2000; adata = adata)
-data3, _ = run!(sir_model3, sir_agent_step!, sir_model_step!, 2000; adata = adata)
+data1, _ = run!(sir_model1, sir_model_step!, sir_agent_step!, 2000; adata = adata)
+data2, _ = run!(sir_model2, sir_model_step!, sir_agent_step!, 2000; adata = adata)
+data3, _ = run!(sir_model3, sir_model_step!, sir_agent_step!, 2000; adata = adata)
 
 data1[(end - 10):end, :]
 
@@ -392,7 +392,7 @@ anim = @animate for i in 0:2:1000
         ylims = (0, e[2]),
     )
     title!(p1, "step $(i)")
-    step!(sir_model, sir_agent_step!, sir_model_step!, 2)
+    step!(sir_model, sir_model_step!, sir_agent_step!, 2)
 end
 gif(anim, "socialdist5.gif", fps = 25)
 
@@ -406,7 +406,7 @@ gif(anim, "socialdist5.gif", fps = 25)
 r4 = 0.04
 sir_model4 = sir_initiation(reinfection_probability = r4, βmin = β1, isolated = 0.8)
 
-data4, _ = run!(sir_model4, sir_agent_step!, sir_model_step!, 2000; adata = adata)
+data4, _ = run!(sir_model4, sir_model_step!, sir_agent_step!, 2000; adata = adata)
 
 plot!(p, data4[:, aggname(:status, infected)], label = "r=$r4, social distancing")
 p

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -221,7 +221,7 @@ end
 # The following animation shows the emergent unequal distribution of agents on resourceful areas.
 
 anim = @animate for i in 1:50
-    step!(model, agent_step!, env!, 1)
+    step!(model, env!, agent_step!, 1)
     p1 = heatmap(model.sugar_values)
     p2 = plotabm(model, as = 3, am = :square, ac = :blue)
     title!(p1, "Sugar levels")
@@ -233,7 +233,7 @@ gif(anim, "sugar.gif", fps = 8)
 # ### Distribution of wealth across individuals
 
 model2 = sugarscape()
-adata, _ = run!(model2, agent_step!, env!, 20, adata = [:wealth])
+adata, _ = run!(model2, env!, agent_step!, 20, adata = [:wealth])
 
 anim2 = @animate for i in 0:20
     histogram(

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -54,7 +54,7 @@ N = 5
 M = 2000
 adata = [:wealth]
 model = wealth_model(numagents = M)
-data, _ = run!(model, agent_step!, N; adata = adata)
+data, _ = run!(model, dummystep, agent_step!, N; adata = adata)
 data[(end - 20):end, :]
 
 # What we mostly care about is the distribution of wealth,
@@ -117,7 +117,7 @@ Random.seed!(5) # hide
 init_wealth = 4
 model = wealth_model_2D(; wealth = init_wealth)
 adata = [:wealth, :pos]
-data, _ = run!(model, agent_step!, 10; adata = adata, when = [1, 5, 9])
+data, _ = run!(model, dummystep, agent_step_2d!, 10; adata = adata, when = [1, 5, 9])
 data[(end - 20):end, :]
 
 # Okay, now we want to get the 2D spatial wealth distribution of the model.

--- a/examples/wright-fisher.jl
+++ b/examples/wright-fisher.jl
@@ -45,11 +45,10 @@ nothing # hide
 modelstep_neutral!(model::ABM) = sample!(model, nagents(model))
 nothing # hide
 
-# We can now run the model and collect data. We use `dummystep` for the agent-step
-# function (as the agents perform no actions).
+# We can now run the model and collect data.
 using Statistics: mean
 
-data, _ = run!(model, dummystep, modelstep_neutral!, 20; adata = [(:trait, mean)])
+data, _ = run!(model, modelstep_neutral!, 20; adata = [(:trait, mean)])
 data
 
 # As expected, the average value of the "trait" remains around 0.5.
@@ -66,7 +65,7 @@ end
 
 modelstep_selection!(model::ABM) = sample!(model, nagents(model), :trait)
 
-data, _ = run!(model, dummystep, modelstep_selection!, 20; adata = [(:trait, mean)])
+data, _ = run!(model, modelstep_selection!, 20; adata = [(:trait, mean)])
 data
 
 # Here we see that as time progresses, the trait becomes closer and closer to 1,

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -89,7 +89,7 @@ function daisyworld(;
         add_agent_pos!(wd, model)
     end
 
-    return model, daisyworld_agent_step!, daisyworld_model_step!
+    return model, daisyworld_model_step!, daisyworld_agent_step!
 end
 
 function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)

--- a/src/models/flocking.jl
+++ b/src/models/flocking.jl
@@ -54,7 +54,7 @@ function flocking(;
             visual_distance,
         )
     end
-    return model, flocking_agent_step!, dummystep
+    return model, dummystep, flocking_agent_step!
 end
 
 function flocking_agent_step!(bird, model)

--- a/src/models/forestfire.jl
+++ b/src/models/forestfire.jl
@@ -22,7 +22,7 @@ function forest_fire(; density = 0.7, griddims = (100, 100))
             add_agent!(position, forest, state)
         end
     end
-    return forest, forest_agent_step!, dummystep
+    return forest, dummystep, forest_agent_step!
 end
 
 function forest_agent_step!(tree, forest)

--- a/src/models/game_of_life.jl
+++ b/src/models/game_of_life.jl
@@ -29,7 +29,7 @@ function game_of_life(;
             idx += 1
         end
     end
-    return model, dummystep, game_of_life_model_step!
+    return model, game_of_life_model_step!, dummystep
 end
 
 function game_of_life_model_step!(model)

--- a/src/models/growing_bacteria.jl
+++ b/src/models/growing_bacteria.jl
@@ -36,7 +36,7 @@ function growing_bacteria()
     add_agent!((6.5, 4.0), model, 0.0, 0.3, 0.0, 0.1)
     add_agent!((7.5, 4.0), model, 0.0, 0.0, 0.0, 0.1)
 
-    return model, growing_bacteria_agent_step!, growing_bacteria_model_step!
+    return model, growing_bacteria_model_step!, growing_bacteria_agent_step!
 end
 
 function update_nodes!(a::SimpleCell)

--- a/src/models/hk.jl
+++ b/src/models/hk.jl
@@ -9,12 +9,14 @@ end
 
 """
 ``` julia
-hk(; 
-    numagents = 100, 
+hk(;
+    numagents = 100,
     ϵ = 0.2
 )
 ```
 Same as in [HK (Hegselmann and Krause) opinion dynamics model](@ref).
+**Note**: this model includes a termination function, so call
+`model, model_step!, agent_step!, terminate = hk()` to envoke it.
 """
 function hk(; numagents = 100, ϵ = 0.2)
     model = ABM(HKAgent, scheduler = fastest, properties = Dict(:ϵ => ϵ))
@@ -22,7 +24,7 @@ function hk(; numagents = 100, ϵ = 0.2)
         o = rand()
         add_agent!(model, o, o, -1)
     end
-    return model, hk_agent_step!, hk_model_step!, terminate
+    return model, hk_model_step!, hk_agent_step!, terminate
 end
 
 function boundfilter(agent, model)

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -31,7 +31,7 @@ function opinion(; dims = (10, 10), nopinions = 3, levels_per_opinion = 4)
             rand(1:levels_per_opinion, nopinions),
         )
     end
-    return model, opinion_agent_step!, dummystep
+    return model, dummystep, opinion_agent_step!
 end
 
 function adopt!(agent, model)

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -84,7 +84,7 @@ function predator_prey(;
         grass = Grass(id, (0, 0), fully_grown, countdown)
         add_agent!(grass, p, model)
     end
-    return model, predator_prey_agent_step!, dummystep
+    return model, dummystep, predator_prey_agent_step!
 end
 
 function predator_prey_agent_step!(sheep::Sheep, model)

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -25,7 +25,7 @@ function schelling(; numagents = 320, griddims = (20, 20), min_to_be_happy = 3)
         agent = SchellingAgent(n, (1, 1), false, n < numagents / 2 ? 1 : 2)
         add_agent_single!(agent, model)
     end
-    return model, schelling_agent_step!, dummystep
+    return model, dummystep, schelling_agent_step!
 end
 
 function schelling_agent_step!(agent, model)

--- a/src/models/social_distancing.jl
+++ b/src/models/social_distancing.jl
@@ -72,7 +72,7 @@ function social_distancing(;
         add_agent!(pos, model, vel, mass, 0, status, β)
     end
 
-    return model, social_distancing_agent_step!, social_distancing_model_step!
+    return model, social_distancing_model_step!, social_distancing_agent_step!
 end
 
 

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -86,7 +86,7 @@ function sugarscape(;
             rand(w0_dist[1]:w0_dist[2]),
         )
     end
-    return model, sugarscape_agent_step!, sugarscape_env!
+    return model, sugarscape_env!, sugarscape_agent_step!
 end
 
 function sugarscape_env!(model)

--- a/src/models/wealth_distribution.jl
+++ b/src/models/wealth_distribution.jl
@@ -20,7 +20,7 @@ function wealth_distribution(; dims = (25, 25), wealth = 1, M = 1000)
     for i in 1:M # add agents in random positions
         add_agent!(model, wealth)
     end
-    return model, wealth_distribution_agent_step!, dummystep
+    return model, dummystep, wealth_distribution_agent_step!
 end
 
 function wealth_distribution_agent_step!(agent, model)

--- a/src/models/wright-fisher.jl
+++ b/src/models/wright-fisher.jl
@@ -17,8 +17,8 @@ function wright_fisher(; numagents = 100, selection = true)
     for i in 1:numagents
         add_agent!(model, rand())
     end
-    !selection && return model, dummystep, wright_fisher_model_step_neutral!
-    return model, dummystep, wright_fisher_model_step_selection!
+    !selection && return model, wright_fisher_model_step_neutral!, dummystep
+    return model, wright_fisher_model_step_selection!, dummystep
 end
 
 wright_fisher_model_step_neutral!(model::ABM) = sample!(model, nagents(model))

--- a/src/simulations/paramscan.jl
+++ b/src/simulations/paramscan.jl
@@ -30,9 +30,9 @@ The following keywords modify the `paramscan` function:
 
 The following keywords are propagated into [`run!`](@ref):
 ```julia
-agent_step!, model_step!, n, when, step0, parallel, replicates, adata, mdata
+model_step!, agent_step!, n, when, step0, parallel, replicates, adata, mdata
 ```
-`agent_step!, model_step!, n` and at least one of `adata, mdata` are mandatory.
+`model_step!, agent_step!, n` and at least one of `adata, mdata` are mandatory.
 
 ## Example
 A runnable example that uses `paramscan` is shown in [Schelling's segregation model](@ref).
@@ -80,11 +80,11 @@ function paramscan(parameters::Dict{Symbol,}, initialize;
   counter = 0
   d, rest = Iterators.peel(combs)
   model = initialize(; d...)
-  df_agent, df_model = run!(model, agent_step!, model_step!, n; kwargs...)
+  df_agent, df_model = run!(model, model_step!, agent_step!, n; kwargs...)
   addparams!(df_agent, df_model, d, changing_params)
   for d in rest
     model = initialize(; d...)
-    df_agentTemp, df_modelTemp = run!(model, agent_step!, model_step!, n; kwargs...)
+    df_agentTemp, df_modelTemp = run!(model, model_step!, agent_step!, n; kwargs...)
     addparams!(df_agentTemp, df_modelTemp, d, changing_params)
     append!(df_agent, df_agentTemp)
     append!(df_model, df_modelTemp)

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -416,7 +416,7 @@ end
         for i in 1:100
             add_agent!(model, rand())
         end
-        step!(model, agent_step!, model_step!, 1, bool)
+        step!(model, model_step!, agent_step!, 1, bool)
         if bool
             @test model.count == 100
         else

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -139,8 +139,8 @@
         six_months(model, step) = step % 182 == 0
         agent_data, model_data = run!(
             model,
-            agent_step!,
             model_step!,
+            agent_step!,
             365 * 5;
             when_model = each_year,
             when = six_months,
@@ -158,8 +158,8 @@
 
         agent_data, model_data = run!(
             model,
-            agent_step!,
             model_step!,
+            agent_step!,
             365 * 5;
             when_model = [1, 365 * 5],
             when = false,
@@ -171,8 +171,8 @@
 
         _, model_data = run!(
             model,
-            agent_step!,
             model_step!,
+            agent_step!,
             365 * 5;
             when_model = [1, 365 * 5],
             when = false,
@@ -197,7 +197,7 @@
 
         for year in 1:5
             for day in 1:365
-                step!(model, agent_step!, model_step!, 1)
+                step!(model, model_step!, agent_step!, 1)
                 collect_model_data!(daily_model_data, model, model_props, day * year)
                 collect_agent_data!(daily_agent_aggregate, model, agent_agg, day * year)
             end
@@ -219,12 +219,12 @@
         @test dummystep(model) == nothing
         @test dummystep(model[1], model) == nothing
         tick = model.tick
-        step!(model, agent_step!, 1)
+        step!(model, dummystep, 1)
         @test tick == model.tick
         stop(m, s) = m.year == 6
-        step!(model, agent_step!, model_step!, stop)
+        step!(model, model_step!, agent_step!, stop)
         @test model.tick == 365 * 6
-        step!(model, agent_step!, model_step!, 1, false)
+        step!(model, model_step!, agent_step!, 1, false)
     end
 
     @testset "Mixed-ABM collections" begin
@@ -369,8 +369,8 @@
         model = initialize()
         agent_data, model_data = run!(
             model,
-            agent_step!,
             model_step!,
+            agent_step!,
             365 * 5;
             when_model = [1, 365 * 5],
             when = false,
@@ -390,7 +390,7 @@ end
         :griddims => (20, 20),
     )
 
-    forest, agent_step!, forest_step! = Models.forest_fire()
+    forest, forest_step!, agent_step! = Models.forest_fire()
     forest_initiation(; kwargs...) = Models.forest_fire(; kwargs...)[1]
 
     burnt(a) = a.status == :burnt
@@ -401,8 +401,8 @@ end
             parameters,
             forest_initiation;
             n = n,
-            agent_step! = agent_step!,
             model_step! = forest_step!,
+            agent_step! = agent_step!,
             adata = adata,
             progress = false,
         )
@@ -412,8 +412,8 @@ end
             parameters,
             forest_initiation;
             n = n,
-            agent_step! = agent_step!,
             model_step! = forest_step!,
+            agent_step! = agent_step!,
             include_constants = true,
             adata = adata,
             progress = false,
@@ -427,8 +427,8 @@ end
             parameters,
             forest_initiation;
             n = n,
-            agent_step! = agent_step!,
             model_step! = forest_step!,
+            agent_step! = agent_step!,
             adata = adata,
             progress = false,
         )
@@ -442,8 +442,8 @@ end
             parameters,
             forest_initiation;
             n = n,
-            agent_step! = dummystep,
             model_step! = forest_step!,
+            agent_step! = dummystep,
             replicates = 3,
             adata = adata,
             progress = false,

--- a/test/collisions_tests.jl
+++ b/test/collisions_tests.jl
@@ -1,90 +1,69 @@
 @testset "collisions" begin
+    speed = 0.002
+    dt = 1.0
+    diameter = 0.1
+    function model_initiation()
+        space = ContinuousSpace((10, 10), 0.1; periodic = true)
+        model = ABM(Agent6, space; properties = Dict(:c => 0))
 
-speed = 0.002
-dt = 1.0
-diameter = 0.1
-function model_initiation()
-  space = ContinuousSpace((10,10), 0.1; periodic = true)
-  model = ABM(Agent6, space; properties = Dict(:c => 0));
+        ## Add initial individuals
+        for i in 1:10, j in 1:10
+            pos = (i / 10, j / 10)
+            # these agents have infinite mass and 0 velocity. They are fixed.
+            if i > 5
+                vel = sincos(2π * rand()) .* speed
+                mass = 1.33
+            else
+                vel = (0.0, 0.0)
+                mass = Inf
+            end
 
-  ## Add initial individuals
-  for i in 1:10, j in 1:10
-    pos = (i/10, j/10)
-    # these agents have infinite mass and 0 velocity. They are fixed.
-    if i > 5
-      vel = sincos(2π*rand()) .* speed
-      mass = 1.33
-    else
-      vel = (0.0, 0.0)
-      mass = Inf
+            add_agent!(pos, model, vel, mass)
+        end
+        return model
     end
 
-    add_agent!(pos, model, vel, mass)
-  end
-  return model
-end
+    agent_step!(agent, model) = move_agent!(agent, model, dt)
 
-agent_step!(agent, model) = move_agent!(agent, model, dt)
-
-function model_step!(model)
-  ipairs = interacting_pairs(model, diameter, :scheduler)
-  for (a1, a2) in ipairs
-    e = elastic_collision!(a1, a2, :weight)
-    if e
-      model.properties[:c] += 1
+    function model_step!(model)
+        ipairs = interacting_pairs(model, diameter, :scheduler)
+        for (a1, a2) in ipairs
+            e = elastic_collision!(a1, a2, :weight)
+            if e
+                model.properties[:c] += 1
+            end
+        end
     end
-  end
-end
 
-function kinetic(model)
-  K = sum(sum(abs2.(a.vel)) for a in allagents(model))
-  p = (0.0, 0.0)
-  for a in allagents(model)
-    p = p .+ a.vel
-  end
-  return K, p
-end
+    function kinetic(model)
+        K = sum(sum(abs2.(a.vel)) for a in allagents(model))
+        p = (0.0, 0.0)
+        for a in allagents(model)
+            p = p .+ a.vel
+        end
+        return K, p
+    end
 
-model = model_initiation()
-initvels = [model[i].vel for i in 1:100]
-x = count(!isapprox(initvels[id][1], model[id].vel[1]) for id in 1:100)
-@test x == 0
+    model = model_initiation()
+    initvels = [model[i].vel for i in 1:100]
+    x = count(!isapprox(initvels[id][1], model[id].vel[1]) for id in 1:100)
+    @test x == 0
 
-K0, p0 = kinetic(model)
-step!(model, agent_step!, model_step!, 10)
-ipairs = interacting_pairs(model, diameter, :scheduler)
-@test length(ipairs) ≠ 100
-@test length(ipairs) ≠ 0
+    K0, p0 = kinetic(model)
+    step!(model, model_step!, agent_step!, 10)
+    ipairs = interacting_pairs(model, diameter, :scheduler)
+    @test length(ipairs) ≠ 100
+    @test length(ipairs) ≠ 0
 
-step!(model, agent_step!, model_step!, 10)
-x = count(any(initvels[id] .≠ model[id].vel) for id in 1:100)
+    step!(model, model_step!, agent_step!, 10)
+    x = count(any(initvels[id] .≠ model[id].vel) for id in 1:100)
 
-y = count(!any(initvels[id] .≈ model[id].vel) for id in 1:50)
-@test y == 0
+    y = count(!any(initvels[id] .≈ model[id].vel) for id in 1:50)
+    @test y == 0
 
-
-# x should be at least the amount of collisions happened
-@test x > 0
-@test model.properties[:c] > 0
-K1, p1 = kinetic(model)
-@test K1 ≈ K0
-# The following test is valid for non-infinite masses only
-# @test p1[1] ≈ p0[1]
-# @test p1[2] ≈ p0[2]
-
-
-# using Plots
-# pyplot()
-# model = model_initiation()
-# colors = [a.id for a in allagents(model)]
-# anim = @animate for i ∈ 1:200
-#   xs = [a.pos[1] for a in values(model.agents)];
-#   ys = [a.pos[2] for a in values(model.agents)];
-#   p1 = scatter(xs, ys, label="", marker_z=colors, xlims=[0,1], ylims=[0, 1], colorbar_title = "Agent ID")
-#   title!(p1, "step $(i)")
-#   step!(model, agent_step!, model_step!, round(Int, 1/dt))
-#   println("step $i")
-# end
-# gif(anim, "movement.gif", fps = 45);
-
+    # x should be at least the amount of collisions happened
+    @test x > 0
+    @test model.properties[:c] > 0
+    K1, p1 = kinetic(model)
+    @test K1 ≈ K0
 end


### PR DESCRIPTION
Fixes #331, assuming all of the docs work and tests pass.

Things to do or at least open for discussion:

- `interactive_abm` should be updated to the new ordering as well when this is released
- Schelling is our goto first model, this change kind of makes the `step!` look complicated, since we must provide the `dummystep`. Can we think of a way to either discuss this, or change something here to make the first model approachable? Stepping in a number of our example models are no longer as 'clean' it seems.
- An example using a more complex model structure would be nice. @fbanning, perhaps you could suggest something here?
- I did not want to introduce the agent_step separation as a legacy utility in the tutorial (which is essentially the only place we talk about step!). There needs to be some second, more advanced place to discuss this matter.

I'd suggest we add something like an UPGRADING.md file, which will give a run through of the changes needed to go from a 3.7 model, to a 4.0 one, but I'll leave that for a different PR.