### PR TITLE
Move gridspace examples to Dim shorthand for their position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ therefore are not "truly breaking".
   - `has_empty_nodes` -> `has_empty_positions`
   - `nodes` -> `positions`
 
+## Non-breaking changes
+- `GridSpace` agents now use `Dims` rather than `Tuple{N,Int}` for their `pos`ition in all examples and pre-defined models.
+
 # v3.7
 - Add the ability to decide whether the agent step or the model step should be performed first using the `agents_first` argument.
 # v3.6

--- a/benchmark/agents.jl
+++ b/benchmark/agents.jl
@@ -27,29 +27,29 @@ end
 
 mutable struct GridAgent <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     one::Float64
     two::Bool
 end
 
 mutable struct GridAgentTwo <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
 end
 
 mutable struct GridAgentThree <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
 end
 
 mutable struct GridAgentFour <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
 end
 
 mutable struct GridAgentFive <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
 end
 
 mutable struct ContinuousAgent <: AbstractAgent

--- a/examples/daisyworld.jl
+++ b/examples/daisyworld.jl
@@ -56,7 +56,7 @@ gr() # hide
 
 mutable struct Daisy <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     breed::Symbol
     age::Int
     albedo::Float64 # 0-1 fraction
@@ -64,7 +64,7 @@ end
 
 mutable struct Land <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     temperature::Float64
 end
 
@@ -75,7 +75,7 @@ const DaisyWorld = ABM{Union{Daisy,Land}};
 # The surface temperature of the world is heated by its sun, but daisies growing upon it
 # absorb or reflect the starlight -- altering the local temperature.
 
-function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function update_surface_temperature!(pos::Dims{2}, model::DaisyWorld)
     ids = ids_in_position(pos, model)
     ## All grid positions have at least one agent (the land)
     absorbed_luminosity = if length(ids) == 1
@@ -96,7 +96,7 @@ end
 nothing # hide
 
 # In addition, temperature diffuses over time
-function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function diffuse_temperature!(pos::Dims{2}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
     ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land) / 8
@@ -115,7 +115,7 @@ nothing # hide
 # daisies compete for land and attempt to spawn a new plant of their `breed` in locations
 # close to them.
 
-function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function propagate!(pos::Dims{2}, model::DaisyWorld)
     ids = ids_in_position(pos, model)
     if length(ids) > 1
         daisy = model[ids[2]]

--- a/examples/daisyworld_matrix.jl
+++ b/examples/daisyworld_matrix.jl
@@ -42,7 +42,7 @@ gr() # hide
 
 mutable struct Daisy <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     breed::Symbol
     age::Int
     albedo::Float64 # 0-1 fraction
@@ -53,7 +53,7 @@ end
 # The surface temperature of the world is heated by its sun, but daisies growing upon it
 # absorb or reflect the starlight -- altering the local temperature.
 
-function suface_temperature!(pos::Tuple{Int,Int}, model::ABM{Daisy})
+function suface_temperature!(pos::Dims{2}, model::ABM{Daisy})
     ids = ids_in_position(pos, model)
     absorbed_luminosity = if isempty(ids)
         ## Set luminosity via surface albedo
@@ -153,7 +153,7 @@ nothing # hide
 # daisies compete for land and attempt to spawn a new plant of their `breed` in locations
 # close to them.
 
-function propagate!(pos::Tuple{Int,Int}, model::ABM{Daisy})
+function propagate!(pos::Dims{2}, model::ABM{Daisy})
     agents = collect(agents_in_position(pos, model))
     if !isempty(agents)
         agent = agents[1]

--- a/examples/forest_fire.jl
+++ b/examples/forest_fire.jl
@@ -23,7 +23,7 @@ gr() # hide
 
 mutable struct Tree <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     status::Symbol  #:green, :burning, :burnt
 end
 nothing # hide

--- a/examples/game_of_life_2D_CA.jl
+++ b/examples/game_of_life_2D_CA.jl
@@ -26,11 +26,11 @@ nothing # hide
 
 mutable struct Cell <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     status::Bool
 end
 
-# The following function builds a 2D cellular automaton. `rules` is of type `Tuple{Int,Int,Int, Int}` representing DSRO.
+# The following function builds a 2D cellular automaton. `rules` is of type `Tuple{Int,Int,Int,Int}` representing DSRO.
 
 # `dims` is a tuple of integers determining the width and height of the grid environment.
 # `metric` specifies whether cells connect to their diagonal neighbors.

--- a/examples/measurements.jl
+++ b/examples/measurements.jl
@@ -15,7 +15,7 @@ using Measurements
 
 mutable struct Daisy <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     breed::Symbol
     age::Int
     albedo::AbstractFloat # Allow Measurements
@@ -23,7 +23,7 @@ end
 
 mutable struct Land <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     temperature::AbstractFloat # Allow Measurements
 end
 
@@ -46,7 +46,7 @@ using Random # hide
 
 const DaisyWorld = ABM{Union{Daisy,Land}}
 
-function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function update_surface_temperature!(pos::Dims{2}, model::DaisyWorld)
     ids = ids_in_position(pos, model)
     absorbed_luminosity = if length(ids) == 1
         (1 - model.surface_albedo) * model.solar_luminosity
@@ -58,7 +58,7 @@ function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     model[ids[1]].temperature = (T0 + local_heating) / 2
 end
 
-function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function diffuse_temperature!(pos::Dims{2}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5)
     ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land) / 8
@@ -66,7 +66,7 @@ function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     land.temperature = (1 - ratio) * land.temperature + ratio * meantemp
 end
 
-function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function propagate!(pos::Dims{2}, model::DaisyWorld)
     ids = ids_in_position(pos, model)
     if length(ids) > 1
         daisy = model[ids[2]]

--- a/examples/opinion_spread.jl
+++ b/examples/opinion_spread.jl
@@ -19,7 +19,7 @@ using Random
 
 mutable struct Citizen <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     stabilized::Bool
     opinion::Array{Int,1}
     prev_opinion::Array{Int,1}

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -35,7 +35,7 @@ pyplot() # hide
 
 mutable struct Sheep <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     energy::Float64
     reproduction_prob::Float64
     Δenergy::Float64
@@ -43,7 +43,7 @@ end
 
 mutable struct Wolf <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     energy::Float64
     reproduction_prob::Float64
     Δenergy::Float64
@@ -51,7 +51,7 @@ end
 
 mutable struct Grass <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     fully_grown::Bool
     regrowth_time::Int
     countdown::Int

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -24,13 +24,13 @@ gr() # hide
 
 mutable struct SchellingAgent <: AbstractAgent
     id::Int # The identifier number of the agent
-    pos::Tuple{Int,Int} # The x, y location of the agent on a 2D grid
+    pos::Dims{2} # The x, y location of the agent on a 2D grid
     mood::Bool # whether the agent is happy in its position. (true = happy)
     group::Int # The group of the agent,  determines mood as it interacts with neighbors
 end
 
-# Notice that the position of this Agent type is a `Tuple{Int,Int}` because
-# we will use a `GridSpace`.
+# Notice that the position of this Agent type is a `Dims{2}`, equivalent to
+# `Tuple{Int,Int}`, because we will use a `GridSpace`.
 
 # We added two more fields for this model, namely a `mood` field which will
 # store `true` for a happy agent and `false` for an unhappy one, and an `group`

--- a/examples/sugarscape.jl
+++ b/examples/sugarscape.jl
@@ -71,7 +71,7 @@ using Random
 
 mutable struct SugarSeeker <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     vision::Int
     metabolic_rate::Int
     age::Int

--- a/src/models/daisyworld.jl
+++ b/src/models/daisyworld.jl
@@ -4,7 +4,7 @@ export Daisy, Land, DaisyWorld
 
 mutable struct Daisy <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     breed::Symbol
     age::Int
     albedo::Float64 # 0-1 fraction
@@ -12,7 +12,7 @@ end
 
 mutable struct Land <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     temperature::Float64
 end
 
@@ -92,7 +92,7 @@ function daisyworld(;
     return model, daisyworld_agent_step!, daisyworld_model_step!
 end
 
-function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function update_surface_temperature!(pos::Dims{2}, model::DaisyWorld)
     ids = ids_in_position(pos, model)
     ## All grid positions have at least one agent (the land)
     absorbed_luminosity = if length(ids) == 1
@@ -111,7 +111,7 @@ function update_surface_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     model[ids[1]].temperature = (T0 + local_heating) / 2
 end
 
-function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function diffuse_temperature!(pos::Dims{2}, model::DaisyWorld)
     ratio = get(model.properties, :ratio, 0.5) # diffusion ratio
     ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land)/8
@@ -121,7 +121,7 @@ function diffuse_temperature!(pos::Tuple{Int,Int}, model::DaisyWorld)
     land.temperature = (1 - ratio)*land.temperature + ratio*meantemp
 end
 
-function propagate!(pos::Tuple{Int,Int}, model::DaisyWorld)
+function propagate!(pos::Dims{2}, model::DaisyWorld)
     ids = ids_in_position(pos, model)
     if length(ids) > 1
         daisy = model[ids[2]]

--- a/src/models/forestfire.jl
+++ b/src/models/forestfire.jl
@@ -1,6 +1,6 @@
 mutable struct Tree <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     status::Symbol  #:green, :burning, :burnt
 end
 

--- a/src/models/game_of_life.jl
+++ b/src/models/game_of_life.jl
@@ -1,6 +1,6 @@
 mutable struct Cell <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     status::Bool
 end
 

--- a/src/models/opinion.jl
+++ b/src/models/opinion.jl
@@ -2,7 +2,7 @@ using Random
 
 mutable struct Citizen <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     stabilized::Bool
     opinion::Array{Int,1}
     prev_opinion::Array{Int,1}

--- a/src/models/predator_prey.jl
+++ b/src/models/predator_prey.jl
@@ -2,19 +2,19 @@ export Sheep, Wolf, Grass
 
 mutable struct Sheep <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     energy::Float64
 end
 
 mutable struct Wolf <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     energy::Float64
 end
 
 mutable struct Grass <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     fully_grown::Bool
     countdown::Int
 end

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -1,6 +1,6 @@
 mutable struct SchellingAgent <: AbstractAgent
     id::Int # The identifier number of the agent
-    pos::Tuple{Int,Int} # The x, y location of the agent on a 2D grid
+    pos::Dims{2} # The x, y location of the agent on a 2D grid
     mood::Bool # whether the agent is happy in its position. (true = happy)
     group::Int # The group of the agent,  determines mood as it interacts with neighbors
 end

--- a/src/models/sugarscape.jl
+++ b/src/models/sugarscape.jl
@@ -1,6 +1,6 @@
 mutable struct SugarSeeker <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     vision::Int
     metabolic_rate::Int
     age::Int

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -137,12 +137,12 @@ models where the agent constructor cannot be deduced (since it is a union).
 using Agents
 mutable struct Daisy <: AbstractAgent
     id::Int
-    pos::Tuple{Int, Int}
+    pos::Dims{2}
     breed::String
 end
 mutable struct Land <: AbstractAgent
     id::Int
-    pos::Tuple{Int, Int}
+    pos::Dims{2}
     temperature::Float64
 end
 space = GridSpace((10, 10))

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -28,8 +28,9 @@ end
 Create a `GridSpace` that has size given by the tuple `d`, having `D ≥ 1` dimensions.
 Optionally decide whether the space will be periodic and what will be the distance metric
 used, which decides the behavior of e.g. [`nearby_ids`](@ref).
-The position type for this space is `NTuple{D, Int}` and valid positions have indices
-in the range `1:d[i]` for the `i`th dimension.
+The position type for this space is `NTuple{D, Int}`. In our examples we use the
+[`Dims{D}`](https://docs.julialang.org/en/v1/base/arrays/#Base.Dims) shorthand.
+Valid positions have indices in the range `1:d[i]` for the `i`th dimension.
 
 `:chebyshev` metric means that the `r`-neighborhood of a position are all
 positions within the hypercube having side length of `2*floor(r)` and being centered in

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -343,12 +343,12 @@ end
 
 mutable struct Daisy <: AbstractAgent
   id::Int
-  pos::Tuple{Int, Int}
+  pos::Dims{2}
   breed::String
 end
 mutable struct Land <: AbstractAgent
   id::Int
-  pos::Tuple{Int, Int}
+  pos::Dims{2}
   temperature::Float64
 end
 @testset "fill space" begin

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -311,7 +311,7 @@
         # In this example, weight exists in both agents, but they have different types
         mutable struct Agent3Int <: AbstractAgent
             id::Int
-            pos::Tuple{Int,Int}
+            pos::Dims{2}
             weight::Int
         end
         model = ABM(Union{Agent3, Agent3Int}, GridSpace((10,10)); warn = false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ end
 
 mutable struct Agent1 <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
 end
 
 mutable struct Agent2 <: AbstractAgent
@@ -17,13 +17,13 @@ end
 
 mutable struct Agent3 <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     weight::Float64
 end
 
 mutable struct Agent4 <: AbstractAgent
     id::Int
-    pos::Tuple{Int,Int}
+    pos::Dims{2}
     p::Int
 end
 

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -238,7 +238,7 @@
 
     mutable struct Agent3D <: AbstractAgent
         id::Int
-        pos::Tuple{Int,Int,Int}
+        pos::Dims{3}
         weight::Float64
     end
 


### PR DESCRIPTION
Closes #361

Not changed everywhere, just where appropriate in the examples and models. Internal references are not required to be altered. 

Added in a few places (tutorial and the first example people see: Schelling) a point that `Dims` is just an alias for `NTuple{N,Int}`.