### PR TITLE
Swap single function stepping method to model_step as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ therefore are not "truly breaking".
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allow performance updates in the future that may change internals but not lead to breaking changes.
 - `vertex2coord, coord2vertex` do not exist anymore because they are unnecessary in the new design.
-- **Default stepping function has changed.** `run!` and `step!` now expect at least `model_step!`, with `agent_step!` as an optional argument.
+- **Default stepping function has changed.** `run!` and `step!` now expects (at least) `model_step!`, with `agent_step!` as an optional argument.
 - API simplification and renaming:
   - `space_neighbors` -> `nearby_ids`
   - `node_neighbors` -> `nearby_positions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ therefore are not "truly breaking".
 - Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allow performance updates in the future that may change internals but not lead to breaking changes.
 - `vertex2coord, coord2vertex` do not exist anymore because they are unnecessary in the new design.
+- **Default stepping function has changed.** `run!` and `step!` now expect at least `model_step!`, with `agent_step!` as an optional argument.
 - API simplification and renaming:
   - `space_neighbors` -> `nearby_ids`
   - `node_neighbors` -> `nearby_positions`

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -52,14 +52,16 @@ For more functions visit the [API](@ref) page.
 ## 4. Evolving the model
 
 Any ABM model should have at least one and at most two step functions.
-An _agent step function_ is required by default.
-Such an agent step function defines what happens to an agent when it activates.
-Sometimes we also need a function that changes all agents at once, or changes a model property. In such cases, we can also provide a _model step function_.
-
-An agent step function should only accept two arguments: first, an agent object, and second, a model object.
-
+A _model step function_ is required by default.
 The model step function should accept only one argument, that is the model object.
-To use only a model step function, users can use the built-in [`dummystep`](@ref) as the agent step function.
+
+Optionally, we can also provide an _agent step function_, which defines what happens to
+an agent when it activates. An agent step function should only accept two arguments:
+first, an agent object, and second, a model object.
+
+Sometimes models are simple enough that changing agent properties is all that's required.
+In these cases, users can use the built-in [`dummystep`](@ref) as the model step
+function, to ignore any dynamics here.
 
 After you have defined these two functions, you evolve your model with `step!`:
 ```@docs

--- a/examples/diffeq.jl
+++ b/examples/diffeq.jl
@@ -343,7 +343,7 @@ import DiffEqCallbacks
 function fish!(integrator, model)
     integrator.p[2] = integrator.u[1] > model.min_threshold ?
         sum(a.yearly_catch for a in allagents(model)) : 0.0
-    Agents.step!(model, agent_cb_step!, 1)
+    Agents.step!(model, agent_cb_step!, dummystep, 1)
 end
 
 function fish_stock!(ds, s, p, t)

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -126,7 +126,7 @@ cd(@__DIR__) #src
 model = initialize_model()
 e = model.space.extent
 anim = @animate for i in 0:100
-    i > 0 && step!(model, agent_step!, 1)
+    i > 0 && step!(model, agent_step!, dummystep, 1)
     p1 = plotabm(
         model;
         am = bird_triangle,

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -71,12 +71,12 @@ nothing # hide
 
 # ## Running the model
 
-step!(forest, tree_step!, 1)
+step!(forest, tree_step!, dummystep, 1)
 count(t->t.status == :burnt, allagents(forest))
 
 #
 
-step!(forest, tree_step!, 10)
+step!(forest, tree_step!, dummystep, 10)
 count(t->t.status == :burnt, allagents(forest))
 
 # Now we can do some data collection as well using an aggregate function `percentage`:
@@ -86,13 +86,13 @@ forest = forest_fire(griddims = (20, 20))
 burnt_percentage(m) = count(t->t.status == :burnt, allagents(m)) / length(positions(m))
 mdata = [burnt_percentage]
 
-_, data = run!(forest, tree_step!, 10; mdata = mdata)
+_, data = run!(forest, tree_step!, dummystep, 10; mdata = mdata)
 data
 
 # Now let's plot the model. We use green for unburnt trees, red for burning and a
 # dark red for burnt.
 forest = forest_fire()
-step!(forest, tree_step!, 1)
+step!(forest, tree_step!, dummystep, 1)
 
 function treecolor(a)
     color = :green
@@ -110,7 +110,7 @@ plotabm(forest; ac = treecolor, ms = 5, msw = 0)
 cd(@__DIR__) #src
 forest = forest_fire(density = 0.6)
 anim = @animate for i in 0:10
-    i > 0 && step!(forest, tree_step!, 5)
+    i > 0 && step!(forest, tree_step!, dummystep, 5)
     p1 = plotabm(forest; ac = treecolor, ms = 5, msw = 0)
     title!(p1, "step $(i)")
 end

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -95,7 +95,7 @@ end
 cd(@__DIR__) #src
 ac(x) = x.status == true ? :black : :white
 anim = @animate for i in 0:100
-    i > 0 && step!(model, dummystep, ca_step!, 1)
+    i > 0 && step!(model, ca_step!, 1)
     p1 = plotabm(model; ac = ac, as = 3, am = :square, showaxis = false)
 end
 nothing # hide

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -110,7 +110,7 @@ levels_per_opinion = 3
 ac(agent) = RGB((agent.opinion[1:3] ./ levels_per_opinion)...)
 model = create_model(nopinions = 3, levels_per_opinion = levels_per_opinion)
 anim = @animate for sp in 1:500
-    step!(model, agent_step!)
+    step!(model, agent_step!, dummystep)
     p = plotabm(model, ac = ac, as = 12, am = :square)
     title!(p, "Step $(sp)")
     if rununtil(model, 1)

--- a/examples/optim.jl
+++ b/examples/optim.jl
@@ -36,6 +36,7 @@ function cost(x)
     _, data = run!(
         model,
         agent_step!,
+        dummystep,
         50;
         mdata = [infected_fraction],
         when_model = [50],
@@ -112,7 +113,7 @@ model = model_initiation(;
 )
 
 _, data =
-    run!(model, agent_step!, 50; mdata = [nagents], when_model = [50], replicates = 10)
+    run!(model, agent_step!, dummystep, 50; mdata = [nagents], when_model = [50], replicates = 10)
 
 mean(data.nagents)
 
@@ -141,6 +142,7 @@ function cost_multi(x)
     _, data = run!(
         model,
         agent_step!,
+        dummystep,
         50;
         mdata = [infected_fraction, n_fraction],
         when_model = [50],

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -239,7 +239,7 @@ sheep(a) = typeof(a) == Sheep
 wolves(a) = typeof(a) == Wolf
 grass(a) = typeof(a) == Grass && a.fully_grown
 adata = [(sheep, count), (wolves, count), (grass, count)]
-results, _ = run!(model, agent_step!, n_steps; adata = adata)
+results, _ = run!(model, agent_step!, dummystep, n_steps; adata = adata)
 
 # The plot shows the population dynamics over time. Initially, wolves become extinct because they
 # consume the sheep too quickly. The few remaining sheep reproduce and gradually reach an
@@ -267,7 +267,7 @@ model = initialize_model(
     sheep_reproduce = 0.2,
     wolf_reproduce = 0.08,
 )
-results, _ = run!(model, agent_step!, n_steps; adata = adata)
+results, _ = run!(model, agent_step!, dummystep, n_steps; adata = adata)
 @df results plot(
     :step,
     :count_sheep,

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -142,10 +142,13 @@ nothing # hide
 model = initialize()
 
 # We can advance the model one step
-step!(model, agent_step!)
+step!(model, agent_step!, dummystep)
 
 # Or for three steps
-step!(model, agent_step!, 3)
+step!(model, agent_step!, dummystep, 3)
+
+# Notice that we must provide a [`dummystep`](@ref) argument in place of `model_step!`
+# here, since we do not need to alter the model in any way.
 
 # ## Running the model and collecting data
 
@@ -157,14 +160,14 @@ step!(model, agent_step!, 3)
 adata = [:pos, :mood, :group]
 
 model = initialize()
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, agent_step!, dummystep, 5; adata = adata)
 data[1:10, :] # print only a few rows
 
 # We could also use functions in `adata`, for example we can define
 x(agent) = agent.pos[1]
 model = initialize()
 adata = [x, :mood, :group]
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, agent_step!, dummystep, 5; adata = adata)
 data[1:10, :]
 
 # With the above `adata` vector, we collected all agent's data.
@@ -174,7 +177,7 @@ data[1:10, :]
 
 model = initialize();
 adata = [(:mood, sum), (x, maximum)]
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, agent_step!, dummystep, 5; adata = adata)
 data
 
 # Other examples in the documentation are more realistic, with a much more meaningful
@@ -199,7 +202,7 @@ model = initialize();
 anim = @animate for i in 0:10
     p1 = plotabm(model; ac = groupcolor, am = groupmarker, as = 4)
     title!(p1, "step $(i)")
-    step!(model, agent_step!, 1)
+    step!(model, agent_step!, dummystep, 1)
 end
 
 gif(anim, "schelling.gif", fps = 2)
@@ -210,7 +213,7 @@ gif(anim, "schelling.gif", fps = 2)
 # To that end, we only need to specify `replicates` in the `run!` function:
 
 model = initialize(numagents = 370, griddims = (20, 20), min_to_be_happy = 3)
-data, _ = run!(model, agent_step!, 5; adata = adata, replicates = 3)
+data, _ = run!(model, agent_step!, dummystep, 5; adata = adata, replicates = 3)
 data[(end - 10):end, :]
 
 # It is possible to run the replicates in parallel.
@@ -234,7 +237,7 @@ data[(end - 10):end, :]
 # Then we can tell the `run!` function to run replicates in parallel:
 
 # ```julia
-# data, _ = run!(model, agent_step!, 2, adata=adata,
+# data, _ = run!(model, agent_step!, dummystep, 2, adata=adata,
 #                replicates=5, parallel=true)
 # ```
 

--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -135,7 +135,7 @@ end
 Random.seed!(6548) #hide
 model = schoolyard()
 anim = @animate for i in 0:30
-    i > 0 && step!(model, agent_step!, 1)
+    i > 0 && step!(model, agent_step!, dummystep, 1)
     p1 = plotabm(model; xlims = (0, 100), ylims = (0, 100), as = 7)
     scatter!(p1, [50], [50]; color = :red, legend = false) # Show position of teacher
     title!(p1, "step $(i)")

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -266,7 +266,7 @@ nothing # hide
 model = model_initiation(; params...)
 
 anim = @animate for i in 0:30
-    i > 0 && step!(model, agent_step!, 1)
+    i > 0 && step!(model, agent_step!, dummystep, 1)
     p1 = plotabm(model; ac = infected_fraction, plotargs...)
     title!(p1, "Day $(i)")
 end
@@ -288,7 +288,7 @@ nothing # hide
 model = model_initiation(; params...)
 
 to_collect = [(:status, f) for f in (infected, recovered, length)]
-data, _ = run!(model, agent_step!, 100; adata = to_collect)
+data, _ = run!(model, agent_step!, dummystep, 100; adata = to_collect)
 data[1:10, :]
 
 # We now plot how quantities evolved in time to show

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -75,7 +75,7 @@ anim = @animate for i in 1:2:100
     )
 
     title!(p1, "step $(i)")
-    step!(model, agent_step!, 2)
+    step!(model, agent_step!, dummystep, 2)
 end
 gif(anim, "socialdist1.gif", fps = 25)
 

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -54,7 +54,7 @@ N = 5
 M = 2000
 adata = [:wealth]
 model = wealth_model(numagents = M)
-data, _ = run!(model, agent_step!, N; adata = adata)
+data, _ = run!(model, agent_step!, dummystep, N; adata = adata)
 data[(end - 20):end, :]
 
 # What we mostly care about is the distribution of wealth,
@@ -117,7 +117,7 @@ Random.seed!(5) # hide
 init_wealth = 4
 model = wealth_model_2D(; wealth = init_wealth)
 adata = [:wealth, :pos]
-data, _ = run!(model, agent_step!, 10; adata = adata, when = [1, 5, 9])
+data, _ = run!(model, agent_step_2d!, dummystep, 10; adata = adata, when = [1, 5, 9])
 data[(end - 20):end, :]
 
 # Okay, now we want to get the 2D spatial wealth distribution of the model.

--- a/examples/wright-fisher.jl
+++ b/examples/wright-fisher.jl
@@ -45,11 +45,10 @@ nothing # hide
 modelstep_neutral!(model::ABM) = sample!(model, nagents(model))
 nothing # hide
 
-# We can now run the model and collect data. We use `dummystep` for the agent-step
-# function (as the agents perform no actions).
+# We can now run the model and collect data.
 using Statistics: mean
 
-data, _ = run!(model, dummystep, modelstep_neutral!, 20; adata = [(:trait, mean)])
+data, _ = run!(model, modelstep_neutral!, 20; adata = [(:trait, mean)])
 data
 
 # As expected, the average value of the "trait" remains around 0.5.
@@ -66,7 +65,7 @@ end
 
 modelstep_selection!(model::ABM) = sample!(model, nagents(model), :trait)
 
-data, _ = run!(model, dummystep, modelstep_selection!, 20; adata = [(:trait, mean)])
+data, _ = run!(model, modelstep_selection!, 20; adata = [(:trait, mean)])
 data
 
 # Here we see that as time progresses, the trait becomes closer and closer to 1,

--- a/src/models/hk.jl
+++ b/src/models/hk.jl
@@ -15,6 +15,8 @@ hk(;
 )
 ```
 Same as in [HK (Hegselmann and Krause) opinion dynamics model](@ref).
+**Note**: this model includes a termination function, so call
+`model, agent_step!, model_step!, terminate = hk()` to envoke it.
 """
 function hk(; numagents = 100, ϵ = 0.2)
     model = ABM(HKAgent, scheduler = fastest, properties = Dict(:ϵ => ϵ))

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -23,7 +23,7 @@ should_we_collect(s, model, when::Bool) = when
 should_we_collect(s, model, when) = when(model, s)
 
 """
-    run!(model, agent_step! [, model_step!], n::Integer; kwargs...) → agent_df, model_df
+    run!(model, [agent_step!, ] model_step!, n::Integer; kwargs...) → agent_df, model_df
     run!(model, agent_step!, model_step!, n::Function; kwargs...) → agent_df, model_df
 
 Run the model (step it with the input arguments propagated into [`step!`](@ref)) and collect
@@ -97,8 +97,8 @@ By default both keywords are `nothing`, i.e. nothing is collected/aggregated.
 """
 function run! end
 
-run!(model::ABM, agent_step!, n::Int = 1; kwargs...) =
-run!(model::ABM, agent_step!, dummystep, n; kwargs...)
+run!(model::ABM, model_step!, n::Int = 1; kwargs...) =
+run!(model::ABM, dummystep, model_step!, n; kwargs...)
 
 function run!(model::ABM, agent_step!, model_step!, n;
   replicates::Int=0, parallel::Bool=false, kwargs...)

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -1,12 +1,12 @@
 export step!, dummystep
 
 """
-    step!(model, agent_step!, n::Int = 1)
+    step!(model, model_step!, n::Int = 1)
     step!(model, agent_step!, model_step!, n::Int = 1, agents_first::Bool=true)
 
-Update agents `n` steps according to the stepping function `agent_step!`.
-Agents will be activated as specified by the `model.scheduler`.
-`model_step!` is triggered _after_ every scheduled agent has acted, unless
+Advances the model `n` steps according to the stepping function `model_step!`.
+Agents will be activated as specified by the `model.scheduler` if `agent_step!`
+is provided. `model_step!` is triggered _after_ every scheduled agent has acted, unless
 the argument `agents_first` is `false` (which then first calls `model_step!` and then
 activates the agents).
 
@@ -39,7 +39,7 @@ dummystep(agent, model) = nothing
 until(s, n::Int, model) = s < n
 until(s, n, model) = !n(model, s)
 
-step!(model::ABM, agent_step!, n::Int=1, agents_first::Bool=true) = step!(model, agent_step!, dummystep, n, agents_first)
+step!(model::ABM, model_step!, n::Int=1, agents_first::Bool=true) = step!(model, dummystep, model_step!, n, agents_first)
 
 function step!(model::ABM, agent_step!, model_step!, n = 1, agents_first=true)
   s = 0

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -219,7 +219,7 @@
         @test dummystep(model) == nothing
         @test dummystep(model[1], model) == nothing
         tick = model.tick
-        step!(model, agent_step!, 1)
+        step!(model, dummystep, 1)
         @test tick == model.tick
         stop(m, s) = m.year == 6
         step!(model, agent_step!, model_step!, stop)


### PR DESCRIPTION
A simpler (saner) implementation of #350, that fixes #331.

Still to consider:
-  An example using a more complex model structure would be nice. @fbanning, perhaps you could suggest something here?
- I did not want to introduce the agent_step separation as a legacy utility in the tutorial (which is essentially the only place we talk about step!). There needs to be some second, more advanced place to discuss this matter. (Ref: [this comment](https://github.com/JuliaDynamics/Agents.jl/issues/331#issuecomment-734314620))

I'd suggest we add something like an UPGRADING.md file, which will give a run through of the changes needed to go from a 3.7 model, to a 4.0 one, but I'll leave that for a different PR.