### PR TITLE
New intro docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Tim DuBois", "George Datseris", "Ali Vahdati"]
-version = "4.0.5"
+version = "4.0.6"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,7 @@
 # API
 
 The API of Agents.jl is defined on top of the fundamental structures  [`AgentBasedModel`](@ref), [Space](@ref Space), [`AbstractAgent`](@ref) which are described in the [Tutorial](@ref) page.
+In this page we list the remaining API functions, which constitute the bulk of Agents.jl functionality.
 
 ## `@agents` macro
 The [`@agents`](@ref) macro makes defining agent types within Agents.jl simple.
@@ -40,7 +41,7 @@ OpenStreetMapSpace
 
 ## Model-agent interaction
 The following API is mostly universal across all types of [Space](@ref Space).
-Only some specific methods are exclusive to a specific type of space.
+Only some specific methods are exclusive to a specific type of space, but these are described further below in this page.
 
 ### Adding agents
 ```@docs
@@ -63,6 +64,46 @@ genocide!
 sample!
 ```
 
+## Discrete space exclusives
+```@docs
+positions
+ids_in_position
+agents_in_position
+fill_space!
+has_empty_positions
+empty_positions
+random_empty
+add_agent_single!
+move_agent_single!
+isempty(::Integer, ::ABM)
+```
+
+## Continuous space exclusives
+```@docs
+interacting_pairs
+nearest_neighbor
+elastic_collision!
+```
+
+## OpenStreetMap space exclusives
+```@docs
+osm_latlon
+osm_intersection
+osm_road
+osm_random_road_position
+osm_plan_route
+osm_random_route!
+osm_road_length
+osm_is_stationary
+osm_map_coordinates
+```
+
+## Graph space exclusives
+```@docs
+add_edge!
+add_node!
+rem_node!
+```
 
 ## Local area
 ```@docs
@@ -121,46 +162,6 @@ map_agent_groups
 index_mapped_groups
 ```
 
-## Discrete space exclusives
-```@docs
-positions
-ids_in_position
-agents_in_position
-fill_space!
-has_empty_positions
-empty_positions
-random_empty
-add_agent_single!
-move_agent_single!
-isempty(::Integer, ::ABM)
-```
-
-## Continuous space exclusives
-```@docs
-interacting_pairs
-nearest_neighbor
-elastic_collision!
-```
-
-## OpenStreetMap space exclusives
-```@docs
-osm_latlon
-osm_intersection
-osm_road
-osm_random_road_position
-osm_plan_route
-osm_random_route!
-osm_road_length
-osm_is_stationary
-osm_map_coordinates
-```
-
-## Graph space exclusives
-```@docs
-add_edge!
-add_node!
-rem_node!
-```
 
 ## Parameter scanning
 ```@docs
@@ -170,13 +171,8 @@ paramscan
 ## Data collection
 The central simulation function is [`run!`](@ref), which is mentioned in our [Tutorial](@ref).
 But there are other functions that are related to simulations listed here.
-```@docs
-init_agent_dataframe
-collect_agent_data!
-init_model_dataframe
-collect_model_data!
-aggname
-```
+Specifically, these functions aid in making custom data collection loops, instead of using the `run!` function.
+
 For example, the core loop of `run!` is just
 ```julia
 df_agent = init_agent_dataframe(model, adata)
@@ -196,6 +192,16 @@ end
 return df_agent, df_model
 ```
 (here `until` and `should_we_collect` are internal functions)
+
+`run!` uses the following functions:
+
+```@docs
+init_agent_dataframe
+collect_agent_data!
+init_model_dataframe
+collect_model_data!
+aggname
+```
 
 ## [Schedulers](@id Schedulers)
 The schedulers of Agents.jl have a very simple interface.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,17 @@
 
 The API of Agents.jl is defined on top of the fundamental structures  [`AgentBasedModel`](@ref), [Space](@ref Space), [`AbstractAgent`](@ref) which are described in the [Tutorial](@ref) page.
 
+## `@agents` macro
+The [`@agents`](@ref) macro makes defining agent types within Agents.jl simple.
+
+```@docs
+@agent
+GraphAgent
+GridAgent
+ContinuousAgent
+OSMAgent
+```
+
 ## Agent/model retrieval
 ```@docs
 getindex(::ABM, ::Integer)
@@ -52,16 +63,6 @@ genocide!
 sample!
 ```
 
-### `@agents` macro
-The [`@agents`](@ref) macro makes defining agent types within Agents.jl simple.
-
-```@docs
-@agent
-GraphAgent
-GridAgent
-ContinuousAgent
-OSMAgent
-```
 
 ## Local area
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -12,6 +12,21 @@ allagents
 allids
 ```
 
+## Available spaces
+Here we list the spaces that are available "out of the box" from Agents.jl. To create your own, see [Creating a new space type](@ref).
+
+### Discrete spaces
+```@docs
+GraphSpace
+GridSpace
+```
+
+### Continuous spaces
+```@docs
+ContinuousSpace
+OpenStreetMapSpace
+```
+
 ## Model-agent interaction
 The following API is mostly universal across all types of [Space](@ref Space).
 Only some specific methods are exclusive to a specific type of space.
@@ -37,9 +52,21 @@ genocide!
 sample!
 ```
 
+### `@agents` macro
+The [`@agents`](@ref) macro makes defining agent types within Agents.jl simple.
+
+```@docs
+@agent
+GraphAgent
+GridAgent
+ContinuousAgent
+OSMAgent
+```
+
 ## Local area
 ```@docs
 nearby_ids
+nearby_agents
 nearby_positions
 edistance
 ```

--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -1,7 +1,9 @@
-# Agents.jl Performance and Complexity Comparison
+# ABM Framework Comparison
+Many agent-based modeling frameworks have been constructed to ease the process of building and analyzing ABMs (see [here](http://dx.doi.org/10.1016/j.cosrev.2017.03.001) for a review).
+Notable examples are [NetLogo](https://ccl.northwestern.edu/netlogo/), [Repast](https://repast.github.io/index.html), [MASON](https://journals.sagepub.com/doi/10.1177/0037549705058073), and [Mesa](https://github.com/projectmesa/mesa).
 
-Here we compare Agents.jl with three current and popular frameworks: Mesa, Netlogo and Mason, to assess where Agents.jl excels and also may need some future improvement.
-We benchmark four models which showcase as many aspects of ABM simulation as possible.
+In this page we compare Agents.jl with Mesa, Netlogo and Mason, to assess where Agents.jl excels and also may need some future improvement.
+We used the following models for the comparison:
 
 - [Model of predator prey dynamics](@ref) (Wolf Sheep Grass), a [`GridSpace`](@ref) model, which requires agents to be added, removed and moved; as well as identify properties of neighbouring positions.
 - The [Flock model](@ref) (Flocking), a [`ContinuousSpace`](@ref) model, chosen over other models to include a MASON benchmark. Agents must move in accordance with social rules over the space.
@@ -29,10 +31,10 @@ For LOC, we use the following convention: code is formatted using standard pract
 
 The results clearly speak for themselves. Across all four models, Agents.jl's performance is exceptional whilst using the least amount of code. This removes many frustrating barriers-to-entry for new users, and streamlines the development process for established ones.
 
-## An in-depth comparison of four frameworks
+## Table-based comparison
 
-In an upcoming scientific paper discussing Agents.jl, the authors compile a large list of features and metrics from the four frameworks discussed above.
-Further details will be made available once the peer review process has been completed; but for now, here is an overview of the comparison.
+In an our [paper discussing Agents.jl](https://arxiv.org/abs/2101.10072), we compiled a comparison over a large list of features and metrics from the four frameworks discussed above.
+They are shown below in a table-based format:
 
 ![Table 1](assets/table1.png)
 ![Table 1 continued](assets/table2.png)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,7 +48,7 @@ There are multiple examples that highlight this core design principle, that one 
 
 Many other agent-based modeling frameworks have been constructed to ease the process of building and analyzing ABMs (see e.g. [here](http://dx.doi.org/10.1016/j.cosrev.2017.03.001) for an outdated review), spanning a varying degree of complexity.
 In the page [ABM Framework Comparison](@REF) we compare how our design philosophy puts us into comparison with other well accepted ABM software.
-Fascinatingly, even though the main focus of Agents.jl is simplicity and ease of use, it outperforms all software we compared it with.
+**Fascinatingly, even though the main focus of Agents.jl is simplicity and ease of use, it outperforms all software we compared it with.**
 
 ## Crash course on agent based modeling
 An agent-based (or individual-based) model is a computational simulation of autonomous agents that react to their environment (including other agents) given a predefined set of rules [[1](http://doi.org/10.1016/j.ecolmodel.2006.04.023)].

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,7 +47,7 @@ Agents.jl was designed with the following philosophy in mind:
 There are multiple examples that highlight this core design principle, that one will quickly encounter when scanning through our [API](@ref) page. Here we just give two quick examples: first, there exists a universal function [`nearby_agents`](@ref), which returns the agents nearby a given agent and within a given "radius". What is special for this function, which is allowed by Julia's Multiple Dispatch, is that `nearby_agents` will work for any space type the model has, reducing the learning curve of finding neighbors in ABMs made with Agents.jl. An even better example is perhaps our treatment of spaces. A user may create an entirely new kind of space (e.g. one representing a planet, or whatever else) by only extending 5 functions, as discussed in our [Creating a new space type](@ref) documentation.
 
 Many other agent-based modeling frameworks have been constructed to ease the process of building and analyzing ABMs (see e.g. [here](http://dx.doi.org/10.1016/j.cosrev.2017.03.001) for an outdated review), spanning a varying degree of complexity.
-In the page [ABM Framework Comparison](@REF) we compare how our design philosophy puts us into comparison with other well accepted ABM software.
+In the page [ABM Framework Comparison](@ref) we compare how our design philosophy puts us into comparison with other well accepted ABM software.
 **Fascinatingly, even though the main focus of Agents.jl is simplicity and ease of use, it outperforms all software we compared it with.**
 
 ## Crash course on agent based modeling

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,8 +8,8 @@ To get started, please read the [Tutorial](@ref) page.
     Welcome to Agents.jl v4.0! This new release features improved `GridSpace` and `ContinuousSpace` (re-written from scratch), overall performance improvements of Agents.jl of a full order of magnitude (and sometimes more) and re-naming many API functions to make sense (deprecations have been put in place). Have a look at the [CHANGELOG](https://github.com/JuliaDynamics/Agents.jl/blob/master/CHANGELOG.md) for more details!
 
 ## Features
-
-* Intuitive and simple-to-learn software for agent based models.
+* Free, open source and extremely transparent.
+* Intuitive and simple-to-learn.
 * Universal model structure where agents are identified by a unique id: [`AgentBasedModel`](@ref)
 * Powerful, feature-full and extendable [API](@ref).
 * Modular, function-based design.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 ![Agents.jl](https://github.com/JuliaDynamics/JuliaDynamics/blob/master/videos/agents/agents3_logo.gif?raw=true)
 
-Agents.jl is a [Julia](https://julialang.org/) framework for agent-based modeling (ABM).
+Agents.jl is a pure [Julia](https://julialang.org/) framework for agent-based modeling (ABM).
 Agents.jl is part of [JuliaDynamics](https://juliadynamics.github.io/JuliaDynamics/).
 To get started, please read the [Tutorial](@ref) page.
 
@@ -32,8 +32,22 @@ To get started, please read the [Tutorial](@ref) page.
 The package is in Julia's package list. Install it using this command:
 
 ```
-]add Agents
+using Pkg; Pkg.add("Agents")
 ```
+
+## Design philosophy of Agents.jl
+Agents.jl was designed with the following philosophy in mind:
+
+**Simple to learn and use and extremely extendable, focusing on fast, yet scalable, model creation and evolution.**
+
+(it should be said nevertheless, that when we have to make a choice between a simpler API or a more performant implementation, we tend to lean in favor of simplicity)
+
+There are multiple examples that highligh this core design principle, that one will quickly encounter when scanning through our [API](@ref) page. Here we just give two quick examples: first, there exists a universal function [`nearby_agents`](@ref), which returns returns the agents nearby a given agent and within a given "radius". What is special for this function, which is allowed by Julia's Multiple Dispatch, is that `nearby_agents` will work for any space type the model has, reducing tremendously the learning curve of finding neighbors in ABMs made with Agents.jl. An even better example is perhaps our treatment of spaces. A user 
+
+Many agent-based modeling frameworks have been constructed to ease the process of building and analyzing ABMs (see e.g. [here](http://dx.doi.org/10.1016/j.cosrev.2017.03.001) for an outdated review), spanning a varying degree of complexity.
+In the page [TODO ADD CORRECT LINK HERE](@REF) we compare how our design philosophy puts us into comparison with other well accepted ABM software.
+
+We believe that (almost) everything imaginable in ABMs is possible with Agents.jl, whether already part of the existing [API](@ref), or from a user direct implementation.
 
 ## Comparison with existing software
 
@@ -58,7 +72,7 @@ ABMs have been adopted and studied in a variety of research disciplines.
 One reason for their popularity is that they enable a relaxation of many simplifying assumptions usually made by mathematical models.
 Relaxing such assumptions of a "perfect world" can change a model's behavior [[2](http://doi.org/10.1038/460685a)].
 
-Agent-based models are increasingly recognized as *the* approach for studying complex systems [[3](https://link.springer.com/chapter/10.1007/3-7908-1721-X_7),[4](http://www.doi.org/10.1162/106454602753694765),[5](http://www.nature.com/articles/460685a),[6](http://www.doi.org/10.1016/j.jaa.2016.01.009)].
+Agent-based models are increasingly recognized as a useful approach for studying complex systems [[3](https://link.springer.com/chapter/10.1007/3-7908-1721-X_7),[4](http://www.doi.org/10.1162/106454602753694765),[5](http://www.nature.com/articles/460685a),[6](http://www.doi.org/10.1016/j.jaa.2016.01.009)].
 Complex systems cannot be fully understood using traditional mathematical tools which aggregate the behavior of elements in a system.
 The behavior of a complex system depends on both the behavior of and interactions between its elements (agents).
 Small changes in the input to complex systems or the behavior of its agents can lead to large changes in outcome.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,8 +9,10 @@ To get started, please read the [Tutorial](@ref) page.
 
 ## Features
 
-* Intuitive, small, yet powerful and simple-to-learn API for agent based models.
+* Intuitive and simple-to-learn software for agent based models.
 * Universal model structure where agents are identified by a unique id: [`AgentBasedModel`](@ref)
+* Powerful, feature-full and extendable [API](@ref).
+* Modular, function-based design.
 * Support for many types of space: arbitrary graphs, regular grids, continuous space, or even instances of Open Street Map.
 - Multi-agent support, for interactions between disparate agent species.
 * Scheduler interface (with default schedulers), making it easy to activate agents in a specific order (e.g. by the value of some property)
@@ -38,33 +40,15 @@ using Pkg; Pkg.add("Agents")
 ## Design philosophy of Agents.jl
 Agents.jl was designed with the following philosophy in mind:
 
-**Simple to learn and use and extremely extendable, focusing on fast, yet scalable, model creation and evolution.**
+**Simple to learn and use, yet extendable, focusing on fast and scalable model creation and evolution.**
 
 (it should be said nevertheless, that when we have to make a choice between a simpler API or a more performant implementation, we tend to lean in favor of simplicity)
 
-There are multiple examples that highligh this core design principle, that one will quickly encounter when scanning through our [API](@ref) page. Here we just give two quick examples: first, there exists a universal function [`nearby_agents`](@ref), which returns returns the agents nearby a given agent and within a given "radius". What is special for this function, which is allowed by Julia's Multiple Dispatch, is that `nearby_agents` will work for any space type the model has, reducing tremendously the learning curve of finding neighbors in ABMs made with Agents.jl. An even better example is perhaps our treatment of spaces. A user 
+There are multiple examples that highlight this core design principle, that one will quickly encounter when scanning through our [API](@ref) page. Here we just give two quick examples: first, there exists a universal function [`nearby_agents`](@ref), which returns the agents nearby a given agent and within a given "radius". What is special for this function, which is allowed by Julia's Multiple Dispatch, is that `nearby_agents` will work for any space type the model has, reducing the learning curve of finding neighbors in ABMs made with Agents.jl. An even better example is perhaps our treatment of spaces. A user may create an entirely new kind of space (e.g. one representing a planet, or whatever else) by only extending 5 functions, as discussed in our [Creating a new space type](@ref) documentation.
 
-Many agent-based modeling frameworks have been constructed to ease the process of building and analyzing ABMs (see e.g. [here](http://dx.doi.org/10.1016/j.cosrev.2017.03.001) for an outdated review), spanning a varying degree of complexity.
-In the page [TODO ADD CORRECT LINK HERE](@REF) we compare how our design philosophy puts us into comparison with other well accepted ABM software.
-
-We believe that (almost) everything imaginable in ABMs is possible with Agents.jl, whether already part of the existing [API](@ref), or from a user direct implementation.
-
-## Comparison with existing software
-
-Many agent-based modeling frameworks have been constructed to ease the process of building and analyzing ABMs (see [here](http://dx.doi.org/10.1016/j.cosrev.2017.03.001) for a review).
-Notable examples are [NetLogo](https://ccl.northwestern.edu/netlogo/), [Repast](https://repast.github.io/index.html), [MASON](https://journals.sagepub.com/doi/10.1177/0037549705058073), and [Mesa](https://github.com/projectmesa/mesa).
-
-Implementing an ABM framework in Julia has several advantages:
-1. Using a general purpose programming language instead of a custom scripting language, such as NetLogo's, removes a learning step and provides a single environment for building the models and analyzing their results.
-2. Julia has a rich ecosystem for data analysis and visualization, implemented and maintained independently from Agents.jl.
-3. Julia is easier-to-use than Java (used for Repast and MASON), and provides a REPL (Read-Eval-Print-Loop) environment to build and analyze models interactively.
-4. Unlike Python (used for Mesa), Julia is fast to run. This is a crucial criterion for models that require considerable computations.
-5. Because the direct output of Agents.jl is a `DataFrame`, it makes it easy to use tools such as DataVoyager.jl, which provide an [interactive environment](https://github.com/vega/voyager) to build custom plots from `DataFrame`s. (and of course the `DataFrame` itself is a tabular data format similar to Python's Pandas).
-
-Agents.jl is lightweight and modular.
-It has a short learning curve, and allows one to extend its capabilities and express complicated modeling scenarios.
-Agents.jl was originally inspired by the [Mesa](https://github.com/projectmesa/mesa) framework for Python, but has since then departed in design, leading to a dramatically simpler and cleaner API, besides having obvious performance benefits (more than 30 times better performance than Mesa in some cases, see our [Agents.jl Performance and Complexity Comparison](@ref)).
-
+Many other agent-based modeling frameworks have been constructed to ease the process of building and analyzing ABMs (see e.g. [here](http://dx.doi.org/10.1016/j.cosrev.2017.03.001) for an outdated review), spanning a varying degree of complexity.
+In the page [ABM Framework Comparison](@REF) we compare how our design philosophy puts us into comparison with other well accepted ABM software.
+Fascinatingly, even though the main focus of Agents.jl is simplicity and ease of use, it outperforms all software we compared it with.
 
 ## Crash course on agent based modeling
 An agent-based (or individual-based) model is a computational simulation of autonomous agents that react to their environment (including other agents) given a predefined set of rules [[1](http://doi.org/10.1016/j.ecolmodel.2006.04.023)].
@@ -94,7 +78,7 @@ If you use this package in work that leads to a publication, then please cite th
 
 ```
 @misc{Agents.jl,
-      title={Agents.jl: A performant and feature-full agent based modelling software of minimal code complexity}, 
+      title={Agents.jl: A performant and feature-full agent based modelling software of minimal code complexity},
       author={George Datseris and Ali R. Vahdati and Timothy C. DuBois},
       year={2021},
       eprint={2101.10072},

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -1,0 +1,4 @@
+# Performance Tips
+Agents.jl is a fast software, and the fastest of the ones we have compared it with, see [Comparison with other ABM software](@ref). Nevertheless, there are various points in the library where we have favored simplicity and ease of use over performance.
+
+Sometimes however, it is absolutely critical to make some code as performant as Julia allows it t

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -1,4 +1,2 @@
 # Performance Tips
 Agents.jl is a fast software, and the fastest of the ones we have compared it with, see [Comparison with other ABM software](@ref). Nevertheless, there are various points in the library where we have favored simplicity and ease of use over performance.
-
-Sometimes however, it is absolutely critical to make some code as performant as Julia allows it t

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -26,29 +26,21 @@ Agents.jl offers several possibilities for the space the agents live in.
 In addition, it is straightforward to implement a fundamentally new type of space, see [Developer Docs](@ref).
 
 Spaces are separated into disrete spaces (which by definition have a **finite** amount of **possible positions**) and continuous spaces.
-Thus, it is common for a specific position to contain several agents.
+In discrete spaces it is common for a specific position to contain several agents.
 
-### Discrete spaces
-```@docs
-GraphSpace
-GridSpace
-```
+The available spaces are:
 
-### Continuous spaces
-```@docs
-ContinuousSpace
-OpenStreetMapSpace
-```
+- [`GraphSpace`](@ref)
+- [`GridSpace`](@ref)
+- [`ContinuousSpace`](@ref)
+- [`OpenStreetMapSpace`](@ref)
+
+One simply initializes an instance of a space, e.g. with `grid = GridSpace((10, 10))` and passes that into [`AgentBasedModel`](@ref).
 
 ## 3. The agent
 
 ```@docs
 AbstractAgent
-@agent
-GraphAgent
-GridAgent
-ContinuousAgent
-OSMAgent
 ```
 
 Once an Agent is created it can be added to a model using e.g. [`add_agent!`](@ref).

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,43 +1,15 @@
 # Tutorial
 
-Agents.jl is composed of components for building models, building and managing space structures, collecting data, running batch simulations, and data visualization.
+Agents.jl structures ABM simulations following the following simple mental model:
 
-Agents.jl structures simulations in three components:
+1. First, the user needs to define the agent type (or types, for mixed models) that will populate the ABM. This is defined as a standard Julia Type.
+2. Then, the user needs to choose in what kind of space these agents will live in, for example a graph, a grid, etc. Several spaces are provided by Agents.jl and can be initialized immediately.
+3. The created agent type, the chosen space, additional model level properties (typically in the form of a dictionary), and a scheduler (a standard Julia function, with several default ones available), are provided in our universal structure [`AgentBasedModel`](@ref). This instance defines the model within an Agents.jl simulation.
+4. Simulations in Agents.jl happen in discrete and individual steps. To evolve the model in time the user needs to define one, or two, stepping functions that control how the agents and the model should evolve. These are standard Julia functions that take advantage of the Agents.jl [API](@ref).
+5. To collect data during time evolution, the user needs to specify which data should be collected, by providing one standard Julia `Vector` of data-to-collect for agents, and another one for the model. The outputted data are in the form of a `DataFrame`.
 
-1. An [`AgentBasedModel`](@ref) instance.
-1. A [space](@ref Space) instance.
-1. A subtype of [`AbstractAgent`](@ref) for the agents.
 
-To run simulations and collect data, the following are also necessary
-
-4. Stepping functions that controls how the agents and the model evolve.
-5. Specifying which data should be collected from the agents and/or the model.
-
-So, in order to set up and run an ABM simulation with Agents.jl, you typically need to define a structure, function, or parameter collection for steps 1-3, define the rules of the agent evolution for step 4, and then declare which parameters of the model and the agents should be collected as data during step 5.
-
-## 1. The model
-
-```@docs
-AgentBasedModel
-```
-
-## [2. The space](@id Space)
-Agents.jl offers several possibilities for the space the agents live in.
-In addition, it is straightforward to implement a fundamentally new type of space, see [Developer Docs](@ref).
-
-Spaces are separated into disrete spaces (which by definition have a **finite** amount of **possible positions**) and continuous spaces.
-In discrete spaces it is common for a specific position to contain several agents.
-
-The available spaces are:
-
-- [`GraphSpace`](@ref)
-- [`GridSpace`](@ref)
-- [`ContinuousSpace`](@ref)
-- [`OpenStreetMapSpace`](@ref)
-
-One simply initializes an instance of a space, e.g. with `grid = GridSpace((10, 10))` and passes that into [`AgentBasedModel`](@ref).
-
-## 3. The agent
+## 1. The agent type
 
 ```@docs
 AbstractAgent
@@ -49,6 +21,27 @@ e.g. [`move_agent!`](@ref) or [`kill_agent!`](@ref).
 
 For more functions visit the [API](@ref) page.
 
+## [2. The space](@id Space)
+Agents.jl offers several possibilities for the space the agents live in.
+In addition, it is straightforward to implement a fundamentally new type of space, see [Developer Docs](@ref).
+
+The available spaces are:
+
+- [`GraphSpace`](@ref): Agent positions are equivalent with nodes of a graph/network.
+- [`GridSpace`](@ref): Space is discretized into boxes, typical style for cellular automata.
+- [`ContinuousSpace`](@ref): Truthful representation of continuous space, regarding location, orientation, and identification of neighboring agents.
+- [`OpenStreetMapSpace`](@ref): A space based on Open Street Map, where agents are confined to move along streets of the map, using real-world meter values for the length of each street.
+
+One simply initializes an instance of a space, e.g. with `grid = GridSpace((10, 10))` and passes that into [`AgentBasedModel`](@ref). See each individual space for all its possible arguments.
+
+
+## 3. The model
+
+```@docs
+AgentBasedModel
+```
+
+
 ## 4. Evolving the model
 
 Any ABM model should have at least one and at most two step functions.
@@ -59,7 +52,7 @@ Sometimes we also need a function that changes all agents at once, or changes a 
 An agent step function should only accept two arguments: first, an agent object, and second, a model object.
 
 The model step function should accept only one argument, that is the model object.
-To use only a model step function, users can use the built-in [`dummystep`](@ref) as the agent step function.
+To use only a model step function, users can use the built-in [`dummystep`](@ref) as the agent step function. This is typically the case for [Advanced stepping](@ref).
 
 After you have defined these two functions, you evolve your model with `step!`:
 ```@docs
@@ -82,7 +75,9 @@ Most of the examples in our documentation can be expressed using an independent 
 
 On the other hand, more advanced models require special handling for scheduling, or may need to schedule several times and act on different subsets of agents with different functions.
 In such a scenario, it is more sensible to provide only a `model_step!` function (and use `dummystep` as `agent_step!`), where all configuration is contained within.
-For example
+Notice that if you follow this road, the argument `scheduler` given to [`AgentBasedModel`](@ref) somewhat loses its meaning.
+
+Here is an example:
 ```julia
 function complex_step!(model)
     for a in scheduler1(model)
@@ -98,7 +93,7 @@ end
 step!(model, dummystep, complex_step!, n)
 ```
 
-For defining your own scheduler, see [Schedulers](@ref).
+For defining your own schedulers, see [Schedulers](@ref).
 
 ## 5. Collecting data
 Running the model and collecting data while the model runs is done with the [`run!`](@ref) function. Besides `run!`, there is also the [`paramscan`](@ref) function that performs data collection, while scanning ranges of the parameters of the model.
@@ -131,8 +126,4 @@ run!(model, agent_step!, model_step!, 10; mdata = assets(model))
 
 ## An educative example
 A simple, education-oriented example of using the basic Agents.jl API is given in [Schelling's segregation model](@ref), also discussing in detail how to visualize your ABMs.
-
-Each of the examples listed within this documentation are designed to showcase different ways of interacting with the API.
-If you are not sure about how to use a particular function, most likely one of the examples can show you how to interact with it.
-
 For a quick reference concerning the main concepts of agent based modelling, and how the Agents.jl examples implement each one, take a look at the [Overview of Examples](@ref) page.

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -7,7 +7,7 @@ Your agent type **must have** the `id` field as first field.
 Depending on the space structure there might be a `pos` field of appropriate type
 and a `vel` field of appropriate type.
 Each space structure quantifies precicely what extra fields (if any) are necessary,
-however we recommend to use the [`@agent`] macro to help you create the agent type.
+however we recommend to use the [`@agent`](@ref) macro to help you create the agent type.
 
 Your agent type may have other additional fields relevant to your system,
 for example variable quantities like "status" or other "counters".

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -1,9 +1,12 @@
 export AbstractAgent, @agent, GraphAgent, GridAgent, ContinuousAgent, OSMAgent
 
 """
-    AbstractAgent
-All agents must be a mutable subtype of `AbstractAgent`.
-Your agent type **must have** the `id` field as first field.
+    YourAgentType <: AbstractAgent
+Agents participating in Agents.jl simulations are instances of user-defined Types that
+are subtypes of `AbstractAgent`. It is almost always the case that mutable Types make
+for a simpler modellign experience.
+
+Your agent type(s) **must have** the `id` field as first field.
 Depending on the space structure there might be a `pos` field of appropriate type
 and a `vel` field of appropriate type.
 Each space structure quantifies precicely what extra fields (if any) are necessary,
@@ -12,7 +15,6 @@ however we recommend to use the [`@agent`](@ref) macro to help you create the ag
 Your agent type may have other additional fields relevant to your system,
 for example variable quantities like "status" or other "counters".
 
-## Examples
 As an example, a [`GraphSpace`](@ref) requires an `id::Int` field and a `pos::Int` field.
 To make an agent with two additional properties, `weight, happy`, we'd write
 ```julia

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -41,13 +41,12 @@ union_types(a::Type, b::Union) = (a, union_types(b)...)
     AgentBasedModel(AgentType [, space]; scheduler, properties) → model
 Create an agent based model from the given agent type and `space`.
 You can provide an agent _instance_ instead of type, and the type will be deduced.
- `ABM` is equivalent with `AgentBasedModel`.
+`ABM` is equivalent with `AgentBasedModel`.
 
 The agents are stored in a dictionary that maps unique ids (integers)
 to agents. Use `model[id]` to get the agent with the given `id`.
 
-`space` is a subtype of `AbstractSpace`: [`GraphSpace`](@ref), [`GridSpace`](@ref) or
-[`ContinuousSpace`](@ref).
+`space` is a subtype of `AbstractSpace`, see [Space](@ref Space) for all available spaces.
 If it is ommited then all agents are virtually in one position and have no spatial structure.
 
 **Note:** Spaces are mutable objects and are not designed to be shared between models.
@@ -63,6 +62,8 @@ which are the fields of `AgentBasedModel`.
 
 `scheduler = fastest` decides the order with which agents are activated
 (see e.g. [`by_id`](@ref) and the scheduler API).
+`scheduler` is only meaningful if an agent-stepping function is defined for [`step!`](@ref)
+or [`run!`](@ref).
 
 Type tests for `AgentType` are done, and by default
 warnings are thrown when appropriate. Use keyword `warn=false` to supress that.


### PR DESCRIPTION
This is an attempt to make the documentation of Agents.jl more welcoming to new users. 

- Remove comparison from homepage
- Add some words about the design of agents in homepage
- Declutter tutorial by removing non-crucial information. (obviously the spaces are crucial information however listing there the docs of all spaces takes a lot of space, and is not necessary at the moment)