### PR TITLE
fixed bug in src/spaces/openstreetmap.jl's function 'travel'

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Tim DuBois", "George Datseris", "Ali Vahdati"]
-version = "4.1.0"
+version = "4.1.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -444,6 +444,7 @@ function travel!(start, finish, distance, agent, model)
             )
         else
             #######################################
+            # TODO: The code here can be simplified by using the existing `park`.
             # alright, so here we're in a situation where the agent is imagined to be at 'start' with 'distance left to travel.
             # the route is empty, but (start,finish) does not equal agent.destination[1:2]
             # what follows is the srouce code of the function "park", but the 'virtual' agent in it has position

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -443,7 +443,35 @@ function travel!(start, finish, distance, agent, model)
                 model,
             )
         else
-            return (finish, finish, 0.0)
+            #######################################
+            # alright, so here we're in a situation where the agent is imagined to be at 'start' with 'distance left to travel.
+            # the route is empty, but (start,finish) does not equal agent.destination[1:2]
+            # what follows is the srouce code of the function "park", but the 'virtual' agent in it has position
+            # pos=(start,finish,distance-edge_distance)
+            # so I replaced that and nothing else.
+            distance-=edge_distance
+            if finish != agent.destination[1]
+                # At the end of the route, we must travel
+                last_distance = osm_road_length(finish, agent.destination[1], model)
+                if distance >= last_distance + agent.destination[3]
+                    # We reach the destination
+                    return agent.destination
+                elseif distance >= last_distance
+                    # We reach the final road, but not the destination
+                    return (agent.destination[1:2]..., distance - last_distance)
+                else
+                    # We travel the final leg
+                    return (finish, agent.destination[1], distance)
+                end
+            else
+                # Reached final road
+                if distance >= agent.destination[3]
+                    return agent.destination
+                else
+                    return (agent.destination[1:2]..., distance)
+                end
+            end
+            #######################################
         end
     else
         return (start, finish, distance)

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -87,7 +87,7 @@
     start = random_position(model)
     finish = osm_random_road_position(model)
     route = osm_plan_route(start, finish, model)
-    long = add_agent!(start, model, route, finish, false)
+    long = add_agent!(start, model, route, finish)
     move_agent!(long, model, 10^5)
     @test long.pos == long.destination
 end

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -82,19 +82,12 @@
 
     @test sort!(nearby_ids(model[6], model, 2)) == [4, 5, 7, 8]
     @test sort!(nearby_ids(model[6], model, 800.0)) == [3, 4, 5, 7, 8]
-    
-    
-    
-    @agent Zombie OSMAgent begin
-        infected::Bool
-    end
-    model = ABM(Zombie, OpenStreetMapSpace(TEST_MAP))
+
+    # Test long moves
     start = random_position(model)
     finish = osm_random_road_position(model)
     route = osm_plan_route(start, finish, model)
-    add_agent!(start, model, route, finish, false)
-    expected_pos=model[1].destination
-    move_agent!(model[1],model,10^5)
-    @test model[1].pos == expected_pos
-    
+    long = add_agent!(start, model, route, finish, false)
+    move_agent!(long, model, 10^5)
+    @test long.pos == long.destination
 end

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -82,5 +82,19 @@
 
     @test sort!(nearby_ids(model[6], model, 2)) == [4, 5, 7, 8]
     @test sort!(nearby_ids(model[6], model, 800.0)) == [3, 4, 5, 7, 8]
+    
+    
+    
+    @agent Zombie OSMAgent begin
+        infected::Bool
+    end
+    model = ABM(Zombie, OpenStreetMapSpace(TEST_MAP))
+    start = random_position(model)
+    finish = osm_random_road_position(model)
+    route = osm_plan_route(start, finish, model)
+    add_agent!(start, model, route, finish, false)
+    expected_pos=model[1].destination
+    move_agent!(model[1],model,10^5)
+    @test model[1].pos == expected_pos
+    
 end
-


### PR DESCRIPTION
This closes #427

Starting from the master branch, I've updated the function "travel!" in src/spaces/openstreetmap.jl:
Only the commented part is new, and it is essentially a copy+pasted version of the "park!" function (same file).