### PR TITLE
Enable 1.6rc testing on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         version:
           - '1'
-        os:  [ubuntu-latest, windows-latest, macos-latest] # adjust according to need, e.g. os: [ubuntu-latest] if testing only on linux
+          - '^1.6.0-0'
+        os:  [ubuntu-latest, windows-latest, macos-latest]
         arch:
           - x64
     steps:


### PR DESCRIPTION
I think we'll have seed failures here, as we did previously in #271, where we 'solved' the issue by dropping 1.0 support. We don't have that luxury this time round. 