### PR TITLE
Fix typo in utilities.jl

### DIFF
--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -99,7 +99,7 @@ The dimensionality of `direction` must be the same as the space. `GridSpace` ask
 `Int`, and `ContinuousSpace` for `Float64` vectors, describing the walk distance in
 each direction. `direction = (2, -3)` is an example of a valid direction on a
 `GridSpace`, which moves the agent to the right 2 positions and down 3 positions.
-Velocity is ignored for this opreation in `ContinuousSpace`.
+Velocity is ignored for this operation in `ContinuousSpace`.
 
 ## Keywords
 - `ifempty` will check that the target position is unnocupied and only move if that's true. Available only on `GridSpace`.


### PR DESCRIPTION
Fixed typo "opreation" --> "operation" in line 102