### PR TITLE
Fix typo in GridSpace periodic default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ therefore are not "truly breaking".
 
 - New `ContinuousSpace` now only supports Euclidean metric.
 - Keyword `moore` of `GridSpace` doesn't exist anymore. Use `metric` instead.
-- Default arguments for `GridSpace` are now `periodc = false, metric = :chebyshev`.
+- Default arguments for `GridSpace` are now `periodic = true, metric = :chebyshev`.
 - Internal structure of the fundamental types like `ABM, GraphSpace`, etc. is now explicitly not part of the public API, and the provided functions like `getindex` and `getproperty` have to be used. This will allow performance updates in the future that may change internals but not lead to breaking changes.
 - `vertex2coord, coord2vertex` do not exist anymore because they are unnecessary in the new design.
 - API simplification and renaming:


### PR DESCRIPTION
See https://github.com/JuliaDynamics/Agents.jl/blob/88af0ec548ade7ec5d805b7aa7c85e49dadbb931/src/spaces/grid.jl#L26-L65 for the correct defaults.