### PR TITLE
High-order iterators and maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.1 (UNRELEASED)
 - A new example: Fractal Growth, explores `ContinuousSpace` and interactive plotting.
+- Higher-order agent grouping utilities to facilitate complex interactions.
 
 # v4.0, Major new release!
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -89,8 +89,8 @@ provide an interface for such calculation.
 
 ```@docs
 iter_agent_groups
-iter_id_groups
 map_agent_groups
+index_groups_filtered
 ```
 
 ## Discrete space exclusives

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -81,6 +81,19 @@ a = random_agent(model)
 sort!(collect(nearby_agents(a, model)))
 ```
 
+## Higher-order interactions
+
+There may be times when pair-wise, triplet-wise or higher interactions need to be
+accounted for across most or all of the model's agent population. The following methods
+provide an interface for such calculation.
+
+```@docs
+group_id_iter
+group_agent_iter
+group_id_map
+group_agent_map
+```
+
 ## Discrete space exclusives
 ```@docs
 positions

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -88,10 +88,9 @@ accounted for across most or all of the model's agent population. The following 
 provide an interface for such calculation.
 
 ```@docs
-group_id_iter
-group_agent_iter
-group_id_map
-group_agent_map
+iter_agent_groups
+iter_id_groups
+map_agent_groups
 ```
 
 ## Discrete space exclusives

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -203,63 +203,43 @@ allids(model) = keys(model.agents)
 #######################################################################################
 # %% Higher order collections
 #######################################################################################
-export group_agent_iter, group_id_iter, group_agent_map, group_id_map
+export iter_agent_groups, iter_id_groups, map_agent_groups
 
 """
-    group_id_iter(order::Int, model::ABM)
-
-Return an iterator over all agent IDs of the model, group by order. When `order = 2`, the
-iterator returns agent pairs, and when `order = 3`: agent triples.
-
-See also [`group_agent_iter`](@ref).
+    iter_id_groups(order::Int, model::ABM)
+Return an iterator over all agents of the model, grouped by order. When `order = 2`, the
+iterator returns ID pairs, e.g `(1, 2)` and when `order = 3`: ID triples, e.g.
+`(1, 7, 8)`.
 """
-group_id_iter(order::Int, model::ABM) =
+iter_id_groups(order::Int, model::ABM) =
     Iterators.product((by_id(model) for _ in 1:order)...)
 
 """
-    group_agent_iter(order::Int, model::ABM)
+    iter_agent_groups(order::Int, model::ABM)
 
-Return an iterator over all agents of the model, group by order. When `order = 2`, the
-iterator returns ID pairs, e.g `(1, 2)` and when `order = 3`: ID triples, e.g.
-`(1, 7, 8)`.
-
-See also [`group_id_iter`](@ref).
+Return an iterator over all agents of the model, grouped by order. When `order = 2`, the
+iterator returns agent pairs, e.g `(agent1, agent2)` and when `order = 3`: agent triples,
+e.g. `(agent1, agent7, agent8)`. `order` must be larger than `1` but has no upper bound.
 """
-group_agent_iter(order::Int, model::ABM) =
+iter_agent_groups(order::Int, model::ABM) =
     Iterators.product((map(i -> model[i], by_id(model)) for _ in 1:order)...)
 
 """
-    group_id_map(order::Int, f::Function, model::ABM)
-    group_id_map(order::Int, f::Function, model::ABM, filter::Function)
+    map_agent_groups(order::Int, f::Function, model::ABM)
+    map_agent_groups(order::Int, f::Function, model::ABM, filter::Function)
 
-Applies function `f` to all grouped agent IDs of a [`group_id_iter`](@ref). `f` must take
-the form `f(model, a, b)`, where the number of arguments (after `model`) is equal to
-`order`.
-Optionally, a `filter` function that accepts an iterable and returns a `Bool` can be
-applied to remove unwanted matches from the results.
-
-See also [`group_agent_map`](@ref).
-"""
-group_id_map(order::Int, f::Function, model::ABM) =
-    (f(model, idx...) for idx in group_id_iter(order, model))
-group_id_map(order::Int, f::Function, model::ABM, filter::Function) =
-    (f(model, idx...) for idx in group_id_iter(order, model) if filter(idx))
-
-"""
-    group_agent_map(order::Int, f::Function, model::ABM)
-    group_agent_map(order::Int, f::Function, model::ABM, filter::Function)
-
-Applies function `f` to all grouped agents of a [`group_agent_iter`](@ref). `f` must take
+Applies function `f` to all grouped agents of a [`iter_agent_groups`](@ref). `f` must take
 the form `f(a, b)`, where the number of arguments is equal to `order`.
-Optionally, a `filter` function that accepts an iterable and returns a `Bool` can be
-applied to remove unwanted matches from the results.
 
-See also [`group_agent_map`](@ref).
+Optionally, a `filter` function that accepts an iterable and returns a `Bool` can be
+applied to remove unwanted matches from the results. **Note:** This option cannot keep
+matrix order, so should be used in conjuction with [`iter_id_groups`](@ref) to associate
+agent ids with the resultant data.
 """
-group_agent_map(order::Int, f::Function, model::ABM) =
-    (f(idx...) for idx in group_agent_iter(order, model))
-group_agent_map(order::Int, f::Function, model::ABM, filter::Function) =
-    (f(idx...) for idx in group_agent_iter(order, model) if filter(idx))
+map_agent_groups(order::Int, f::Function, model::ABM) =
+    (f(idx...) for idx in iter_agent_groups(order, model))
+map_agent_groups(order::Int, f::Function, model::ABM, filter::Function) =
+    (f(idx...) for idx in iter_agent_groups(order, model) if filter(idx))
 
 #######################################################################################
 # %% Model construction validation

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -221,8 +221,9 @@ iter_agent_groups(order::Int, model::ABM) =
     map_agent_groups(order::Int, f::Function, model::ABM)
     map_agent_groups(order::Int, f::Function, model::ABM, filter::Function)
 
-Applies function `f` to all grouped agents of a [`iter_agent_groups`](@ref). `f` must
-take the form `f(NTuple{O,AgentType})`, where the dimension `O` is equal to `order`.
+Applies function `f` to all grouped agents of an [`iter_agent_groups`](@ref) iterator.
+`f` must take the form `f(NTuple{O,AgentType})`, where the dimension `O` is equal to
+`order`.
 
 Optionally, a `filter` function that accepts an iterable and returns a `Bool` can be
 applied to remove unwanted matches from the results. **Note:** This option cannot keep
@@ -236,7 +237,7 @@ map_agent_groups(order::Int, f::Function, model::ABM, filter::Function) =
 
 """
     index_groups_filtered(order::Int, model::ABM, filter::Function)
-Return an iterable of agents in the model meeting the criterea of `filter`. Should be
+Return an iterable of agent ids in the model meeting the criterea of `filter`. Should be
 used in conjuction with [`map_agent_groups`](@ref) when the filter option is in use.
 """
 index_groups_filtered(order::Int, model::ABM, filter::Function) =

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -211,6 +211,8 @@ export iter_agent_groups, map_agent_groups, index_groups_filtered
 Return an iterator over all agents of the model, grouped by order. When `order = 2`, the
 iterator returns agent pairs, e.g `(agent1, agent2)` and when `order = 3`: agent triples,
 e.g. `(agent1, agent7, agent8)`. `order` must be larger than `1` but has no upper bound.
+
+Index order is provided by the [`by_id`](@ref) scheduler.
 """
 iter_agent_groups(order::Int, model::ABM) =
     Iterators.product((map(i -> model[i], by_id(model)) for _ in 1:order)...)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -5,14 +5,15 @@ export ABM, AgentBasedModel
 #######################################################################################
 
 abstract type AbstractSpace end
-SpaceType=Union{Nothing, AbstractSpace}
+SpaceType = Union{Nothing,AbstractSpace}
 
 abstract type DiscreteSpace <: AbstractSpace end
 
 # This is a collection of valid position types, sometimes used for ambiguity resolution
-ValidPos = Union{Int, NTuple{N, Int}, NTuple{M, <:AbstractFloat}, Tuple{Int, Int, Float64}} where {N, M}
+ValidPos =
+    Union{Int,NTuple{N,Int},NTuple{M,<:AbstractFloat},Tuple{Int,Int,Float64}} where {N,M}
 
-struct AgentBasedModel{S<:SpaceType, A<:AbstractAgent, F, P}
+struct AgentBasedModel{S<:SpaceType,A<:AbstractAgent,F,P}
     agents::Dict{Int,A}
     space::S
     scheduler::F
@@ -22,7 +23,7 @@ end
 
 const ABM = AgentBasedModel
 
-agenttype(::ABM{S, A}) where {S, A} = A
+agenttype(::ABM{S,A}) where {S,A} = A
 spacetype(::ABM{S}) where {S} = S
 
 """
@@ -35,7 +36,6 @@ union_types(a::Type, b::Type) = (a, b)
 union_types(x::Type) = (x,)
 # For completness
 union_types(a::Type, b::Union) = (a, union_types(b)...)
-
 
 """
     AgentBasedModel(AgentType [, space]; scheduler, properties) → model
@@ -68,13 +68,16 @@ Type tests for `AgentType` are done, and by default
 warnings are thrown when appropriate. Use keyword `warn=false` to supress that.
 """
 function AgentBasedModel(
-        ::Type{A}, space::S = nothing;
-        scheduler::F = fastest, properties::P = nothing, warn = true
-        ) where {A<:AbstractAgent, S<:SpaceType, F, P}
+    ::Type{A},
+    space::S = nothing;
+    scheduler::F = fastest,
+    properties::P = nothing,
+    warn = true,
+) where {A<:AbstractAgent,S<:SpaceType,F,P}
     agent_validator(A, space, warn)
 
-    agents = Dict{Int, A}()
-    return ABM{S, A, F, P}(agents, space, scheduler, properties, Ref(0))
+    agents = Dict{Int,A}()
+    return ABM{S,A,F,P}(agents, space, scheduler, properties, Ref(0))
 end
 
 function AgentBasedModel(agent::AbstractAgent, args...; kwargs...)
@@ -103,7 +106,8 @@ Note this method will return an error if the `id` requested is not equal to `age
 **Internal method**, use [`add_agents!`](@ref) instead to actually add an agent.
 """
 function Base.setindex!(m::ABM, a::AbstractAgent, id::Int)
-    a.id ≠ id && throw(ArgumentError("You are adding an agent to an ID not equal with the agent's ID!"))
+    a.id ≠ id &&
+    throw(ArgumentError("You are adding an agent to an ID not equal with the agent's ID!"))
     m.agents[id] = a
     m.maxid[] < id && (m.maxid[] += 1)
     return a
@@ -127,7 +131,7 @@ retrieving these values can be obtained via `model.weight`.
 The property names `:agents, :space, :scheduler, :properties, :maxid` are internals
 and **should not be accessed by the user**.
 """
-function Base.getproperty(m::ABM{S, A, F, P}, s::Symbol) where {S, A, F, P}
+function Base.getproperty(m::ABM{S,A,F,P}, s::Symbol) where {S,A,F,P}
     if s === :agents
         return getfield(m, :agents)
     elseif s === :space
@@ -145,7 +149,7 @@ function Base.getproperty(m::ABM{S, A, F, P}, s::Symbol) where {S, A, F, P}
     end
 end
 
-function Base.setproperty!(m::ABM{S, A, F, P}, s::Symbol, x) where {S, A, F, P}
+function Base.setproperty!(m::ABM{S,A,F,P}, s::Symbol, x) where {S,A,F,P}
     properties = getfield(m, :properties)
     if properties ≠ nothing && haskey(properties, s)
         properties[s] = x
@@ -190,12 +194,72 @@ Return an iterator over all agents of the model.
 """
 allagents(model) = values(model.agents)
 
-
 """
     allids(model)
 Return an iterator over all agent IDs of the model.
 """
 allids(model) = keys(model.agents)
+
+#######################################################################################
+# %% Higher order collections
+#######################################################################################
+export group_agent_iter, group_id_iter, group_agent_map, group_id_map
+
+"""
+    group_id_iter(order::Int, model::ABM)
+
+Return an iterator over all agent IDs of the model, group by order. When `order = 2`, the
+iterator returns agent pairs, and when `order = 3`: agent triples.
+
+See also [`group_agent_iter`](@ref).
+"""
+group_id_iter(order::Int, model::ABM) =
+    Iterators.product((by_id(model) for _ in 1:order)...)
+
+"""
+    group_agent_iter(order::Int, model::ABM)
+
+Return an iterator over all agents of the model, group by order. When `order = 2`, the
+iterator returns ID pairs, e.g `(1, 2)` and when `order = 3`: ID triples, e.g.
+`(1, 7, 8)`.
+
+See also [`group_id_iter`](@ref).
+"""
+group_agent_iter(order::Int, model::ABM) =
+    Iterators.product((map(i -> model[i], by_id(model)) for _ in 1:order)...)
+
+"""
+    group_id_map(order::Int, f::Function, model::ABM)
+    group_id_map(order::Int, f::Function, model::ABM, filter::Function)
+
+Applies function `f` to all grouped agent IDs of a [`group_id_iter`](@ref). `f` must take
+the form `f(model, a, b)`, where the number of arguments (after `model`) is equal to
+`order`.
+Optionally, a `filter` function that accepts an iterable and returns a `Bool` can be
+applied to remove unwanted matches from the results.
+
+See also [`group_agent_map`](@ref).
+"""
+group_id_map(order::Int, f::Function, model::ABM) =
+    (f(model, idx...) for idx in group_id_iter(order, model))
+group_id_map(order::Int, f::Function, model::ABM, filter::Function) =
+    (f(model, idx...) for idx in group_id_iter(order, model) if filter(idx))
+
+"""
+    group_agent_map(order::Int, f::Function, model::ABM)
+    group_agent_map(order::Int, f::Function, model::ABM, filter::Function)
+
+Applies function `f` to all grouped agents of a [`group_agent_iter`](@ref). `f` must take
+the form `f(a, b)`, where the number of arguments is equal to `order`.
+Optionally, a `filter` function that accepts an iterable and returns a `Bool` can be
+applied to remove unwanted matches from the results.
+
+See also [`group_agent_map`](@ref).
+"""
+group_agent_map(order::Int, f::Function, model::ABM) =
+    (f(idx...) for idx in group_agent_iter(order, model))
+group_agent_map(order::Int, f::Function, model::ABM, filter::Function) =
+    (f(idx...) for idx in group_agent_iter(order, model) if filter(idx))
 
 #######################################################################################
 # %% Model construction validation
@@ -205,12 +269,17 @@ allids(model) = keys(model.agents)
 Validate the user supplied agent (subtype of `AbstractAgent`).
 Checks for mutability and existence and correct types for fields depending on `SpaceType`.
 """
-function agent_validator(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:SpaceType}
+function agent_validator(
+    ::Type{A},
+    space::S,
+    warn::Bool,
+) where {A<:AbstractAgent,S<:SpaceType}
     # Check A for required properties & fields
     if isconcretetype(A)
         do_checks(A, space, warn)
     else
-        warn && @warn "AgentType is not concrete. If your agent is parametrically typed, you're probably seeing this warning because you gave `Agent` instead of `Agent{Float64}` (for example) to this function. You can also create an instance of your agent and pass it to this function. If you want to use `Union` types for mixed agent models, you can silence this warning."
+        warn &&
+        @warn "AgentType is not concrete. If your agent is parametrically typed, you're probably seeing this warning because you gave `Agent` instead of `Agent{Float64}` (for example) to this function. You can also create an instance of your agent and pass it to this function. If you want to use `Union` types for mixed agent models, you can silence this warning."
         for type in union_types(A)
             do_checks(type, space, warn)
         end
@@ -221,26 +290,32 @@ end
     do_checks(agent, space)
 Helper function for `agent_validator`.
 """
-function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:SpaceType}
+function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent,S<:SpaceType}
     if warn
-        isbitstype(A) && @warn "AgentType should be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition."
+        isbitstype(A) &&
+        @warn "AgentType should be mutable. Try adding the `mutable` keyword infront of `struct` in your agent definition."
     end
-    (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) || throw(ArgumentError("First field of Agent struct must be `id` (it should be of type `Int`)."))
-    fieldtype(A, :id) <: Integer || throw(ArgumentError("`id` field in Agent struct must be of type `Int`."))
+    (any(isequal(:id), fieldnames(A)) && fieldnames(A)[1] == :id) ||
+    throw(ArgumentError("First field of Agent struct must be `id` (it should be of type `Int`)."))
+    fieldtype(A, :id) <: Integer ||
+    throw(ArgumentError("`id` field in Agent struct must be of type `Int`."))
     if space !== nothing
-        (any(isequal(:pos), fieldnames(A)) && fieldnames(A)[2] == :pos) || throw(ArgumentError("Second field of Agent struct must be `pos` when using a space."))
+        (any(isequal(:pos), fieldnames(A)) && fieldnames(A)[2] == :pos) ||
+        throw(ArgumentError("Second field of Agent struct must be `pos` when using a space."))
         # Check `pos` field in A has the correct type
         pos_type = fieldtype(A, :pos)
         space_type = typeof(space)
         if space_type <: GraphSpace && !(pos_type <: Integer)
             throw(ArgumentError("`pos` field in Agent struct must be of type `Int` when using GraphSpace."))
-        elseif space_type <: GridSpace && !(pos_type <: NTuple{D, Integer} where {D})
+        elseif space_type <: GridSpace && !(pos_type <: NTuple{D,Integer} where {D})
             throw(ArgumentError("`pos` field in Agent struct must be of type `NTuple{Int}` when using GridSpace."))
         elseif space_type <: ContinuousSpace || space_type <: ContinuousSpace
-            if !(pos_type <: NTuple{D, <:AbstractFloat} where {D})
+            if !(pos_type <: NTuple{D,<:AbstractFloat} where {D})
                 throw(ArgumentError("`pos` field in Agent struct must be of type `NTuple{<:AbstractFloat}` when using ContinuousSpace."))
             end
-            if warn && any(isequal(:vel), fieldnames(A)) && !(fieldtype(A, :vel) <: NTuple{D, <:AbstractFloat} where {D})
+            if warn &&
+               any(isequal(:vel), fieldnames(A)) &&
+               !(fieldtype(A, :vel) <: NTuple{D,<:AbstractFloat} where {D})
                 @warn "`vel` field in Agent struct should be of type `NTuple{<:AbstractFloat}` when using ContinuousSpace."
             end
         end
@@ -250,18 +325,18 @@ end
 #######################################################################################
 # %% Pretty printing
 #######################################################################################
-function Base.show(io::IO, abm::ABM{S, A}) where {S, A}
+function Base.show(io::IO, abm::ABM{S,A}) where {S,A}
     n = isconcretetype(A) ? nameof(A) : string(A)
     s = "AgentBasedModel with $(nagents(abm)) agents of type $(n)"
     if abm.space === nothing
-        s*= "\n no space"
+        s *= "\n no space"
     else
-        s*= "\n space: $(sprint(show, abm.space))"
+        s *= "\n space: $(sprint(show, abm.space))"
     end
-    s*= "\n scheduler: $(schedulername(abm.scheduler))"
+    s *= "\n scheduler: $(schedulername(abm.scheduler))"
     print(io, s)
     if abm.properties ≠ nothing
         print(io, "\n properties: ", abm.properties)
     end
 end
-schedulername(x::Union{Function, DataType}) = nameof(x)
+schedulername(x::Union{Function,DataType}) = nameof(x)

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -203,16 +203,7 @@ allids(model) = keys(model.agents)
 #######################################################################################
 # %% Higher order collections
 #######################################################################################
-export iter_agent_groups, iter_id_groups, map_agent_groups
-
-"""
-    iter_id_groups(order::Int, model::ABM)
-Return an iterator over all agents of the model, grouped by order. When `order = 2`, the
-iterator returns ID pairs, e.g `(1, 2)` and when `order = 3`: ID triples, e.g.
-`(1, 7, 8)`.
-"""
-iter_id_groups(order::Int, model::ABM) =
-    Iterators.product((by_id(model) for _ in 1:order)...)
+export iter_agent_groups, map_agent_groups, index_groups_filtered
 
 """
     iter_agent_groups(order::Int, model::ABM)
@@ -228,18 +219,27 @@ iter_agent_groups(order::Int, model::ABM) =
     map_agent_groups(order::Int, f::Function, model::ABM)
     map_agent_groups(order::Int, f::Function, model::ABM, filter::Function)
 
-Applies function `f` to all grouped agents of a [`iter_agent_groups`](@ref). `f` must take
-the form `f(a, b)`, where the number of arguments is equal to `order`.
+Applies function `f` to all grouped agents of a [`iter_agent_groups`](@ref). `f` must
+take the form `f(NTuple{O,AgentType})`, where the dimension `O` is equal to `order`.
 
 Optionally, a `filter` function that accepts an iterable and returns a `Bool` can be
 applied to remove unwanted matches from the results. **Note:** This option cannot keep
-matrix order, so should be used in conjuction with [`iter_id_groups`](@ref) to associate
-agent ids with the resultant data.
+matrix order, so should be used in conjuction with [`index_groups_filtered`](@ref) to
+associate agent ids with the resultant data.
 """
 map_agent_groups(order::Int, f::Function, model::ABM) =
-    (f(idx...) for idx in iter_agent_groups(order, model))
+    (f(idx) for idx in iter_agent_groups(order, model))
 map_agent_groups(order::Int, f::Function, model::ABM, filter::Function) =
-    (f(idx...) for idx in iter_agent_groups(order, model) if filter(idx))
+    (f(idx) for idx in iter_agent_groups(order, model) if filter(idx))
+
+"""
+    index_groups_filtered(order::Int, model::ABM, filter::Function)
+Return an iterable of agents in the model meeting the criterea of `filter`. Should be
+used in conjuction with [`map_agent_groups`](@ref) when the filter option is in use.
+"""
+index_groups_filtered(order::Int, model::ABM, filter::Function) =
+    Iterators.filter(filter, Iterators.product((by_id(model) for _ in 1:order)...))
+
 
 #######################################################################################
 # %% Model construction validation

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -467,3 +467,42 @@ end
         end
     end
 end
+
+@testset "Higher order groups" begin
+    model = ABM(Agent3, GridSpace((10, 10)))
+    for i in 1:10
+        add_agent!(model, i)
+    end
+
+    iter_second_ids = map(x -> (x[1].id, x[2].id), iter_agent_groups(2, model))
+    @test size(iter_second_ids) == (10, 10)
+    @test iter_second_ids[1] == (1, 1)
+    @test iter_second_ids[15] == (5, 2)
+    @test iter_second_ids[end] == (10, 10)
+
+    second = collect(map_agent_groups(2, x -> x[1].weight + x[2].weight, model))
+    @test size(second) == (10, 10)
+    @test second[1] == 2.0
+    @test second[15] == 7.0
+    @test second[end] == 20.0
+
+    third =
+        collect(map_agent_groups(3, x -> x[1].weight + x[2].weight + x[3].weight, model))
+    @test size(third) == (10, 10, 10)
+    @test third[1] == 3.0
+    @test third[15] == 8.0
+    @test third[end] == 30.0
+
+    second_filtered =
+        collect(map_agent_groups(2, x -> x[1].weight + x[2].weight, model, allunique))
+    @test size(second_filtered) == (90,)
+    @test second_filtered[1] == 3.0
+    @test second_filtered[15] == 9.0
+    @test second_filtered[end] == 19.0
+
+    idx_second_filtered = collect(index_groups_filtered(2, model, allunique))
+    @test size(idx_second_filtered) == (90,)
+    @test idx_second_filtered[1] == (2, 1)
+    @test idx_second_filtered[15] == (7, 2)
+    @test idx_second_filtered[end] == (9, 10)
+end


### PR DESCRIPTION
A start on #408. These methods handle any order you need / can fit in memory. Initially I thought it would only be required to export the map functions, but in the case of the filtered versions of the map it's not clear which ids correspond to the output.

So, in our examples for these methods, we'll need to state clearly that you can get indexes for your results in a few ways:
- No filter, you just need one row of indices: `by_id(model)`
- No filter, you want the lot: collect the `group_id_iter`. The results are correct for the agent version as well.
- Filter: use the filter to filter the `group_id_iter`. For example: `Iterators.filter(allunique, group_id_iter(2,model))`.

Feel free to suggest better names here. Still needs tests, and the examples we discussed.