### PR TITLE
Continuous Space Pathfinding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - pathfinding_rework
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - master
-      - pathfinding_rework
   push:
     branches:
       - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## New features and fixes
 - Provide a generator function to collect `mdata` in `run!` and `ensemblerun!`.
 - Save/load entire models using `save_checkpoint` and `load_checkpoint`
+- New functions `get_spatial_property` and `get_spatial_index` that allows better handling of spatial fields present in `ContinuousSpace` that are represented via the forms of discretization over the space.
 
 # v4.3
 ## New features and fixes

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -52,6 +52,7 @@ random_position
 ```@docs
 move_agent!
 walk!
+get_direction
 ```
 
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -87,6 +87,7 @@ isempty(::Integer, ::ABM)
 
 ## Continuous space exclusives
 ```@docs
+get_spatial_property
 interacting_pairs
 nearest_neighbor
 elastic_collision!

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -275,6 +275,7 @@ Pathfinding.set_target!
 Pathfinding.set_best_target!
 Pathfinding.penaltymap
 Pathfinding.nearby_walkable
+Pathfinding.random_walkable
 ```
 
 ### Metrics

--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -14,7 +14,7 @@ The results are characterised in two ways: how long it took each model to perfor
 
 Time taken is presented in normalised units, measured against the runtime of Agents.jl. In other words: the results do not depend on any computers specific hardware. If one wishes to repeat the results personally by using the scripts in the [ABM_Framework_Comparisons](https://github.com/JuliaDynamics/ABM_Framework_Comparisons) repository: they will compute the same results. For details on the parameters used for each comparison, see the `benchmark.jl` file in that repository.
 
-For LOC, we use the following convention: code is formatted using standard practices & linting for the associated language. Documentation strings and in-line comments (residing on lines of their own) are discarded, as well as any benchmark infrastructure. NetLogo is assigned two values since its files have a code base section and an encoding of the GUI. Since many parameters live in the GUI, we must take this into account. Thus `375 (785)` in a NetLogo count means 375 lines in the code section, 785 lines total in the file.
+For LOC, we use the following convention: code is formatted using standard practices & linting for the associated language. Documentation strings and in-line comments (residing on lines of their own) are discarded, as well as any benchmark infrastructure. NetLogo is assigned two values since its files have a code base section and an encoding of the GUI. Since many parameters live in the GUI, we must take this into account. Thus `375 (785)` in a NetLogo count means 375 lines in the code section, 785 lines total in the file. An additional complication to this value in NetLogo is that it stores plotting information (colours, shapes, sizes) as agent properties, and as such the number outside of the bracket may be slightly inflated.
 
 | Model/Framework | Agents 4.2 | Mesa 0.8| Netlogo 6.2 | MASON 20.0 |
 |---|---|---|---|---|
@@ -25,7 +25,7 @@ For LOC, we use the following convention: code is formatted using standard pract
 |Forest Fire|1|125.6x|53.0x|NA|
 |(LOC)|23|35|43 (545)|.|
 |Schelling|1|29.4x|8.0x|14.3x|
-|(LOC)|31|56|68 (732)|248|
+|(LOC)|31|56|60 (743)|248|
 
 ᕯ Netlogo has a different implementation to the other three frameworks here. It cheats a little by only choosing one nearest neighbor in some cases rather than considering all neighbors within vision. So a true comparison would ultimately see a slower result.
 
@@ -33,7 +33,7 @@ The results clearly speak for themselves. Across all four models, Agents.jl's pe
 
 ## Table-based comparison
 
-In an our [paper discussing Agents.jl](https://arxiv.org/abs/2101.10072), we compiled a comparison over a large list of features and metrics from the four frameworks discussed above.
+In our [paper discussing Agents.jl](https://arxiv.org/abs/2101.10072), we compiled a comparison over a large list of features and metrics from the four frameworks discussed above.
 They are shown below in a table-based format:
 
 ![Table 1](assets/table1.png)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,7 +65,7 @@ Complex systems cannot be fully understood using traditional mathematical tools 
 The behavior of a complex system depends on both the behavior of and interactions between its elements (agents).
 Small changes in the input to complex systems or the behavior of its agents can lead to large changes in outcome.
 That is to say, a complex system's behavior is nonlinear, and that it is not only the sum of the behavior of its elements.
-Use of ABMs have become feasible after the availability of computers and has been growing ever since, especially in modeling biological and economical systems, and has extended to social studies and archaeology.
+Use of ABMs have become feasible after the availability of computers and has been growing ever since, especially in modeling biological and economic systems, and has extended to social studies and archaeology.
 
 An ABM consists of autonomous agents that behave given a set of rules.
 A classic example of an ABM is [Schelling's segregation model](https://www.tandfonline.com/doi/abs/10.1080/0022250X.1971.9989794), which we implement as an example here.

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -1,7 +1,6 @@
 module Agents
 
 using Requires
-using Scratch
 using Distributed
 using DataStructures
 using LightGraphs
@@ -37,48 +36,35 @@ include("simulations/ensemblerun.jl")
 include("submodules/pathfinding/all_pathfinders.jl")
 include("submodules/schedulers.jl")
 include("submodules/io/AgentsIO.jl")
-
-function __init__()
-    # Plot recipes
-    @require Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
-        include("visualization/plot-recipes.jl")
-    end
-    # Workaround for Documenter.jl, so we don't need to include
-    # heavy dependencies to build documentation
-    @require Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4" begin
-        include("visualization/plot-recipes.jl")
-    end
-    # Update message:
-    display_update = true
-    version_number = "4.4"
-    update_name = "update_v$(version_number)"
-    
-    if display_update
-        # Get scratch space for this package
-        versions_dir = @get_scratch!("versions")
-        if !isfile(joinpath(versions_dir, update_name))
-            printstyled(
-                stdout,
-                """
-                \nUpdate message: Agents v$(version_number)
-                Please see the changelog online. Some key features:
-    
-                * Agent data can be loaded from and saved to CSV files using `populate_from_csv!` and `dump_to_csv`
-                * Support for saving and loading entire models using `save_checkpoint` and `load_checkpoint`
-                """;
-                color = :light_magenta,
-            )
-            touch(joinpath(versions_dir, update_name))
-        end
-    end
-end
-
-# Deprecations, that will be removed in future versions
-include("deprecated.jl")
+include("deprecations.jl")
 
 # Predefined models
 include("models/Models.jl")
 export Models
 
+# Update messages:
+using Scratch
+display_update = true
+version_number = "4.4"
+update_name = "update_v$(version_number)"
+
+if display_update
+    # Get scratch space for this package
+    versions_dir = @get_scratch!("versions")
+    if !isfile(joinpath(versions_dir, update_name))
+        printstyled(
+            stdout,
+            """
+            \nUpdate message: Agents v$(version_number)
+            Please see the changelog online. Some key features:
+
+            * Agent data can be loaded from and saved to CSV files using `populate_from_csv!` and `dump_to_csv`
+            * Support for saving and loading entire models using `save_checkpoint` and `load_checkpoint`
+            """;
+            color = :light_magenta,
+        )
+        touch(joinpath(versions_dir, update_name))
+    end
+end
 
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,33 @@
+function ContinuousSpace(
+    extent,
+    spacing;
+    kwargs...,
+)
+    @warn "Giving `spacing` as a positional argument to `ContinuousSpace` is "*
+    "deprecated, provide it as a keyword instead."
+    return ContinuousSpace(extend; spacing, kwargs...)
+end
+
+
+function __init__()
+    # Plot recipes
+    @require Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
+        include("visualization/plot-recipes.jl")
+    end
+    # Workaround for Documenter.jl, so we don't need to include
+    # heavy dependencies to build documentation
+    @require Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4" begin
+        include("visualization/plot-recipes.jl")
+    end
+end
+
+
+# 4.0 Depreciations
+@deprecate space_neighbors nearby_ids
+@deprecate node_neighbors nearby_positions
+@deprecate get_node_contents ids_in_position
+@deprecate get_node_agents agents_in_position
+@deprecate pick_empty random_empty
+@deprecate find_empty_nodes empty_positions
+@deprecate has_empty_nodes has_empty_positions
+@deprecate nodes positions

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -11,32 +11,39 @@ Base.eltype(s::ContinuousSpace{D,P,T,F}) where {D,P,T,F} = T
 defvel(a, m) = nothing
 
 """
-    ContinuousSpace(extent::NTuple{D, <:Real}, spacing = min(extent...)/10; kwargs...)
+    ContinuousSpace(extent::NTuple{D, <:Real}; kwargs...)
 Create a `D`-dimensional `ContinuousSpace` in range 0 to (but not including) `extent`.
-`spacing` configures the compartment spacing that the space is divided in, in order to
-accelerate nearest neighbor functions like [`nearby_ids`](@ref).
-All dimensions in `extent` must be completely divisible by `spacing` (i.e. no
-fractional remainder).
 Your agent positions (field `pos`) must be of type `NTuple{D, <:Real}`,
-use [`ContinuousAgent`](@ref) for convenience.
-In addition it is useful for agents to have a field `vel::NTuple{D, <:Real}` to use
-in conjunction with [`move_agent!`](@ref).
+and it is strongly recommend that agents also have a field `vel::NTuple{D, <:Real}` to use
+in conjunction with [`move_agent!`](@ref). Use [`ContinuousAgent`](@ref) for convenience.
 
-The keyword `periodic = true` configures whether the space is periodic or not. If set to
-`false` an error will occur if an agent's position exceeds the boundary.
+`ContinuousSpace` is a _true_ representation of agent dynamics on a continuous medium
+where agent position, orientation, and speed, are true floats.
+In addition, strong support is provided for representing spatial properties in a model
+that contains a `ContinuousSpace`. Spatial properties (which typically are contained in 
+the model properties) can either be functions of the position vector, `f(pos) = value`,
+or `AbstractArrays`, representing discretizations of 
+spatial data that may not be available in analytic form. In the latter case,
+the position is automatically mapped into the discretization represented by the array.
+Use [`get_spatial_property`](@ref) to access spatial properties in conjuction with
+`ContinuousSpace`.
 
-The keyword argument `update_vel!` is a **function**, `update_vel!(agent, model)` that updates
-the agent's velocity **before** the agent has been moved, see [`move_agent!`](@ref).
-You can of course change the agents' velocities
-during the agent interaction, the `update_vel!` functionality targets spatial force
-fields acting on the agents individually (e.g. some magnetic field).
-By default no update is done this way.
-If you use `update_vel!`, the agent type must have a field `vel::NTuple{D, <:Real}`.
+See also [Continuous space exclusives](@ref) on the online docs for more functionality.
 
-There is no "best" choice for the value of `spacing`. If you need optimal performance it's
-advised to set up a benchmark over a range of choices. The value matters most when searching
-for neighbors. In [`Models.flocking`](@ref) for example, an optimal value for `spacing` is
-66% of the search distance.
+## Keywords
+* `periodic = true`: Whether the space is periodic or not. If set to
+  `false` an error will occur if an agent's position exceeds the boundary.
+* `spacing = min(extent...)/10`: Configures an internal compartment spacing that is used
+  to accelerate nearest neighbor searches like [`nearby_ids`](@ref).
+  All dimensions in `extent` must be completely divisible by `spacing`.
+  There is no "best" choice for the value of `spacing` and if you need optimal performance
+  it's advised to set up a benchmark over a range of choices.
+* `update_vel!`: A **function**, `update_vel!(agent, model)` that updates
+  the agent's velocity **before** the agent has been moved, see [`move_agent!`](@ref).
+  You can of course change the agents' velocities
+  during the agent interaction, the `update_vel!` functionality targets spatial force
+  fields acting on the agents individually (e.g. some magnetic field).
+  If you use `update_vel!`, the agent type must have a field `vel::NTuple{D, <:Real}`.
 """
 function ContinuousSpace(
     extent::NTuple{D,X},
@@ -189,7 +196,7 @@ function Base.show(io::IO, space::ContinuousSpace{D,P}) where {D,P}
 end
 
 #######################################################################################
-# Continuous space exclusive
+# Continuous space exclusive: agent interactions
 #######################################################################################
 export nearest_neighbor, elastic_collision!, interacting_pairs
 
@@ -410,3 +417,42 @@ function Base.iterate(iter::PairIterator, i = 1)
     id1, id2 = p
     return (iter.agents[id1], iter.agents[id2]), i + 1
 end
+
+
+#######################################################################################
+# %% Spatial fields
+#######################################################################################
+export get_spatial_property, get_spatial_index
+"""
+    get_spatial_property(pos::NTuple{D, Float64}, property::AbstractArray, model::ABM)
+Convert the continuous agent position into an appropriate `index` of `property`, which
+represents some discretization of a spatial field over a [`ContinuousSpace`](@ref).
+Then, return `property[index]`. To get the `index` directly, for e.g. mutating the
+`property` in-place, use [`get_spatial_index`](@ref).
+
+The dimensionality of `property` and the continuous space must match.
+"""
+function get_spatial_property(pos, property::AbstractArray, model::ABM)
+    index = get_spatial_index(pos, property, model)
+    return property[index]
+end
+
+"""
+    get_spatial_index(pos, property::AbstractArray, model::ABM)
+Convert the continuous agent position into an appropriate `index` of `property`, which
+represents some discretization of a spatial field over a [`ContinuousSpace`](@ref).
+"""
+function get_spatial_index(pos, property::AbstractArray, model::ABM)
+    spacesize = model.space.extent
+    propertysize = size(property)
+    εs = spacesize ./ propertysize
+    idxs = floor.(Int, pos ./ εs) .+ 1
+    return CartesianIndex(idxs)
+end
+
+"""
+    get_spatial_property(pos::NTuple{D, Float64}, property::Any, model::ABM)
+Literally equivalent with `property(pos, model)`, useful when `property` is a function,
+or a function-like object.
+"""
+get_spatial_property(pos, property, model::ABM) = property(pos, model)

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -189,6 +189,9 @@ end
 ################################################################################
 ### Pretty printing
 ################################################################################
+
+Base.size(space::ContinuousSpace) = space.extent
+
 function Base.show(io::IO, space::ContinuousSpace{D,P}) where {D,P}
     s = "$(P ? "periodic" : "") continuous space with $(join(space.dims, "×")) divisions"
     space.update_vel! ≠ defvel && (s *= " with velocity updates")

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -57,7 +57,7 @@ end
 
 """
     get_direction(from, to, model::ABM)
-Returns the direction vector from `from` to `to` taking into account periodicity of the space
+Return the direction vector from `from` to `to` taking into account periodicity of the space
 """
 get_direction(from, to, model::ABM) = get_direction(from, to, model.space)
 

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -1,4 +1,4 @@
-export edistance, walk!
+export edistance, get_direction, walk!
 
 #######################################################################################
 # %% (Mostly) space agnostic helper functions
@@ -53,6 +53,26 @@ function edistance(p1::ValidPos, p2::ValidPos, model::ABM{<:GridSpace{D,true}}) 
         total += delta^2
     end
     sqrt(total)
+end
+
+"""
+    get_direction(from, to, model::ABM)
+Returns the direction vector from `from` to `to` taking into account periodicity of the space
+"""
+get_direction(from, to, model::ABM) = get_direction(from, to, model.space)
+
+function get_direction(from::NTuple{D,Float64}, to::NTuple{D,Float64}, space::ContinuousSpace{D,true}) where {D}
+    all_dirs = [to .+ space.extent .* (i, j) .- from for i in -1:1, j in -1:1]
+    return all_dirs[argmin(map(x -> sum(x .^ 2), all_dirs))]
+end
+
+function get_direction(from::NTuple{D,Int64}, to::NTuple{D,Int64}, space::GridSpace{D,true}) where {D}
+    all_dirs = [to .+ size(space.s) .* (i, j) .- from for i in -1:1, j in -1:1]
+    return all_dirs[argmin(map(x -> sum(x .^ 2), all_dirs))]
+end
+
+function get_direction(from, to, ::Union{GridSpace,ContinuousSpace})
+    return to .- from
 end
 
 """

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -61,14 +61,17 @@ Return the direction vector from `from` to `to` taking into account periodicity 
 """
 get_direction(from, to, model::ABM) = get_direction(from, to, model.space)
 
-function get_direction(from::NTuple{D,Float64}, to::NTuple{D,Float64}, space::ContinuousSpace{D,true}) where {D}
-    all_dirs = [to .+ space.extent .* (i, j) .- from for i in -1:1, j in -1:1]
-    return all_dirs[argmin(map(x -> sum(x .^ 2), all_dirs))]
-end
-
-function get_direction(from::NTuple{D,Int64}, to::NTuple{D,Int64}, space::GridSpace{D,true}) where {D}
-    all_dirs = [to .+ size(space.s) .* (i, j) .- from for i in -1:1, j in -1:1]
-    return all_dirs[argmin(map(x -> sum(x .^ 2), all_dirs))]
+function get_direction(
+    from::NTuple{D,Float64},
+    to::NTuple{D,Float64},
+    space::Union{ContinuousSpace{D,true}, GridSpace{D,true}}
+) where {D}
+    best = to .- from
+    for offset in Iterators.product([-1:1 for _ in 1:D]...)
+        dir = to .+ offset .* size(space) .- from
+        sum(dir .^ 2) < sum(best .^ 2) && (best = dir)
+    end
+    return best
 end
 
 function get_direction(from, to, ::Union{GridSpace,ContinuousSpace})

--- a/src/submodules/io/jld2_integration.jl
+++ b/src/submodules/io/jld2_integration.jl
@@ -81,8 +81,8 @@ struct SerializableOSMSpace
     agents::Vector{OSMAgentPositionData}
 end
 
-struct SerializableAStar{D,P,M}
-    agent_paths::Vector{Tuple{Int,Vector{Dims{D}}}}
+struct SerializableAStar{D,P,M,T}
+    agent_paths::Vector{Tuple{Int,Vector{NTuple{D,T}}}}
     grid_dims::Dims{D}
     neighborhood::Vector{Dims{D}}
     admissibility::Float64
@@ -90,7 +90,7 @@ struct SerializableAStar{D,P,M}
     cost_metric::Pathfinding.CostMetric{D}
 end
 
-JLD2.writeas(::Type{Pathfinding.AStar{D,P,M}}) where {D,P,M} = SerializableAStar{D,P,M}
+JLD2.writeas(::Type{Pathfinding.AStar{D,P,M,T}}) where {D,P,M,T} = SerializableAStar{D,P,M,T}
 
 function to_serializable(t::ABM{S}) where {S}
     sabm = SerializableABM(
@@ -139,8 +139,8 @@ to_serializable(t::GraphSpace{G}) where {G} = SerializableGraphSpace{G}(t.graph)
 
 to_serializable(t::OSM.OpenStreetMapSpace) = SerializableOSMSpace([])
 
-JLD2.wconvert(::Type{SerializableAStar{D,P,M}}, t::Pathfinding.AStar{D,P,M}) where {D,P,M} =
-    SerializableAStar{D,P,M}(
+JLD2.wconvert(::Type{SerializableAStar{D,P,M,T}}, t::Pathfinding.AStar{D,P,M,T}) where {D,P,M,T} =
+    SerializableAStar{D,P,M,T}(
         [(k, collect(v)) for (k, v) in t.agent_paths],
         t.grid_dims,
         map(Tuple, t.neighborhood),
@@ -214,10 +214,10 @@ function from_serializable(t::SerializableOSMSpace; kwargs...)
     )
 end
 
-JLD2.rconvert(::Type{Pathfinding.AStar{D,P,M}}, t::SerializableAStar{D,P,M}) where {D,P,M} =
-    Pathfinding.AStar{D,P,M}(
-        Dict{Int,Pathfinding.Path{D}}(
-            k => Pathfinding.Path{D}(v...) for (k, v) in t.agent_paths
+JLD2.rconvert(::Type{Pathfinding.AStar{D,P,M,T}}, t::SerializableAStar{D,P,M,T}) where {D,P,M,T} =
+    Pathfinding.AStar{D,P,M,T}(
+        Dict{Int,Pathfinding.Path{D,T}}(
+            k => Pathfinding.Path{D,T}(v...) for (k, v) in t.agent_paths
         ),
         t.grid_dims,
         map(CartesianIndex, t.neighborhood),

--- a/src/submodules/pathfinding/all_pathfinders.jl
+++ b/src/submodules/pathfinding/all_pathfinders.jl
@@ -29,6 +29,7 @@ include("metrics.jl")
 include("pathfinding_utils.jl")
 include("astar.jl")
 include("astar_grid.jl")
+include("astar_continuous.jl")
 
 export CostMetric,
     DirectDistance,

--- a/src/submodules/pathfinding/all_pathfinders.jl
+++ b/src/submodules/pathfinding/all_pathfinders.jl
@@ -40,6 +40,7 @@ export CostMetric,
     set_target!,
     set_best_target!,
     penaltymap,
-    nearby_walkable
+    nearby_walkable,
+    random_walkable
 
 end

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -88,12 +88,11 @@ AStar(
 AStar(
     space::ContinuousSpace{D,periodic},
     granularity::Dims{D};
-    diagonal_movement::Bool = true,
     admissibility::Float64 = 0.0,
     walkable::BitArray{D} = trues(granularity),
     cost_metric::CostMetric{D} = DirectDistance{D}(),
 ) where {D,periodic} =
-    AStar{Float64}(granularity; periodic, diagonal_movement, admissibility, walkable, cost_metric)
+    AStar{Float64}(granularity; periodic, diagonal_movement = true, admissibility, walkable, cost_metric)
 
 
 moore_neighborhood(D) = [

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -21,7 +21,7 @@ struct AStar{D,P,M,T} <: GridPathfinder{D,P,M}
         walkable::BitArray{D},
         cost_metric::CostMetric{D},
     ) where {D,P,M,T}
-        @assert grid_dims .> 0 "Grid must have valid dimensions"
+        @assert all(grid_dims .> 0) "Grid must have valid dimensions"
         @assert size(walkable) == grid_dims "Walkmap must be same dimensions as grid"
         @assert admissibility >= 0 "Invalid value for admissibility: $admissibility ≱ 0"
         if cost_metric isa PenaltyMap{D}

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -21,6 +21,7 @@ struct AStar{D,P,M,T} <: GridPathfinder{D,P,M}
         walkable::BitArray{D},
         cost_metric::CostMetric{D},
     ) where {D,P,M,T}
+        @assert grid_dims .> 0 "Grid must have valid dimensions"
         @assert size(walkable) == grid_dims "Walkmap must be same dimensions as grid"
         @assert admissibility >= 0 "Invalid value for admissibility: $admissibility ≱ 0"
         if cost_metric isa PenaltyMap{D}
@@ -230,5 +231,5 @@ end
 Returns an iterable of all [`nearby_positions`](@ref) within "radius" `r` of the given
 `position` (excluding `position`), which are walkable as specified by the given `pathfinder`.
 """
-nearby_walkable(position, model, pathfinder, r = 1) =
+nearby_walkable(position, model::ABM{<:GridSpace}, pathfinder, r = 1) =
     Iterators.filter(x -> pathfinder.walkable[x...] == 1, nearby_positions(position, model, r))

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -3,7 +3,7 @@
 Alias of `MutableLinkedList{Dims{D}}`. Used to represent the path to be
 taken by an agent in a `D` dimensional [`GridSpace`](@ref).
 """
-const Path{D,T} = MutableLinkedList{Dims{D,T}}
+const Path{D,T} = MutableLinkedList{NTuple{D,T}}
 
 struct AStar{D,P,M,T} <: GridPathfinder{D,P,M}
     agent_paths::Dict{Int,Path{D,T}}
@@ -13,14 +13,14 @@ struct AStar{D,P,M,T} <: GridPathfinder{D,P,M}
     walkable::BitArray{D}
     cost_metric::CostMetric{D}
 
-    function AStar{D,P,M}(
+    function AStar{D,P,M,T}(
         agent_paths::Dict,
         grid_dims::Dims{D},
         neighborhood::Vector{CartesianIndex{D}},
         admissibility::Float64,
         walkable::BitArray{D},
         cost_metric::CostMetric{D},
-    ) where {D,P,M}
+    ) where {D,P,M,T}
         @assert size(walkable) == grid_dims "Walkmap must be same dimensions as grid"
         @assert admissibility >= 0 "Invalid value for admissibility: $admissibility ≱ 0"
         if cost_metric isa PenaltyMap{D}
@@ -65,7 +65,7 @@ function AStar{T}(
     cost_metric::CostMetric{D} = DirectDistance{D}(),
 ) where {D,T}
     neighborhood = diagonal_movement ? moore_neighborhood(D) : vonneumann_neighborhood(D)
-    return AStar{D,periodic,diagonal_movement}(
+    return AStar{D,periodic,diagonal_movement,T}(
         Dict{Int,Path{D,T}}(),
         dims,
         neighborhood,

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -174,6 +174,7 @@ function find_path(pathfinder::AStar{D}, from::Dims{D}, to::Dims{D}) where {D}
         pushfirst!(agent_path, cur)
         cur = parent[cur]
     end
+    cur == from || return # nothing
     return agent_path
 end
 

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -224,11 +224,3 @@ function Agents.kill_agent!(
     delete!(model.agents, agent.id)
     Agents.remove_agent_from_space!(agent, model)
 end
-
-"""
-    nearby_walkable(position, model, pathfinder, r = 1)
-Returns an iterable of all [`nearby_positions`](@ref) within "radius" `r` of the given
-`position` (excluding `position`), which are walkable as specified by the given `pathfinder`.
-"""
-nearby_walkable(position, model::ABM{<:GridSpace}, pathfinder, r = 1) =
-    Iterators.filter(x -> pathfinder.walkable[x...] == 1, nearby_positions(position, model, r))

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -1,0 +1,116 @@
+"""
+    find_continuous_path(pathfinder, from, to, model)
+Functions like find_path, but uses the output of find_path and converts it to the coordinate
+space used by model.space (which is continuous). Also performs checks on the last two waypoints
+in the discrete path to ensure continuous path is optimal.
+"""
+function find_continuous_path(
+    pathfinder::AStar{D},
+    from::NTuple{D,Float64},
+    to::NTuple{D,Float64},
+    model::ABM{<:ContinuousSpace{D}}
+) where {D}
+    discrete_from = floor.(Int, from ./ model.space.extent .* pathfinder.grid_dims)
+    discrete_to = floor.(Int, to ./ model.space.extent .* pathfinder.grid_dims)
+    discrete_path = find_path(pathfinder, discrete_from, discrete_to)
+    cts_path = Path{D,Float64}()
+    for pos in discrete_path
+        push!(cts_path, pos ./ pathfinder.grid_dims .* model.space.extent)
+    end
+    last_pos = last(cts_path)
+    pop!(cts_path)
+    second_last_pos = last(cts_path)
+    if edistance(last_pos, to, model) < edistance(second_last_pos, to, model)
+        push!(cts_path, last_pos)
+    end
+    push!(cts_path, to)
+end
+
+"""
+    Pathfinding.set_target!(agent, target::NTuple{D,Int}, pathfinder)
+Calculate and store the shortest path to move the agent from its current position to
+`target` (a grid position e.g. `(1, 5)`) for using the provided `pathfinder`.
+
+Use this method in conjuction with [`move_along_route!`](@ref).
+"""
+function set_target!(
+    agent::A,
+    target::NTuple{D,Float64},
+    pathfinder::AStar{D},
+    model::ABM{<:ContinuousSpace{D},A},
+) where {D,A<:AbstractAgent}
+    pathfinder.agent_paths[agent.id] = find_continuous_path(pathfinder, agent.pos, target, model)
+end
+
+"""
+    Pathfinding.set_best_target!(agent, targets::Vector{NTuple{D,Int}}, pathfinder)
+
+Calculate and store the best path to move the agent from its current position to
+a chosen target position taken from `targets` for models using [`Pathfinding`](@ref).
+
+The `condition = :shortest` keyword retuns the shortest path which is shortest
+(allowing for the conditions of the models pathfinder) out of the possible target
+positions. Alternatively, the `:longest` path may also be requested.
+
+Returns the position of the chosen target.
+"""
+function set_best_target!(
+    agent::A,
+    targets::Vector{Dims{D}},
+    pathfinder::AStar{D},
+    model::ABM{<:ContinuousSpace{D}};
+    condition::Symbol = :shortest,
+) where {D,A<:AbstractAgent}
+    @assert condition ∈ (:shortest, :longest)
+    compare = condition == :shortest ? (a, b) -> a < b : (a, b) -> a > b
+    best_path = Path{D,Float64}()
+    best_target = nothing
+    for target in targets
+        path = find_continuous_path(pathfinder, agent.pos, target, model)
+        if isempty(best_path) || compare(length(path), length(best_path))
+            best_path = path
+            best_target = target
+        end
+    end
+
+    pathfinder.agent_paths[agent.id] = best_path
+    return best_target
+end
+
+"""
+    move_along_route!(agent, model, pathfinder)
+Move `agent` for one step along the route toward its target set by [`Pathfinding.set_target!`](@ref)
+for agents on a [`GridSpace`](@ref) using a [`Pathfinding.AStar`](@ref).
+If the agent does not have a precalculated path or the path is empty, it remains stationary.
+"""
+function Agents.move_along_route!(
+    agent::A,
+    speed::Float64,
+    model::ABM{<:ContinuousSpace{D},A},
+    pathfinder::AStar{D,false},
+    dt::Real = 1.0,
+) where {D,A<:AbstractAgent}
+    isempty(agent.id, pathfinder) && return
+    next_pos = agent.pos
+    while true
+        next_waypoint = first(pathfinder.agent_paths[agent.id])
+        dir = next_waypoint .- agent.pos
+        norm_dir = √sum(dir .^ 2)
+        dir = dir ./ norm_dir
+        next_pos = agent.pos .+ dir .* speed .* dt
+
+        # overshooting means we reached the waypoint
+        if edistance(agent.pos, next_pos, model) > edistance(agent.pos, next_waypoint, model)
+            pop!(pathfinder.agent_paths[agent.id])
+            # if the path is now empty, go directly to the end
+            if isempty(agent.id, pathfinder)
+                next_pos = next_waypoint
+                break
+            end
+        else
+            break
+        end
+    end
+
+    move_agent!(agent, next_pos, model)
+end

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -24,10 +24,12 @@ function find_continuous_path(
     last_pos = last(cts_path)
     pop!(cts_path)
     second_last_pos = isempty(cts_path) ? from : last(cts_path)
-    if edistance(last_pos, to, model) < edistance(second_last_pos, to, model)
+    last_to_end = edistance(last_pos, to, model)
+    second_last_to_end = edistance(second_last_pos, to, model)
+    if last_to_end < second_last_to_end
         push!(cts_path, last_pos)
     end
-    push!(cts_path, to)
+    last_to_end ≈ 0. || push!(cts_path, to)
     return cts_path
 end
 
@@ -122,7 +124,7 @@ function Agents.move_along_route!(
         dir = get_direction(from, next_waypoint, model.space)
         norm_dir = √sum(dir .^ 2)
         dir = dir ./ norm_dir
-        next_pos = agent.pos .+ dir .* speed .* dt
+        next_pos = from .+ dir .* speed .* dt
 
         # overshooting means we reached the waypoint
         dist_to_target = edistance(from, next_waypoint, model)
@@ -137,7 +139,7 @@ function Agents.move_along_route!(
             # without this, agent would end up at (0.85, 0.85) instead of (1, 0.2)
             from = next_waypoint
             dt -= dist_to_target / speed
-            pop!(pathfinder.agent_paths[agent.id])
+            popfirst!(pathfinder.agent_paths[agent.id])
             # if the path is now empty, go directly to the end
             if isempty(agent.id, pathfinder)
                 next_pos = next_waypoint

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -30,6 +30,7 @@ function find_continuous_path(
         end
     end
     push!(cts_path, to)
+    return cts_path
 end
 
 """

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -13,8 +13,8 @@ function find_continuous_path(
     # used to offset positions, so edge cases get handled properly (i.e. (0., 0.) maps to grid
     # cell (1, 1))
     half_cell_size = model.space.extent ./ pathfinder.grid_dims ./ 2.
-    discrete_from = floor.(Int, from ./ model.space.extent .* pathfinder.grid_dims) .+ 1
-    discrete_to = floor.(Int, to ./ model.space.extent .* pathfinder.grid_dims) .+ 1
+    discrete_from = Tuple(Agents.get_spatial_index(from, pathfinder.walkable, model))
+    discrete_to = Tuple(Agents.get_spatial_index(to, pathfinder.walkable, model))
     discrete_path = find_path(pathfinder, discrete_from, discrete_to)
     isempty(discrete_path) && return
     cts_path = Path{D,Float64}()

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -155,11 +155,6 @@ function random_walkable(model::ABM{<:ContinuousSpace{D}}, pathfinder::AStar{D})
         Tuple(rand(model.rng, D) .- 0.5) .* half_cell_size
 end
 
-filter_condition(offset, pos, pathfinder::AStar{D,false}, r) where {D} =
-    1 .<= (pos .+ offset) .<= pathfinder.grid_dims &&
-    pathfinder.walkable[pos .+ offset] &&
-    sum(offset .^ 2) <= r*r
-
 walkable_cells_in_radius(pos, r, pathfinder::AStar{D,false}) where {D} =
     Iterators.filter(
         x -> all(1 .<= x .<= pathfinder.grid_dims) &&

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -1,7 +1,7 @@
 """
     find_continuous_path(pathfinder, from, to, model)
-Functions like find_path, but uses the output of find_path and converts it to the coordinate
-space used by model.space (which is continuous). Also performs checks on the last two waypoints
+Functions like `find_path``, but uses the output of `find_path` and converts it to the coordinate
+space used by `model.space` (which is continuous). Also performs checks on the last two waypoints
 in the discrete path to ensure continuous path is optimal.
 """
 function find_continuous_path(

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -21,13 +21,11 @@ function find_continuous_path(
     for pos in discrete_path
         push!(cts_path, pos ./ pathfinder.grid_dims .* model.space.extent .- half_cell_size)
     end
-    if length(cts_path) > 1
-        last_pos = last(cts_path)
-        pop!(cts_path)
-        second_last_pos = last(cts_path)
-        if edistance(last_pos, to, model) < edistance(second_last_pos, to, model)
-            push!(cts_path, last_pos)
-        end
+    last_pos = last(cts_path)
+    pop!(cts_path)
+    second_last_pos = isempty(cts_path) ? from : last(cts_path)
+    if edistance(last_pos, to, model) < edistance(second_last_pos, to, model)
+        push!(cts_path, last_pos)
     end
     push!(cts_path, to)
     return cts_path

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -16,7 +16,8 @@ function find_continuous_path(
     discrete_from = Tuple(Agents.get_spatial_index(from, pathfinder.walkable, model))
     discrete_to = Tuple(Agents.get_spatial_index(to, pathfinder.walkable, model))
     discrete_path = find_path(pathfinder, discrete_from, discrete_to)
-    isempty(discrete_path) && return
+    isnothing(discrete_path) && return
+    isempty(discrete_path) && return Path{D,Float64}()
     cts_path = Path{D,Float64}()
     for pos in discrete_path
         push!(cts_path, pos ./ pathfinder.grid_dims .* model.space.extent .- half_cell_size)
@@ -86,6 +87,7 @@ function set_best_target!(
         end
     end
 
+    isnothing(best_target) && return
     pathfinder.agent_paths[agent.id] = best_path
     return best_target
 end

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -192,6 +192,9 @@ function random_walkable(
     cts_rand = discrete_rand ./ pathfinder.grid_dims .* model.space.extent .- half_cell_size .+
         Tuple(rand(model.rng, D) .- 0.5) .* half_cell_size
     dist = edistance(pos, cts_rand, model)
-    dist > r && (cts_rand = cts_rand ./ dist .* r)
+    dist > r && (cts_rand = mod1.(
+        pos .+ get_direction(pos, cts_rand, model) ./ dist .* r,
+        model.space.extent
+    ))
     return cts_rand
 end

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -67,8 +67,16 @@ end
 
 """
     nearby_walkable(position, model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}, r = 1)
-Returns an iterable of all [`nearby_positions`](@ref) within "radius" `r` of the given
+Return an iterator over all [`nearby_positions`](@ref) within "radius" `r` of the given
 `position` (excluding `position`), which are walkable as specified by the given `pathfinder`.
 """
 nearby_walkable(position, model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}, r = 1) where {D} =
     Iterators.filter(x -> pathfinder.walkable[x...] == 1, nearby_positions(position, model, r))
+
+"""
+    random_walkable(model, pathfinder::AStar{D})
+Return a random position in the given `model` that is walkable as specified by the given
+`pathfinder`.
+"""
+random_walkable(model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}) where {D} =
+    rand(model.rng, filter(x -> pathfinder.walkable(x), CartesianIndices(model.space.s)))

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -34,7 +34,7 @@ function set_best_target!(
 ) where {D,A<:AbstractAgent}
     @assert condition ∈ (:shortest, :longest)
     compare = condition == :shortest ? (a, b) -> a < b : (a, b) -> a > b
-    best_path = Path{D}()
+    best_path = Path{D,Int64}()
     best_target = nothing
     for target in targets
         path = find_path(pathfinder, agent.pos, target)

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -64,3 +64,11 @@ function Agents.move_along_route!(
     move_agent!(agent, first(pathfinder.agent_paths[agent.id]), model)
     popfirst!(pathfinder.agent_paths[agent.id])
 end
+
+"""
+    nearby_walkable(position, model, pathfinder, r = 1)
+Returns an iterable of all [`nearby_positions`](@ref) within "radius" `r` of the given
+`position` (excluding `position`), which are walkable as specified by the given `pathfinder`.
+"""
+nearby_walkable(position, model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}, r = 1) where {D} =
+    Iterators.filter(x -> pathfinder.walkable[x...] == 1, nearby_positions(position, model, r))

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -22,7 +22,8 @@ a chosen target position taken from `targets` using `pathfinder`.
 The `condition = :shortest` keyword retuns the shortest path which is shortest out of the
 possible target positions. Alternatively, the `:longest` path may also be requested.
 
-Returns the position of the chosen target.
+Returns the position of the chosen target, or `nothing` if none of the supplied targets are
+reachable.
 """
 function set_best_target!(
     agent::A,
@@ -36,12 +37,14 @@ function set_best_target!(
     best_target = nothing
     for target in targets
         path = find_path(pathfinder, agent.pos, target)
+        isnothing(path) && continue
         if isempty(best_path) || compare(length(path), length(best_path))
             best_path = path
             best_target = target
         end
     end
 
+    isnothing(best_target) && return
     pathfinder.agent_paths[agent.id] = best_path
     return best_target
 end

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -16,13 +16,11 @@ end
 
 """
     Pathfinding.set_best_target!(agent, targets::Vector{NTuple{D,Int}}, pathfinder)
-
 Calculate and store the best path to move the agent from its current position to
-a chosen target position taken from `targets` for models using [`Pathfinding`](@ref).
+a chosen target position taken from `targets` using `pathfinder`.
 
-The `condition = :shortest` keyword retuns the shortest path which is shortest
-(allowing for the conditions of the models pathfinder) out of the possible target
-positions. Alternatively, the `:longest` path may also be requested.
+The `condition = :shortest` keyword retuns the shortest path which is shortest out of the
+possible target positions. Alternatively, the `:longest` path may also be requested.
 
 Returns the position of the chosen target.
 """

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -1,5 +1,5 @@
 """
-    Pathfinding.set_target!(agent, target::NTuple{D,Int}, pathfinder)
+    Pathfinding.set_target!(agent, target::NTuple{D,Int}, pathfinder::AStar{D})
 Calculate and store the shortest path to move the agent from its current position to
 `target` (a grid position e.g. `(1, 5)`) for using the provided `pathfinder`.
 
@@ -15,7 +15,7 @@ function set_target!(
 end
 
 """
-    Pathfinding.set_best_target!(agent, targets::Vector{NTuple{D,Int}}, pathfinder)
+    Pathfinding.set_best_target!(agent, targets::Vector{NTuple{D,Int}}, pathfinder::AStar{D})
 Calculate and store the best path to move the agent from its current position to
 a chosen target position taken from `targets` using `pathfinder`.
 
@@ -47,9 +47,11 @@ function set_best_target!(
 end
 
 """
-    move_along_route!(agent, model, pathfinder)
+    move_along_route!(agent, model::ABM{<:GridSpace{D}}, pathfinder::AStar{D})
 Move `agent` for one step along the route toward its target set by [`Pathfinding.set_target!`](@ref)
-for agents on a [`GridSpace`](@ref) using a [`Pathfinding.AStar`](@ref).
+
+For pathfinding in models with [`GridSpace`](@ref).
+
 If the agent does not have a precalculated path or the path is empty, it remains stationary.
 """
 function Agents.move_along_route!(
@@ -64,7 +66,7 @@ function Agents.move_along_route!(
 end
 
 """
-    nearby_walkable(position, model, pathfinder, r = 1)
+    nearby_walkable(position, model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}, r = 1)
 Returns an iterable of all [`nearby_positions`](@ref) within "radius" `r` of the given
 `position` (excluding `position`), which are walkable as specified by the given `pathfinder`.
 """

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -73,6 +73,7 @@ Return an iterator over all [`nearby_positions`](@ref) within "radius" `r` of th
 nearby_walkable(position, model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}, r = 1) where {D} =
     Iterators.filter(x -> pathfinder.walkable[x...] == 1, nearby_positions(position, model, r))
 
+
 """
     random_walkable(model, pathfinder::AStar{D})
 Return a random position in the given `model` that is walkable as specified by the given

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -83,4 +83,4 @@ Return a random position in the given `model` that is walkable as specified by t
 `pathfinder`.
 """
 random_walkable(model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}) where {D} =
-    rand(model.rng, filter(x -> pathfinder.walkable(x), CartesianIndices(model.space.s)))
+    Tuple(rand(model.rng, filter(x -> pathfinder.walkable[x], CartesianIndices(model.space.s))))

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -85,12 +85,13 @@
         @test !is_stationary(a, model.pf)
         @test length(model.pf.agent_paths) == 1
 
-        move_along_route!(a, 0.3535, model, model.pf)
-        @test a.pos ≈ (4.75, 4.75)
+        move_along_route!(a, 0.35355, model, model.pf)
+        @test all(isapprox.(a.pos, (4.75, 4.75); atol = 0.0001))
 
         delete!(model.pf.agent_paths, 1)
         @test length(model.pf.agent_paths) == 0
-        @test set_best_target!(a, [(2.5, 2.5), (5.,0.), (0., 5.)], model.pf, model) == (2.5, 2.5)
+        move_agent!(a, (0., 0.), model)
+        @test all(set_best_target!(a, [(2.5, 2.5), (5.,0.), (0., 5.)], model.pf, model) .≈ (2.5, 2.5))
         @test length(model.pf.agent_paths) == 1
 
         kill_agent!(a, model, model.pf)
@@ -98,7 +99,7 @@
 
         @test isnothing(penaltymap(model.pf))
         pmap = fill(1, 10, 10)
-        pathfinder = AStar(cspace; cost_metric = PenaltyMap(pmap))
+        pathfinder = AStar(cspace, (10, 10); cost_metric = PenaltyMap(pmap))
         @test penaltymap(pathfinder) == pmap
     end
 

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -144,7 +144,7 @@
 
         @test all(get_spatial_property(random_walkable(model, model.pf), model.pf.walkable, model) for _ in 1:10)
         rpos = [random_walkable((2.5, 0.75), model, model.pf, 2.0) for _ in 1:10]
-        @test all(get_spatial_property(x, model.pf.walkable, model) && sum((x .- (2.5, 0.75)) .^ 2) <= 4.0 for x in rpos)
+        @test all(get_spatial_property(x, model.pf.walkable, model) && edistance(x, (2.5, 0.75), model) <= 2.0 for x in rpos)
     end
 
     @testset "metrics" begin

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -81,7 +81,7 @@
         a = add_agent!((0., 0.), model, (0., 0.), 0.)
         @test is_stationary(a, model.pf)
 
-        set_target!(a, (3., 4.), model.pf, model)
+        set_target!(a, (4., 4.), model.pf, model)
         @test !is_stationary(a, model.pf)
         @test length(model.pf.agent_paths) == 1
 
@@ -90,8 +90,13 @@
 
         delete!(model.pf.agent_paths, 1)
         @test length(model.pf.agent_paths) == 0
+
+        pcspace = ContinuousSpace((5., 5.); periodic = false)
+        pathfinder = AStar(pcspace, (10, 10))
+        model = ABM(Agent6, pcspace; properties = (pf = pathfinder,))
+        a = add_agent!((0., 0.), model, (0., 0.), 0.)
         move_agent!(a, (0., 0.), model)
-        @test all(set_best_target!(a, [(2.5, 2.5), (5.,0.), (0., 5.)], model.pf, model) .≈ (2.5, 2.5))
+        @test all(set_best_target!(a, [(2.5, 2.5), (4.99,0.), (0., 4.99)], model.pf, model) .≈ (2.5, 2.5))
         @test length(model.pf.agent_paths) == 1
 
         kill_agent!(a, model, model.pf)

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -82,6 +82,14 @@
         @test length(npos) == length(ans)
         @test all(x in npos for x in ans)
 
+        sp = GridSpace((5, 5); periodic = false)
+        pf = AStar(sp)
+        model = ABM(Agent3, sp; properties = (pf = pf,))
+        model.pf.walkable[3, :] .= 0
+        a = add_agent!((1, 3), model, 0.)
+        @test set_best_target!(a, [(1, 3), (4, 1)], model.pf) == (1, 3)
+        @test isnothing(set_best_target!(a, [(5, 3), (4, 1)], model.pf))
+
         # ContinuousSpace
         pathfinder = AStar(cspace, (10, 10))
         model = ABM(Agent6, cspace; properties = (pf = pathfinder,))
@@ -115,6 +123,11 @@
         move_along_route!(a, model, model.pf, 1.0)
         @test all(isapprox.(a.pos, (0.7071, 0.7071); atol))
 
+        model.pf.walkable[:, 3] .= 0
+        move_agent!(a, (2.5, 2.5), model)
+        @test all(set_best_target!(a, [(3., 0.3), (2.5, 2.5)], model.pf, model) .≈ (2.5, 2.5))
+        @test isnothing(set_best_target!(a, [(3., 0.3), (1., 0.1)], model.pf, model))
+
         kill_agent!(a, model, model.pf)
         @test length(model.pf.agent_paths) == 0
 
@@ -122,6 +135,7 @@
         pmap = fill(1, 10, 10)
         pathfinder = AStar(cspace, (10, 10); cost_metric = PenaltyMap(pmap))
         @test penaltymap(pathfinder) == pmap
+
     end
 
     @testset "metrics" begin

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -88,10 +88,14 @@
 
         move_along_route!(a, 0.35355, model, model.pf)
         @test all(isapprox.(a.pos, (4.75, 4.75); atol))
+        # test waypoint skipping
         move_agent!(a, (0.25, 0.25), model)
         set_target!(a, (0.75, 1.25), model.pf, model)
         move_along_route!(a, 0.807106, model, model.pf)
         @test all(isapprox.(a.pos, (0.467156, 0.967156); atol))
+        # make sure it doesn't overshoot the end
+        move_along_route!(a, 20., model, model.pf)
+        @test all(isapprox.(a.pos, (0.75, 1.25); atol))
 
         delete!(model.pf.agent_paths, 1)
         @test length(model.pf.agent_paths) == 0

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -115,6 +115,11 @@
         delete!(model.pf.agent_paths, 1)
         @test length(model.pf.agent_paths) == 0
 
+        model.pf.walkable[:, 3] .= 0
+        @test all(get_spatial_property(random_walkable(model, model.pf), model.pf.walkable, model) for _ in 1:10)
+        rpos = [random_walkable((2.5, 0.75), model, model.pf, 2.0) for _ in 1:10]
+        @test all(get_spatial_property(x, model.pf.walkable, model) && edistance(x, (2.5, 0.75), model) <= 2.0 for x in rpos)
+
         pcspace = ContinuousSpace((5., 5.); periodic = false)
         pathfinder = AStar(pcspace, (10, 10))
         model = ABM(Agent6, pcspace; properties = (pf = pathfinder,))

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -5,6 +5,7 @@
     vonneumann = Pathfinding.vonneumann_neighborhood(2)
     gspace = GridSpace((5, 5))
     cspace = ContinuousSpace((5., 5.))
+    atol = 0.0001
     @testset "constructors" begin
         # GridSpace
         @test_throws AssertionError AStar(gspace; admissibility = -1.0)
@@ -86,7 +87,7 @@
         @test length(model.pf.agent_paths) == 1
 
         move_along_route!(a, 0.35355, model, model.pf)
-        @test all(isapprox.(a.pos, (4.75, 4.75); atol = 0.0001))
+        @test all(isapprox.(a.pos, (4.75, 4.75); atol))
 
         delete!(model.pf.agent_paths, 1)
         @test length(model.pf.agent_paths) == 0
@@ -95,9 +96,10 @@
         pathfinder = AStar(pcspace, (10, 10))
         model = ABM(Agent6, pcspace; properties = (pf = pathfinder,))
         a = add_agent!((0., 0.), model, (0., 0.), 0.)
-        move_agent!(a, (0., 0.), model)
         @test all(set_best_target!(a, [(2.5, 2.5), (4.99,0.), (0., 4.99)], model.pf, model) .≈ (2.5, 2.5))
         @test length(model.pf.agent_paths) == 1
+        move_along_route!(a, 1.0, model, model.pf)
+        @test all(isapprox.(a.pos, (0.7071, 0.7071); atol))
 
         kill_agent!(a, model, model.pf)
         @test length(model.pf.agent_paths) == 0
@@ -213,5 +215,27 @@
         @test p == [(2, 6), (3, 6), (4, 6), (5, 6), (6, 6)]
         p = collect(Pathfinding.find_path(pfinder_2d_p_nm, (1, 1), (6, 6)))
         @test p == [(1, 6), (2, 6), (3, 6), (4, 6), (5, 6), (6, 6)]
+
+        # Continuous
+        model = ABM(Agent6, ContinuousSpace((10., 10.)))
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_m, (0.25, 0.25), (8.8, 9.5)))
+        testp = [(0.7143, 2.5), (0.7143, 4.1667), (0.7143, 5.8333), (0.7143, 7.5), (2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        @test length(p) == length(testp)
+        @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
+
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_nm, (0.25, 0.25), (8.8, 9.5)))
+        testp = [(0.7143, 2.5), (0.7143, 4.1667), (0.7143, 5.8333), (0.7143, 7.5), (0.7143, 9.1667), (2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        @test length(p) == length(testp)
+        @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
+
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_m, (0.25, 0.25), (8.8, 9.5)))
+        testp = [(2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        @test length(p) == length(testp)
+        @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
+
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_nm, (0.25, 0.25), (8.8, 9.5)))
+        testp = [(0.7143, 9.1667), (2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        @test length(p) == length(testp)
+        @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
     end
 end

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -88,6 +88,10 @@
 
         move_along_route!(a, 0.35355, model, model.pf)
         @test all(isapprox.(a.pos, (4.75, 4.75); atol))
+        move_agent!(a, (0.25, 0.25), model)
+        set_target!(a, (0.75, 1.25), model.pf, model)
+        move_along_route!(a, 0.807106, model, model.pf)
+        @test all(isapprox.(a.pos, (0.467156, 0.967156); atol))
 
         delete!(model.pf.agent_paths, 1)
         @test length(model.pf.agent_paths) == 0
@@ -223,18 +227,8 @@
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
 
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_nm, (0.25, 0.25), (7.8, 9.5), model))
-        testp = [(0.71429, 2.5), (0.71429, 4.16667), (0.71429, 5.83333), (0.71429, 7.5), (0.71429, 9.16667), (2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
-        @test length(p) == length(testp)
-        @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
-
         p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_m, (0.25, 0.25), (7.8, 9.5), model))
         testp = [(2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
-        @test length(p) == length(testp)
-        @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
-
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_nm, (0.25, 0.25), (7.8, 9.5), model))
-        testp = [(0.71429, 9.16667), (2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
     end

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -76,6 +76,12 @@
         model = ABM(Agent3, gspace; properties = (pf = pathfinder, ))
         @test penaltymap(model.pf) == pmap
 
+        pathfinder.walkable[:, 3] .= false
+        npos = collect(nearby_walkable((5, 4), model, model.pf))
+        ans = [(4, 4), (5, 5), (1, 4), (4, 5), (1, 5)]
+        @test length(npos) == length(ans)
+        @test all(x in npos for x in ans)
+
         # ContinuousSpace
         pathfinder = AStar(cspace, (10, 10))
         model = ABM(Agent6, cspace; properties = (pf = pathfinder,))

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -86,15 +86,15 @@
         @test !is_stationary(a, model.pf)
         @test length(model.pf.agent_paths) == 1
 
-        move_along_route!(a, 0.35355, model, model.pf)
+        move_along_route!(a, model, model.pf, 0.35355)
         @test all(isapprox.(a.pos, (4.75, 4.75); atol))
         # test waypoint skipping
         move_agent!(a, (0.25, 0.25), model)
         set_target!(a, (0.75, 1.25), model.pf, model)
-        move_along_route!(a, 0.807106, model, model.pf)
+        move_along_route!(a, model, model.pf, 0.807106)
         @test all(isapprox.(a.pos, (0.467156, 0.967156); atol))
         # make sure it doesn't overshoot the end
-        move_along_route!(a, 20., model, model.pf)
+        move_along_route!(a, model, model.pf, 20.)
         @test all(isapprox.(a.pos, (0.75, 1.25); atol))
 
         delete!(model.pf.agent_paths, 1)
@@ -106,7 +106,7 @@
         a = add_agent!((0., 0.), model, (0., 0.), 0.)
         @test all(set_best_target!(a, [(2.5, 2.5), (4.99,0.), (0., 4.99)], model.pf, model) .≈ (2.5, 2.5))
         @test length(model.pf.agent_paths) == 1
-        move_along_route!(a, 1.0, model, model.pf)
+        move_along_route!(a, model, model.pf, 1.0)
         @test all(isapprox.(a.pos, (0.7071, 0.7071); atol))
 
         kill_agent!(a, model, model.pf)

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -67,7 +67,7 @@
     end
 
     @testset "metrics" begin
-        pfinder_2d_np_m = AStar{2,false,true}(
+        pfinder_2d_np_m = AStar{2,false,true,Int64}(
             Dict(),
             (10, 10),
             copy(moore),
@@ -75,7 +75,7 @@
             trues(10, 10),
             DirectDistance{2}(),
         )
-        pfinder_2d_np_nm = AStar{2,false,false}(
+        pfinder_2d_np_nm = AStar{2,false,false,Int64}(
             Dict(),
             (10, 10),
             copy(vonneumann),
@@ -83,7 +83,7 @@
             trues(10, 10),
             DirectDistance{2}(),
         )
-        pfinder_2d_p_m = AStar{2,true,true}(
+        pfinder_2d_p_m = AStar{2,true,true,Int64}(
             Dict(),
             (10, 10),
             copy(moore),
@@ -91,7 +91,7 @@
             trues(10, 10),
             DirectDistance{2}(),
         )
-        pfinder_2d_p_nm = AStar{2,true,false}(
+        pfinder_2d_p_nm = AStar{2,true,false,Int64}(
             Dict(),
             (10, 10),
             copy(vonneumann),
@@ -129,7 +129,7 @@
         wlk[4, 3] = false
         wlk[5, 3] = false
 
-        pfinder_2d_np_m = AStar{2,false,true}(
+        pfinder_2d_np_m = AStar{2,false,true,Int64}(
             Dict(),
             (7, 6),
             copy(moore),
@@ -137,7 +137,7 @@
             wlk,
             DirectDistance{2}(),
         )
-        pfinder_2d_np_nm = AStar{2,false,false}(
+        pfinder_2d_np_nm = AStar{2,false,false,Int64}(
             Dict(),
             (7, 6),
             copy(vonneumann),
@@ -145,7 +145,7 @@
             wlk,
             DirectDistance{2}(),
         )
-        pfinder_2d_p_m = AStar{2,true,true}(
+        pfinder_2d_p_m = AStar{2,true,true,Int64}(
             Dict(),
             (7, 6),
             copy(moore),
@@ -153,7 +153,7 @@
             wlk,
             DirectDistance{2}(),
         )
-        pfinder_2d_p_nm = AStar{2,true,false}(
+        pfinder_2d_p_nm = AStar{2,true,false,Int64}(
             Dict(),
             (7, 6),
             copy(vonneumann),

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -218,23 +218,23 @@
 
         # Continuous
         model = ABM(Agent6, ContinuousSpace((10., 10.)))
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_m, (0.25, 0.25), (8.8, 9.5)))
-        testp = [(0.7143, 2.5), (0.7143, 4.1667), (0.7143, 5.8333), (0.7143, 7.5), (2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_m, (0.25, 0.25), (7.8, 9.5), model))
+        testp = [(0.71429, 2.5), (0.71429, 4.16667), (0.71429, 5.83333), (0.71429, 7.5), (2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
 
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_nm, (0.25, 0.25), (8.8, 9.5)))
-        testp = [(0.7143, 2.5), (0.7143, 4.1667), (0.7143, 5.8333), (0.7143, 7.5), (0.7143, 9.1667), (2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_nm, (0.25, 0.25), (7.8, 9.5), model))
+        testp = [(0.71429, 2.5), (0.71429, 4.16667), (0.71429, 5.83333), (0.71429, 7.5), (0.71429, 9.16667), (2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
 
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_m, (0.25, 0.25), (8.8, 9.5)))
-        testp = [(2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_m, (0.25, 0.25), (7.8, 9.5), model))
+        testp = [(2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
 
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_nm, (0.25, 0.25), (8.8, 9.5)))
-        testp = [(0.7143, 9.1667), (2.1429, 9.1667), (3.5714, 9.1667), (5.0, 9.1667), (6.4286, 9.1667), (7.8571, 9.1667), (8.8, 9.5)]
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_nm, (0.25, 0.25), (7.8, 9.5), model))
+        testp = [(0.71429, 9.16667), (2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
     end

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -81,6 +81,7 @@
         ans = [(4, 4), (5, 5), (1, 4), (4, 5), (1, 5)]
         @test length(npos) == length(ans)
         @test all(x in npos for x in ans)
+        @test all(pathfinder.walkable[random_walkable(model, model.pf)...] for _ in 1:10)
 
         sp = GridSpace((5, 5); periodic = false)
         pf = AStar(sp)
@@ -136,6 +137,9 @@
         pathfinder = AStar(cspace, (10, 10); cost_metric = PenaltyMap(pmap))
         @test penaltymap(pathfinder) == pmap
 
+        @test all(get_spatial_property(random_walkable(model, model.pf), model.pf.walkable, model) for _ in 1:10)
+        rpos = [random_walkable((2.5, 0.75), model, model.pf, 2.0) for _ in 1:10]
+        @test all(get_spatial_property(x, model.pf.walkable, model) && sum((x .- (2.5, 0.75)) .^ 2) <= 4.0 for x in rpos)
     end
 
     @testset "metrics" begin

--- a/test/continuousSpace_tests.jl
+++ b/test/continuousSpace_tests.jl
@@ -20,9 +20,9 @@
   @test length(space7.dims) == 3
   @test length(space8.dims) == 3
 
-  @test_throws ArgumentError ContinuousSpace((-1,1), 0.1) # Cannot have negative extent
-  @test_throws MethodError ContinuousSpace([1,1], 0.1) # Must be a tuple
-  @test_throws MethodError ContinuousSpace(("one",1.0), 0.1) # Must contain reals
+  @test_throws ArgumentError ContinuousSpace((-1,1)) # Cannot have negative extent
+  @test_throws MethodError ContinuousSpace([1,1]) # Must be a tuple
+  @test_throws MethodError ContinuousSpace(("one",1.0)) # Must contain reals
 
   @test space1.dims == ContinuousSpace((1,1)).dims
   @test space1.extent == ContinuousSpace((1,1)).extent


### PR DESCRIPTION
None of the new methods are tested, and the docstrings are just copied over from `astar_grid.jl`. ~I'll work on getting `move_along_route!` working for periodic continuous spaces before addressing that~ (done). Some points to address:
- `set_target!` and `set_best_target!` for continuous space require the model to be passed in, for continuous space dimensions
- I chose to keep `find_path` as it is and add a new `find_continuous_path` method. The alternative was having `find_path` return `parent` and each `set_target!` method extract the path from that, possibly through another method such as `unravel_path`.

TODO:
- [x] Revert `ci.yml`
- [x] Tests
- [x] Docs
- [x] Example