### PR TITLE
Model property type checking in `init_model_dataframe`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Tim DuBois", "George Datseris", "Ali Vahdati"]
-version = "4.2.4"
+version = "4.2.5"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -404,7 +404,13 @@ function init_model_dataframe(model::ABM, properties::Vector)
     for (i,k) in enumerate(properties)
         types[i+1] =
             if typeof(k) <: Symbol
-                typeof(model.properties[k])[]
+                current_props = model.properties
+                # How the properties are accessed depends on the type
+                if typeof(current_props) <: Dict || typeof(current_props) <: Tuple
+                    typeof(current_props[k])[]
+                else
+                    typeof(getfield(current_props, k))[]
+                end
             else
                 current_type = typeof(k(model))
                 isconcretetype(current_type) || warn("Type is not concrete when using $(k)"*

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -408,6 +408,24 @@
         @test size(agent_data) == (0, 2)
         @test size(model_data) == (2, 5)
     end
+
+    @testset "init_model_dataframe issue #494 fix" begin
+        # Ensure that model_init_dataframe works when properties are specified as a struct.
+        struct Props
+            a::Float64
+            b::Bool
+        end
+
+        model = ABM(
+            Agent3,
+            GridSpace((10, 10));
+            properties=Props(1, false),
+        )
+        mdata = [:a, :b]
+
+        model_data = init_model_dataframe(model, mdata)
+        @test eltype.(eachcol(model_data)) == [Int, Float64, Bool]
+    end
 end
 
 @testset "Parameter scan" begin


### PR DESCRIPTION
Very minor fix to #494 by adding type checking of `model.property`. New to Julia so let me know if I missed anything obvious.