### PR TITLE
Abbreviate keyword argument values

### DIFF
--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -317,7 +317,7 @@ adata = [(black, count, daisies), (white, count, daisies)]
 Random.seed!(165) # hide
 model = daisyworld(; solar_luminosity = 1.0)
 
-agent_df, model_df = run!(model, agent_step!, model_step!, 1000; adata = adata)
+agent_df, model_df = run!(model, agent_step!, model_step!, 1000; adata)
 
 p = plot(agent_df[!, :step], agent_df[!, :count_black_daisies], label = "black")
 plot!(p, agent_df[!, :step], agent_df[!, :count_white_daisies], label = "white")

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -131,7 +131,7 @@ function daisyworld(;
         :scenario => scenario,
         :tick => 0,
     )
-    model = ABM(Daisy, space; properties = properties)
+    model = ABM(Daisy, space; properties)
     for _ in 1:(init_white * nv(space) / 100)
         add_agent_single!(model, :white, rand(0:max_age), albedo_white)
     end

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -86,7 +86,7 @@ forest = forest_fire(griddims = (20, 20))
 burnt_percentage(m) = count(t->t.status == :burnt, allagents(m)) / length(positions(m))
 mdata = [burnt_percentage]
 
-_, data = run!(forest, tree_step!, 10; mdata = mdata)
+_, data = run!(forest, tree_step!, 10; mdata)
 data
 
 # Now let's plot the model. We use green for unburnt trees, red for burning and a

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -38,9 +38,9 @@ end
 # This function creates a model where all cells are "off".
 
 function build_model(; rules::Tuple, dims = (100, 100), metric = :chebyshev)
-    space = GridSpace(dims; metric = metric)
+    space = GridSpace(dims; metric)
     properties = Dict(:rules => rules)
-    model = ABM(Cell, space; properties = properties)
+    model = ABM(Cell, space; properties)
     idx = 1
     for x in 1:dims[1]
         for y in 1:dims[2]

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -239,7 +239,7 @@ sheep(a) = typeof(a) == Sheep
 wolves(a) = typeof(a) == Wolf
 grass(a) = typeof(a) == Grass && a.fully_grown
 adata = [(sheep, count), (wolves, count), (grass, count)]
-results, _ = run!(model, agent_step!, n_steps; adata = adata)
+results, _ = run!(model, agent_step!, n_steps; adata)
 
 # The plot shows the population dynamics over time. Initially, wolves become extinct because they
 # consume the sheep too quickly. The few remaining sheep reproduce and gradually reach an
@@ -267,7 +267,7 @@ model = initialize_model(
     sheep_reproduce = 0.2,
     wolf_reproduce = 0.08,
 )
-results, _ = run!(model, agent_step!, n_steps; adata = adata)
+results, _ = run!(model, agent_step!, n_steps; adata)
 @df results plot(
     :step,
     :count_sheep,

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -48,7 +48,7 @@ space = GridSpace((10, 10), periodic = false)
 # We also want to include a property `min_to_be_happy` in our model, and so we have:
 
 properties = Dict(:min_to_be_happy => 3)
-schelling = ABM(SchellingAgent, space; properties = properties)
+schelling = ABM(SchellingAgent, space; properties)
 
 
 # Here we used the default scheduler (which is also the fastest one) to create
@@ -157,14 +157,14 @@ step!(model, agent_step!, 3)
 adata = [:pos, :mood, :group]
 
 model = initialize()
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, agent_step!, 5; adata)
 data[1:10, :] # print only a few rows
 
 # We could also use functions in `adata`, for example we can define
 x(agent) = agent.pos[1]
 model = initialize()
 adata = [x, :mood, :group]
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, agent_step!, 5; adata)
 data[1:10, :]
 
 # With the above `adata` vector, we collected all agent's data.
@@ -174,7 +174,7 @@ data[1:10, :]
 
 model = initialize();
 adata = [(:mood, sum), (x, maximum)]
-data, _ = run!(model, agent_step!, 5; adata = adata)
+data, _ = run!(model, agent_step!, 5; adata)
 data
 
 # Other examples in the documentation are more realistic, with a much more meaningful

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -94,7 +94,7 @@ function model_initiation(;
         death_rate
     )
     space = GraphSpace(complete_digraph(C))
-    model = ABM(PoorSoul, space; properties = properties)
+    model = ABM(PoorSoul, space; properties)
 
     ## Add initial individuals
     for city in 1:C, n in 1:Ns[city]

--- a/examples/siroptim.jl
+++ b/examples/siroptim.jl
@@ -51,7 +51,7 @@ function model_initiation(;
         C,
     )
     space = GraphSpace(complete_digraph(C))
-    model = ABM(PoorSoul, space; properties = properties)
+    model = ABM(PoorSoul, space; properties)
 
     # Add initial individuals
     for city in 1:C, n in 1:Ns[city]

--- a/examples/social_distancing.jl
+++ b/examples/social_distancing.jl
@@ -348,9 +348,9 @@ sir_model1 = sir_initiation(reinfection_probability = r1, βmin = β1)
 sir_model2 = sir_initiation(reinfection_probability = r2, βmin = β1)
 sir_model3 = sir_initiation(reinfection_probability = r1, βmin = β2)
 
-data1, _ = run!(sir_model1, sir_agent_step!, sir_model_step!, 2000; adata = adata)
-data2, _ = run!(sir_model2, sir_agent_step!, sir_model_step!, 2000; adata = adata)
-data3, _ = run!(sir_model3, sir_agent_step!, sir_model_step!, 2000; adata = adata)
+data1, _ = run!(sir_model1, sir_agent_step!, sir_model_step!, 2000; adata)
+data2, _ = run!(sir_model2, sir_agent_step!, sir_model_step!, 2000; adata)
+data3, _ = run!(sir_model3, sir_agent_step!, sir_model_step!, 2000; adata)
 
 data1[(end - 10):end, :]
 
@@ -406,7 +406,7 @@ gif(anim, "socialdist5.gif", fps = 25)
 r4 = 0.04
 sir_model4 = sir_initiation(reinfection_probability = r4, βmin = β1, isolated = 0.8)
 
-data4, _ = run!(sir_model4, sir_agent_step!, sir_model_step!, 2000; adata = adata)
+data4, _ = run!(sir_model4, sir_agent_step!, sir_model_step!, 2000; adata)
 
 plot!(p, data4[:, aggname(:status, infected)], label = "r=$r4, social distancing")
 p

--- a/examples/wealth_distribution.jl
+++ b/examples/wealth_distribution.jl
@@ -54,7 +54,7 @@ N = 5
 M = 2000
 adata = [:wealth]
 model = wealth_model(numagents = M)
-data, _ = run!(model, agent_step!, N; adata = adata)
+data, _ = run!(model, agent_step!, N; adata)
 data[(end - 20):end, :]
 
 # What we mostly care about is the distribution of wealth,

--- a/src/models/game_of_life.jl
+++ b/src/models/game_of_life.jl
@@ -19,9 +19,9 @@ function game_of_life(;
     dims = (100, 100),
     metric = :chebyshev
 )
-    space = GridSpace(dims; metric = metric)
+    space = GridSpace(dims; metric)
     properties = Dict(:rules => rules)
-    model = ABM(Cell, space; properties = properties)
+    model = ABM(Cell, space; properties)
     idx = 1
     for x in 1:dims[1]
         for y in 1:dims[2]

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -137,19 +137,19 @@ function _run!(model, agent_step!, model_step!, n;
     s = 0
     while until(s, n, model)
         if should_we_collect(s, model, when)
-            collect_agent_data!(df_agent, model, adata, s; obtainer = obtainer)
+            collect_agent_data!(df_agent, model, adata, s; obtainer)
         end
         if should_we_collect(s, model, when_model)
-            collect_model_data!(df_model, model, mdata, s; obtainer = obtainer)
+            collect_model_data!(df_model, model, mdata, s; obtainer)
         end
         step!(model, agent_step!, model_step!, 1, agents_first)
         s += 1
     end
     if should_we_collect(s, model, when)
-        collect_agent_data!(df_agent, model, adata, s; obtainer = obtainer)
+        collect_agent_data!(df_agent, model, adata, s; obtainer)
     end
     if should_we_collect(s, model, when_model)
-        collect_model_data!(df_model, model, mdata, s; obtainer = obtainer)
+        collect_model_data!(df_model, model, mdata, s; obtainer)
     end
     return df_agent, df_model
 end

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -213,7 +213,7 @@ function nearest_neighbor(
         r;
         exact = false,
     ) where {A}
-    n = collect(nearby_ids(agent, model, r; exact = exact))
+    n = collect(nearby_ids(agent, model, r; exact))
     length(n) == 0 && return nothing
     d, j = Inf, 1
     for i in 1:length(n)
@@ -355,7 +355,7 @@ function all_pairs!(
         exact = true,
     ) where {A}
     for a in allagents(model)
-        for nid in nearby_ids(a, model, r; exact = exact)
+        for nid in nearby_ids(a, model, r; exact)
             # Sort the pair to overcome any uniqueness issues
             new_pair = isless(a.id, nid) ? (a.id, nid) : (nid, a.id)
             new_pair ∉ pairs && push!(pairs, new_pair)


### PR DESCRIPTION
Hi! I'm working on a linter, and saw that this repository is set to Julia 1.5 and has [26 occurrences](https://lint.huijzer.xyz/github/juliadynamics/agents.jl/#abbreviate_keyword_argument_values_26_hits) of using 
```
f(a, b; c = c)
```
which [from Julia 1.5 onwards](https://julialang.org/blog/2020/08/julia-1.5-highlights) can be abbreviated to
```
f(a, b; c)
```
This PR applies this abbreviation. Feel free to close this PR immediately if you're not interested in this small refactoring.

Note that currently, I'm not matching cases like `f(a, b; c = c, d = e)` or `f(a, b; d = e, c = c)`. If you want to include this in one big PR, then let me know, and I'll add the patterns and update this PR :smile: 