### PR TITLE
Avoid findall(x -> x == false, Y)

### DIFF
--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -53,7 +53,7 @@ function adopt!(agent, model)
     matches = model[neighbor].opinion .== agent.opinion
     nmatches = count(matches)
     if nmatches < model.nopinions && rand() < nmatches / model.nopinions
-        switchId = rand(findall(x -> x == false, matches))
+        switchId = rand(findall(!, matches))
         agent.opinion[switchId] = model[neighbor].opinion[switchId]
     end
 end

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -40,7 +40,7 @@ function adopt!(agent, model)
     nmatches = count(matches)
     # Adopt a different opinion w/ calculated probability
     if nmatches < model.nopinions && rand() < nmatches / model.nopinions
-        switchId = rand(findall(x -> x == false, matches))
+        switchId = rand(findall(!, matches))
         agent.opinion[switchId] = model[neighbor].opinion[switchId]
     end
 end


### PR DESCRIPTION
This is an extension of PR https://github.com/JuliaDynamics/Agents.jl/pull/357.

Instead of writing
```
julia> findall(x -> x == false, [true, false])
1-element Array{Int64,1}:
 2
```
it is possible to write
```
julia> findall(!, [true, false])
1-element Array{Int64,1}:
 2
```
or even
```
findall(.!Y)
1-element Array{Int64,1}:
 2
```
I guess the second variant is the clearest to readers, so this PR suggest to rewrite to occurrences to that.

Feel free to press close immediately if you don't find this a good suggestion! :smile: 