### PR TITLE
Tuple for search direction on GridSpaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   (see Breaking changes).
 - Performance increase of finding neighbors in GraphSpace with r > 1.
 - New wrapping function `nearby_agents` that returns an iterable of neighboring agents.
+- Positions and neighbors on `GridSpace` can now be searched in each direction separately by accepting `r` as a tuple.
 - New public `schedule` function for writing custom loops.
 - Mixed models are supported in data collection methods.
 - `random_agent(model, condition)` allows obtaining random agents that satisfy given condition.

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -72,7 +72,9 @@ What the "radius" means depends on the space type:
   For example, for `r=2` include first and second degree neighbors.
 - `GridSpace, ContinuousSpace`: Either Chebyshev (also called Moore) or Euclidean distance,
   in the space of cartesian indices.
-- `ContinuousSpace`: Euclidean distance.
+- `GridSpace` can also take a tuple argument, e.g. `r = (5, 2)` for a 2D space, which
+extends 5 positions in the x direction and 2 in the y. Only possible with Chebyshev
+spaces.
 
 ## Keywords
 Keyword arguments are space-specific.

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -20,6 +20,7 @@ struct GridSpace{D,P} <: DiscreteSpace
     s::Array{Vector{Int},D}
     metric::Symbol
     hoods::Dict{Float64,Hood{D}}
+    hoods_tuple::Dict{NTuple{D,Float64},Hood{D}}
 end
 
 
@@ -119,6 +120,16 @@ function initialize_neighborhood!(space::GridSpace{D}, r::Real) where {D}
     return hood
 end
 
+function initialize_neighborhood!(space::GridSpace{D}, r::NTuple{D,Real}) where {D}
+    @assert space.metric == :chebyshev "Cannot use tuple based neighbor search with the Euclidean metric."
+    d = size(space.s)
+    r0 = (floor(Int, i) for i in r)
+    βs = vec([CartesianIndex(a) for a in Iterators.product([(-r_0):r_0 for r_0 in r0]...)])
+    whole = Region(map(one, d), d)
+    hood = Hood{D}(whole, βs)
+    push!(space.hoods_tuple, float.(r) => hood)
+    return hood
+end
 
 """
     grid_space_neighborhood(α::CartesianIndex, space::GridSpace, r::Real)

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -23,7 +23,6 @@ struct GridSpace{D,P} <: DiscreteSpace
     hoods_tuple::Dict{NTuple{D,Float64},Hood{D}}
 end
 
-
 """
     GridSpace(d::NTuple{D, Int}; periodic = true, metric = :chebyshev)
 Create a `GridSpace` that has size given by the tuple `d`, having `D ≥ 1` dimensions.
@@ -41,11 +40,11 @@ cartesian indices have Euclidean distance `≤ r` from the cartesian index of th
 position.
 """
 function GridSpace(
-        d::NTuple{D,Int};
-        periodic::Bool = true,
-        metric::Symbol = :chebyshev,
-        moore = nothing
-    ) where {D}
+    d::NTuple{D,Int};
+    periodic::Bool = true,
+    metric::Symbol = :chebyshev,
+    moore = nothing,
+) where {D}
     s = Array{Vector{Int},D}(undef, d)
     if moore ≠ nothing
         @warn "Keyword `moore` is deprecated, use `metric` instead."
@@ -54,7 +53,12 @@ function GridSpace(
     for i in eachindex(s)
         s[i] = Int[]
     end
-    return GridSpace{D,periodic}(s, metric, Dict{Float64,Hood{D}}())
+    return GridSpace{D,periodic}(
+        s,
+        metric,
+        Dict{Float64,Hood{D}}(),
+        Dict{NTuple{D,Float64},Hood{D}}(),
+    )
 end
 
 #######################################################################################
@@ -124,7 +128,7 @@ function initialize_neighborhood!(space::GridSpace{D}, r::NTuple{D,Real}) where 
     @assert space.metric == :chebyshev "Cannot use tuple based neighbor search with the Euclidean metric."
     d = size(space.s)
     r0 = (floor(Int, i) for i in r)
-    βs = vec([CartesianIndex(a) for a in Iterators.product([(-r_0):r_0 for r_0 in r0]...)])
+    βs = vec([CartesianIndex(a) for a in Iterators.product([(-ri):ri for ri in r0]...)])
     whole = Region(map(one, d), d)
     hood = Hood{D}(whole, βs)
     push!(space.hoods_tuple, float.(r) => hood)
@@ -154,19 +158,39 @@ function grid_space_neighborhood(α::CartesianIndex, space::GridSpace, r::Real)
     _grid_space_neighborhood(α, space, hood)
 end
 
+"""
+    grid_space_neighborhood(α::CartesianIndex, space::GridSpace, r::NTuple)
+
+Return an iterator over all positions within distances of the tuple `r`, from `α`
+according to the `space`. `r` must have as many elements as `space` has dimensions.
+For example, with a `GridSpace((10, 10, 10))` : `r = (1, 7, 9)`.
+"""
+function grid_space_neighborhood(
+    α::CartesianIndex,
+    space::GridSpace{D},
+    r::NTuple{D,Real},
+) where {D}
+    hood = if haskey(space.hoods_tuple, r)
+        space.hoods_tuple[r]
+    else
+        initialize_neighborhood!(space, r)
+    end
+    _grid_space_neighborhood(α, space, hood)
+end
+
 function _grid_space_neighborhood(
-        α::CartesianIndex,
-        space::GridSpace{D,true},
-        hood,
-    ) where {D}
+    α::CartesianIndex,
+    space::GridSpace{D,true},
+    hood,
+) where {D}
     return ((mod1.(Tuple(α + β), hood.whole.maxi)) for β in hood.βs)
 end
 
 function _grid_space_neighborhood(
-        α::CartesianIndex,
-        space::GridSpace{D,false},
-        hood,
-    ) where {D}
+    α::CartesianIndex,
+    space::GridSpace{D,false},
+    hood,
+) where {D}
     return Iterators.filter(x -> x ∈ hood.whole, (Tuple(α + β) for β in hood.βs))
 end
 
@@ -202,7 +226,7 @@ end
 # %% pretty printing
 ###################################################################
 Base.size(space::GridSpace) = size(space.s)
-function Base.show(io::IO, space::GridSpace{D, P}) where {D, P}
+function Base.show(io::IO, space::GridSpace{D,P}) where {D,P}
     s = "GridSpace with size $(size(space)), metric=$(space.metric) and periodic=$(P)"
     print(io, s)
 end

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -1,260 +1,294 @@
 @testset "Space" begin
 
-@testset "1D grids" begin
-    a = GridSpace((5, ))
-    @test size(a) == (5, )
-    @test typeof(a.s) <: Array{Array{Int64,1},1}
-    @test a.metric == :chebyshev
+    @testset "1D grids" begin
+        a = GridSpace((5,))
+        @test size(a) == (5,)
+        @test typeof(a.s) <: Array{Array{Int64,1},1}
+        @test a.metric == :chebyshev
 
-    b = GridSpace((5, ), periodic = false)
-    @test size(b) == (5, )
-    @test typeof(b.s) <: Array{Array{Int64,1},1}
-    @test b.metric == :chebyshev
+        b = GridSpace((5,), periodic = false)
+        @test size(b) == (5,)
+        @test typeof(b.s) <: Array{Array{Int64,1},1}
+        @test b.metric == :chebyshev
 
-    c = GridSpace((3, ), metric = :euclidean)
-    @test size(c) == (3, )
-    @test typeof(c.s) <: Array{Array{Int64,1},1}
-    @test c.metric == :euclidean
+        c = GridSpace((3,), metric = :euclidean)
+        @test size(c) == (3,)
+        @test typeof(c.s) <: Array{Array{Int64,1},1}
+        @test c.metric == :euclidean
 
-    d = GridSpace((3, ), metric = :euclidean, periodic = false)
-    @test size(d) == (3, )
-    @test typeof(d.s) <: Array{Array{Int64,1},1}
-    @test d.metric == :euclidean
-end
-
-@testset "2D grids" begin
-    a = GridSpace((2, 3))
-    @test size(a) == (2, 3)
-    @test typeof(a.s) <: Array{Array{Int64,1},2}
-    @test a.metric == :chebyshev
-
-    b = GridSpace((2, 3), periodic = false)
-    @test size(b) == (2, 3)
-    @test typeof(b.s) <: Array{Array{Int64,1},2}
-    @test b.metric == :chebyshev
-
-    c = GridSpace((3, 3), metric = :euclidean)
-    @test size(c) == (3, 3)
-    @test typeof(c.s) <: Array{Array{Int64,1},2}
-    @test c.metric == :euclidean
-
-    d = GridSpace((3, 4), metric = :euclidean, periodic = false)
-    @test size(d) == (3, 4)
-    @test typeof(d.s) <: Array{Array{Int64,1},2}
-    @test d.metric == :euclidean
-end
-
-@testset "3D grids" begin
-    a = GridSpace((2, 3, 4))
-    @test size(a) == (2, 3, 4)
-    @test typeof(a.s) <: Array{Array{Int64,1},3}
-    @test a.metric == :chebyshev
-
-    b = GridSpace((2, 3, 7), periodic = false)
-    @test size(b) == (2, 3, 7)
-    @test typeof(b.s) <: Array{Array{Int64,1},3}
-    @test b.metric == :chebyshev
-
-    c = GridSpace((3, 3, 3), metric = :euclidean)
-    @test size(c) == (3, 3, 3)
-    @test typeof(c.s) <: Array{Array{Int64,1},3}
-    @test c.metric == :euclidean
-
-    d = GridSpace((3, 4, 2), metric = :euclidean, periodic = false)
-    @test size(d) == (3, 4, 2)
-    @test typeof(d.s) <: Array{Array{Int64,1},3}
-    @test d.metric == :euclidean
-end
-
-@testset "Positions" begin
-    space = GridSpace((3, 3))
-    model = ABM(Agent1, space)
-    empty = collect(empty_positions(model))
-    @test length(empty) > 0
-    for n in [1, 5, 6, 9, 2, 3, 4]
-        add_agent!(empty[n], model)
+        d = GridSpace((3,), metric = :euclidean, periodic = false)
+        @test size(d) == (3,)
+        @test typeof(d.s) <: Array{Array{Int64,1},1}
+        @test d.metric == :euclidean
     end
-    # only positions (1,3) and (2,3) should be empty
-    @test random_empty(model) ∈ [(1,3), (2,3)]
-    pos_map = [(1, 1)  (1, 2)  (1, 3)
-               (2, 1)  (2, 2)  (2, 3)
-               (3, 1)  (3, 2)  (3, 3)]
-    @test collect(positions(model)) == pos_map
-    random_positions = positions(model, :random)
-    @test all(n ∈ pos_map for n in random_positions)
-    @test positions(model, :population) == [pos_map[i] for i in [1, 2, 3, 4, 5, 6, 9, 7, 8]]
-    @test length(ids_in_position(5, model)) > length(ids_in_position(7, model))
-    @test_throws ErrorException positions(model, :notreal)
-end
 
-@testset "Euclidean Distance" begin
-    model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic=true))
-    a = add_agent!((1.0, 6.0), model, (0.5, 0.5), 2.0)
-    b = add_agent!((11.0, 4.0), model, (0.5, 0.7), 3.0)
-    @test edistance(a, b, model) ≈ 2.82842712
+    @testset "2D grids" begin
+        a = GridSpace((2, 3))
+        @test size(a) == (2, 3)
+        @test typeof(a.s) <: Array{Array{Int64,1},2}
+        @test a.metric == :chebyshev
 
-    model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic=false))
-    a = add_agent!((1.0, 6.0), model, (0.5, 0.5), 2.0)
-    b = add_agent!((11.0, 4.0), model, (0.5, 0.7), 3.0)
-    @test edistance(a, b, model) ≈ 10.198039
+        b = GridSpace((2, 3), periodic = false)
+        @test size(b) == (2, 3)
+        @test typeof(b.s) <: Array{Array{Int64,1},2}
+        @test b.metric == :chebyshev
 
-    model = ABM(Agent3, GridSpace((12, 10); periodic=true))
-    a = add_agent!((1.0, 6.0), model, 2.0)
-    b = add_agent!((11.0, 4.0), model, 3.0)
-    @test edistance(a, b, model) ≈ 2.82842712
+        c = GridSpace((3, 3), metric = :euclidean)
+        @test size(c) == (3, 3)
+        @test typeof(c.s) <: Array{Array{Int64,1},2}
+        @test c.metric == :euclidean
 
-    model = ABM(Agent3, GridSpace((12, 10); periodic=false))
-    a = add_agent!((1.0, 6.0), model, 2.0)
-    b = add_agent!((11.0, 4.0), model, 3.0)
-    @test edistance(a, b, model) ≈ 10.198039
+        d = GridSpace((3, 4), metric = :euclidean, periodic = false)
+        @test size(d) == (3, 4)
+        @test typeof(d.s) <: Array{Array{Int64,1},2}
+        @test d.metric == :euclidean
+    end
 
-    model = ABM(Agent5, GraphSpace(path_graph(5)))
-    a = add_agent!(1, model, rand())
-    b = add_agent!(2, model, rand())
-    @test_throws MethodError edistance(a, b, model)
-end
+    @testset "3D grids" begin
+        a = GridSpace((2, 3, 4))
+        @test size(a) == (2, 3, 4)
+        @test typeof(a.s) <: Array{Array{Int64,1},3}
+        @test a.metric == :chebyshev
 
-@testset "Nearby Agents" begin
-    undirected = ABM(Agent5, GraphSpace(path_graph(5)))
-    @test nearby_positions(3, undirected) == [2, 4]
-    @test nearby_positions(1, undirected) == [2]
-    @test nearby_positions(5, undirected) == [4]
-    @test nearby_positions(3, undirected; neighbor_type = :out) ==
-    nearby_positions(3, undirected; neighbor_type = :in) ==
-    nearby_positions(3, undirected; neighbor_type = :all) ==
-    nearby_positions(3, undirected; neighbor_type = :default)
-    add_agent!(1, undirected, rand())
-    add_agent!(2, undirected, rand())
-    add_agent!(3, undirected, rand())
-    # We expect id 2 to be included for a grid based search
-    @test sort!(collect(nearby_ids(2, undirected))) == [1, 2, 3]
-    # But to be excluded if we are looking around it.
-    @test sort!(collect(nearby_ids(undirected[2], undirected))) == [1, 3]
+        b = GridSpace((2, 3, 7), periodic = false)
+        @test size(b) == (2, 3, 7)
+        @test typeof(b.s) <: Array{Array{Int64,1},3}
+        @test b.metric == :chebyshev
 
-    directed = ABM(Agent5, GraphSpace(path_digraph(5)))
-    @test nearby_positions(3, directed) == [4]
-    @test nearby_positions(1, directed) == [2]
-    @test nearby_positions(5, directed) == []
-    @test nearby_positions(3, directed; neighbor_type = :default) ==
-          nearby_positions(3, directed)
-    @test nearby_positions(3, directed; neighbor_type = :in) == [2]
-    @test nearby_positions(3, directed; neighbor_type = :out) == [4]
-    @test sort!(nearby_positions(3, directed; neighbor_type = :all)) == [2, 4]
-    add_agent!(1, directed, rand())
-    add_agent!(2, directed, rand())
-    add_agent!(3, directed, rand())
-    @test sort!(nearby_ids(2, directed)) == [2, 3]
-    @test sort!(nearby_ids(2, directed; neighbor_type=:in)) == [1, 2]
-    @test sort!(nearby_ids(2, directed; neighbor_type=:all)) == [1, 2, 3]
-    @test collect(nearby_ids(directed[2], directed)) == [3]
-    @test collect(nearby_ids(directed[2], directed; neighbor_type=:in)) == [1]
-    @test sort!(collect(nearby_ids(directed[2], directed; neighbor_type=:all))) == [1, 3]
+        c = GridSpace((3, 3, 3), metric = :euclidean)
+        @test size(c) == (3, 3, 3)
+        @test typeof(c.s) <: Array{Array{Int64,1},3}
+        @test c.metric == :euclidean
 
-    gridspace = ABM(Agent3, GridSpace((3, 3); metric = :euclidean, periodic = false))
-    @test collect(nearby_positions((2, 2), gridspace)) == [(2, 1), (1, 2), (3, 2), (2, 3)]
-    @test collect(nearby_positions((1, 1), gridspace)) == [(2, 1), (1, 2)]
-    a = add_agent!((2, 2), gridspace, rand())
-    add_agent!((3, 2), gridspace, rand())
-    @test collect(nearby_ids((1, 2), gridspace)) == [1]
-    @test sort!(collect(nearby_ids((1, 2), gridspace, 2))) == [1, 2]
-    @test sort!(collect(nearby_ids((2, 2), gridspace))) == [1, 2]
-    @test collect(nearby_ids(a, gridspace)) == [2]
+        d = GridSpace((3, 4, 2), metric = :euclidean, periodic = false)
+        @test size(d) == (3, 4, 2)
+        @test typeof(d.s) <: Array{Array{Int64,1},3}
+        @test d.metric == :euclidean
+    end
 
-    Random.seed!(78)
-    continuousspace = ABM(Agent6, ContinuousSpace((1, 1), 0.1))
-    a = add_agent!((0.5, 0.5), continuousspace, (0.2, 0.1), 0.01)
-    b = add_agent!((0.6, 0.5), continuousspace, (0.1, -0.1), 0.01)
-    @test_throws MethodError nearby_positions(1, continuousspace)
-    @test collect(nearby_ids(a, continuousspace, 0.05)) == [2] # Not true, but we are not using the exact method
-    @test collect(nearby_ids(a, continuousspace, 0.05; exact=true)) == []
-    @test collect(nearby_ids(a, continuousspace, 0.1)) == [2]
-    @test sort!(collect(nearby_ids((0.55, 0.5), continuousspace, 0.05))) == [1, 2]
-    move_agent!(a, continuousspace)
-    move_agent!(b, continuousspace)
-    @test collect(nearby_ids(a, continuousspace, 0.1; exact=true)) == []
-    # Checks for type instability #208
-    @test typeof(collect(nearby_ids(a, continuousspace, 0.1))) <: Vector{Int}
-    @test typeof(collect(nearby_ids((0.55, 0.5), continuousspace, 0.05))) <: Vector{Int}
-end
+    @testset "Positions" begin
+        space = GridSpace((3, 3))
+        model = ABM(Agent1, space)
+        empty = collect(empty_positions(model))
+        @test length(empty) > 0
+        for n in [1, 5, 6, 9, 2, 3, 4]
+            add_agent!(empty[n], model)
+        end
+        # only positions (1,3) and (2,3) should be empty
+        @test random_empty(model) ∈ [(1, 3), (2, 3)]
+        pos_map = [
+            (1, 1) (1, 2) (1, 3)
+            (2, 1) (2, 2) (2, 3)
+            (3, 1) (3, 2) (3, 3)
+        ]
+        @test collect(positions(model)) == pos_map
+        random_positions = positions(model, :random)
+        @test all(n ∈ pos_map for n in random_positions)
+        @test positions(model, :population) ==
+              [pos_map[i] for i in [1, 2, 3, 4, 5, 6, 9, 7, 8]]
+        @test length(ids_in_position(5, model)) > length(ids_in_position(7, model))
+        @test_throws ErrorException positions(model, :notreal)
+    end
 
-@testset "Discrete space mutability" begin
-    model1 = ABM(Agent1, GridSpace((3,3)))
+    @testset "Euclidean Distance" begin
+        model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic = true))
+        a = add_agent!((1.0, 6.0), model, (0.5, 0.5), 2.0)
+        b = add_agent!((11.0, 4.0), model, (0.5, 0.7), 3.0)
+        @test edistance(a, b, model) ≈ 2.82842712
 
-    agent = add_agent!((1,1), model1)
-    @test agent.pos == (1, 1)
-    @test agent.id == 1
-    pos1 = ids_in_position((1,1), model1)
-    @test length(pos1) == 1
-    @test pos1[1] == 1
+        model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic = false))
+        a = add_agent!((1.0, 6.0), model, (0.5, 0.5), 2.0)
+        b = add_agent!((11.0, 4.0), model, (0.5, 0.7), 3.0)
+        @test edistance(a, b, model) ≈ 10.198039
 
-    move_agent!(agent, (2,2), model1)
-    @test agent.pos == (2,2)
-    pos1 = ids_in_position((1,1), model1)
-    @test length(pos1) == 0
-    pos2 = ids_in_position((2,2), model1)
-    @test pos2[1] == 1
+        model = ABM(Agent3, GridSpace((12, 10); periodic = true))
+        a = add_agent!((1.0, 6.0), model, 2.0)
+        b = add_agent!((11.0, 4.0), model, 3.0)
+        @test edistance(a, b, model) ≈ 2.82842712
 
-    # %% get/set testing
-    model = ABM(Agent1, GridSpace((10,10)); properties=Dict(:number => 1, :nested => BadAgent(1,1)))
-    add_agent!(model)
-    add_agent!(model)
-    @test (model.number += 1) == 2
-    @test (model.nested.pos = 5) == 5
-    @test_throws ErrorException (model.space = ContinuousSpace((1,1), 0.1))
-end
+        model = ABM(Agent3, GridSpace((12, 10); periodic = false))
+        a = add_agent!((1.0, 6.0), model, 2.0)
+        b = add_agent!((11.0, 4.0), model, 3.0)
+        @test edistance(a, b, model) ≈ 10.198039
 
-mutable struct Agent3D <: AbstractAgent
-    id::Int
-    pos::Tuple{Int,Int,Int}
-    weight::Float64
-end
+        model = ABM(Agent5, GraphSpace(path_graph(5)))
+        a = add_agent!(1, model, rand())
+        b = add_agent!(2, model, rand())
+        @test_throws MethodError edistance(a, b, model)
+    end
 
-@testset "Walk" begin
-    # Periodic
-    model = ABM(Agent3, GridSpace((3, 3)))
-    a = add_agent!((1, 1), model, rand())
-    walk!(a, North, model)
-    @test a.pos == (1, 2)
-    walk!(a, NorthEast, model)
-    @test a.pos == (2, 3)
-    walk!(a, East, model)
-    @test a.pos == (3, 3)
-    walk!(a, East, model, 2) # PBC
-    @test a.pos == (2, 3)
-    walk!(a, SouthEast, model)
-    @test a.pos == (3, 2)
-    walk!(a, South, model)
-    @test a.pos == (3, 1)
-    walk!(a, SouthWest, model) # PBC
-    @test a.pos == (2, 3)
-    walk!(a, West, model)
-    @test a.pos == (1, 3)
-    walk!(a, South, model, 8) # Round the world
-    @test a.pos == (1, 1)
+    @testset "Nearby Agents" begin
+        undirected = ABM(Agent5, GraphSpace(path_graph(5)))
+        @test nearby_positions(3, undirected) == [2, 4]
+        @test nearby_positions(1, undirected) == [2]
+        @test nearby_positions(5, undirected) == [4]
+        @test nearby_positions(3, undirected; neighbor_type = :out) ==
+              nearby_positions(3, undirected; neighbor_type = :in) ==
+              nearby_positions(3, undirected; neighbor_type = :all) ==
+              nearby_positions(3, undirected; neighbor_type = :default)
+        add_agent!(1, undirected, rand())
+        add_agent!(2, undirected, rand())
+        add_agent!(3, undirected, rand())
+        # We expect id 2 to be included for a grid based search
+        @test sort!(collect(nearby_ids(2, undirected))) == [1, 2, 3]
+        # But to be excluded if we are looking around it.
+        @test sort!(collect(nearby_ids(undirected[2], undirected))) == [1, 3]
 
-    # Non-Periodic
-    model = ABM(Agent3, GridSpace((3, 3); periodic = false))
-    a = add_agent!((1, 1), model, rand())
-    walk!(a, North, model)
-    @test a.pos == (1, 2)
-    walk!(a, NorthEast, model)
-    @test a.pos == (2, 3)
-    walk!(a, East, model)
-    @test a.pos == (3, 3)
-    walk!(a, East, model) # Boundary
-    @test a.pos == (3, 3)
-    walk!(a, West, model, 5) # Boundary
-    @test a.pos == (1, 3)
-    walk!(a, SouthWest, model) # Boundary in one direction, not in the other
-    @test a.pos == (1, 2)
+        directed = ABM(Agent5, GraphSpace(path_digraph(5)))
+        @test nearby_positions(3, directed) == [4]
+        @test nearby_positions(1, directed) == [2]
+        @test nearby_positions(5, directed) == []
+        @test nearby_positions(3, directed; neighbor_type = :default) ==
+              nearby_positions(3, directed)
+        @test nearby_positions(3, directed; neighbor_type = :in) == [2]
+        @test nearby_positions(3, directed; neighbor_type = :out) == [4]
+        @test sort!(nearby_positions(3, directed; neighbor_type = :all)) == [2, 4]
+        add_agent!(1, directed, rand())
+        add_agent!(2, directed, rand())
+        add_agent!(3, directed, rand())
+        @test sort!(nearby_ids(2, directed)) == [2, 3]
+        @test sort!(nearby_ids(2, directed; neighbor_type = :in)) == [1, 2]
+        @test sort!(nearby_ids(2, directed; neighbor_type = :all)) == [1, 2, 3]
+        @test collect(nearby_ids(directed[2], directed)) == [3]
+        @test collect(nearby_ids(directed[2], directed; neighbor_type = :in)) == [1]
+        @test sort!(collect(nearby_ids(directed[2], directed; neighbor_type = :all))) ==
+              [1, 3]
 
-    # Not 2D
-    model = ABM(Agent3D, GridSpace((3, 3, 3)))
-    a = add_agent!((1, 1, 1), model, rand())
-    @test_throws MethodError walk!(a, North, model)
-    # Not Grid
-    model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic = false))
-    a = add_agent!(model, (0, 0), rand())
-    @test_throws MethodError walk!(a, North, model)
-end
+        gridspace = ABM(Agent3, GridSpace((3, 3); metric = :euclidean, periodic = false))
+        @test collect(nearby_positions((2, 2), gridspace)) ==
+              [(2, 1), (1, 2), (3, 2), (2, 3)]
+        @test collect(nearby_positions((1, 1), gridspace)) == [(2, 1), (1, 2)]
+        a = add_agent!((2, 2), gridspace, rand())
+        add_agent!((3, 2), gridspace, rand())
+        @test collect(nearby_ids((1, 2), gridspace)) == [1]
+        @test sort!(collect(nearby_ids((1, 2), gridspace, 2))) == [1, 2]
+        @test sort!(collect(nearby_ids((2, 2), gridspace))) == [1, 2]
+        @test collect(nearby_ids(a, gridspace)) == [2]
+
+        @test_throws AssertionError nearby_positions((2, 2), gridspace, (1, 2))
+
+        model = ABM(Agent3, GridSpace((10, 5); periodic = false))
+        nearby_positions((5, 5), model, (1, 2))
+        @test collect(nearby_positions((5, 5), model, (1, 2))) ==
+              [(4, 3), (5, 3), (6, 3), (4, 4), (5, 4), (6, 4), (4, 5), (6, 5)]
+
+        model = ABM(Agent3, GridSpace((10, 5)))
+        @test collect(nearby_positions((5, 5), model, (1, 2))) == [
+            (4, 3),
+            (5, 3),
+            (6, 3),
+            (4, 4),
+            (5, 4),
+            (6, 4),
+            (4, 5),
+            (6, 5),
+            (4, 1),
+            (5, 1),
+            (6, 1),
+            (4, 2),
+            (5, 2),
+            (6, 2),
+        ]
+
+        Random.seed!(78)
+        continuousspace = ABM(Agent6, ContinuousSpace((1, 1), 0.1))
+        a = add_agent!((0.5, 0.5), continuousspace, (0.2, 0.1), 0.01)
+        b = add_agent!((0.6, 0.5), continuousspace, (0.1, -0.1), 0.01)
+        @test_throws MethodError nearby_positions(1, continuousspace)
+        @test collect(nearby_ids(a, continuousspace, 0.05)) == [2] # Not true, but we are not using the exact method
+        @test collect(nearby_ids(a, continuousspace, 0.05; exact = true)) == []
+        @test collect(nearby_ids(a, continuousspace, 0.1)) == [2]
+        @test sort!(collect(nearby_ids((0.55, 0.5), continuousspace, 0.05))) == [1, 2]
+        move_agent!(a, continuousspace)
+        move_agent!(b, continuousspace)
+        @test collect(nearby_ids(a, continuousspace, 0.1; exact = true)) == []
+        # Checks for type instability #208
+        @test typeof(collect(nearby_ids(a, continuousspace, 0.1))) <: Vector{Int}
+        @test typeof(collect(nearby_ids((0.55, 0.5), continuousspace, 0.05))) <: Vector{Int}
+    end
+
+    @testset "Discrete space mutability" begin
+        model1 = ABM(Agent1, GridSpace((3, 3)))
+
+        agent = add_agent!((1, 1), model1)
+        @test agent.pos == (1, 1)
+        @test agent.id == 1
+        pos1 = ids_in_position((1, 1), model1)
+        @test length(pos1) == 1
+        @test pos1[1] == 1
+
+        move_agent!(agent, (2, 2), model1)
+        @test agent.pos == (2, 2)
+        pos1 = ids_in_position((1, 1), model1)
+        @test length(pos1) == 0
+        pos2 = ids_in_position((2, 2), model1)
+        @test pos2[1] == 1
+
+        # %% get/set testing
+        model = ABM(
+            Agent1,
+            GridSpace((10, 10));
+            properties = Dict(:number => 1, :nested => BadAgent(1, 1)),
+        )
+        add_agent!(model)
+        add_agent!(model)
+        @test (model.number += 1) == 2
+        @test (model.nested.pos = 5) == 5
+        @test_throws ErrorException (model.space = ContinuousSpace((1, 1), 0.1))
+    end
+
+    mutable struct Agent3D <: AbstractAgent
+        id::Int
+        pos::Tuple{Int,Int,Int}
+        weight::Float64
+    end
+
+    @testset "Walk" begin
+        # Periodic
+        model = ABM(Agent3, GridSpace((3, 3)))
+        a = add_agent!((1, 1), model, rand())
+        walk!(a, North, model)
+        @test a.pos == (1, 2)
+        walk!(a, NorthEast, model)
+        @test a.pos == (2, 3)
+        walk!(a, East, model)
+        @test a.pos == (3, 3)
+        walk!(a, East, model, 2) # PBC
+        @test a.pos == (2, 3)
+        walk!(a, SouthEast, model)
+        @test a.pos == (3, 2)
+        walk!(a, South, model)
+        @test a.pos == (3, 1)
+        walk!(a, SouthWest, model) # PBC
+        @test a.pos == (2, 3)
+        walk!(a, West, model)
+        @test a.pos == (1, 3)
+        walk!(a, South, model, 8) # Round the world
+        @test a.pos == (1, 1)
+
+        # Non-Periodic
+        model = ABM(Agent3, GridSpace((3, 3); periodic = false))
+        a = add_agent!((1, 1), model, rand())
+        walk!(a, North, model)
+        @test a.pos == (1, 2)
+        walk!(a, NorthEast, model)
+        @test a.pos == (2, 3)
+        walk!(a, East, model)
+        @test a.pos == (3, 3)
+        walk!(a, East, model) # Boundary
+        @test a.pos == (3, 3)
+        walk!(a, West, model, 5) # Boundary
+        @test a.pos == (1, 3)
+        walk!(a, SouthWest, model) # Boundary in one direction, not in the other
+        @test a.pos == (1, 2)
+
+        # Not 2D
+        model = ABM(Agent3D, GridSpace((3, 3, 3)))
+        a = add_agent!((1, 1, 1), model, rand())
+        @test_throws MethodError walk!(a, North, model)
+        # Not Grid
+        model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic = false))
+        a = add_agent!(model, (0, 0), rand())
+        @test_throws MethodError walk!(a, North, model)
+    end
 end


### PR DESCRIPTION
Closes #314 by allowing `r` to be a tuple. We need to store a separate dictionary for this, but in general there is not too much overhead. 