### PR TITLE
Empty positions performance boost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# v4.5 (UNRELEASED)
+# v4.5
 ## New features and fixes
 - Add `get_spatial_property` and `get_spatial_index` for easier usage of spatially distributed properties in `ContinuousSpace`.
 - Rework the pathfinding system to be more streamlined and offer greater control over the its details.
 - Add support for pathfinding in `ContinuousSpace`.
 - New utility functions `nearby_walkable` and `random_walkable` for use in models with pathfinding.
 - Fixed bug where there was no differentiation between empty paths and paths to unreachable nodes.
+- Performance enhancements for `random_empty`.
 
 ## BREAKING
 - The old pathfinding system is now deprecated. Pathfinding structs are not saved as part of the

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["Tim DuBois", "George Datseris", "Aayush Sabharwal", "Ali Vahdati"]
-version = "4.5.2"
+version = "4.5.3"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -16,15 +16,15 @@ Time taken is presented in normalised units, measured against the runtime of Age
 
 For LOC, we use the following convention: code is formatted using standard practices & linting for the associated language. Documentation strings and in-line comments (residing on lines of their own) are discarded, as well as any benchmark infrastructure. NetLogo is assigned two values since its files have a code base section and an encoding of the GUI. Since many parameters live in the GUI, we must take this into account. Thus `375 (785)` in a NetLogo count means 375 lines in the code section, 785 lines total in the file. An additional complication to this value in NetLogo is that it stores plotting information (colours, shapes, sizes) as agent properties, and as such the number outside of the bracket may be slightly inflated.
 
-| Model/Framework | Agents 4.2 | Mesa 0.8| Netlogo 6.2 | MASON 20.0 |
+| Model/Framework | Agents 4.5.3 | Mesa 0.8.9| Netlogo 6.2 | MASON 20.0 |
 |---|---|---|---|---|
-|Wolf Sheep Grass|1|31.9x|10.3x|NA|
+|Wolf Sheep Grass|1|21.5x|12.4x|NA|
 |(LOC)|122|227|137 (871)| . |
 |Flocking|1|26.8x|10.3xᕯ|2.1x|
 |(LOC)|62|102|82 (689)|369|
-|Forest Fire|1|125.6x|53.0x|NA|
+|Forest Fire|1|120.5x|53.8x|NA|
 |(LOC)|23|35|43 (545)|.|
-|Schelling|1|29.4x|8.0x|14.3x|
+|Schelling|1|84.7x|40.9x|73.1x|
 |(LOC)|31|56|60 (743)|248|
 
 ᕯ Netlogo has a different implementation to the other three frameworks here. It cheats a little by only choosing one nearest neighbor in some cases rather than considering all neighbors within vision. So a true comparison would ultimately see a slower result.

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -86,7 +86,7 @@ function random_empty(model::ABM{<:DiscreteSpace}, cutoff = 0.998)
     # This switch assumes the worst case (for this algorithm) of one
     # agent per position, which is not true in general but is appropriate
     # here.
-    if nagents(model) / prod(size(model.space)) < cutoff
+    if nagents(model) / prod(size(model.space.s)) < cutoff
         # 0.998 has been benchmarked as a performant branching point
         # It sits close to where the maximum return time is better
         # than the code in the else loop runs. So we guarantee

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -86,7 +86,7 @@ function random_empty(model::ABM{<:DiscreteSpace}, cutoff = 0.998)
     # This switch assumes the worst case (for this algorithm) of one
     # agent per position, which is not true in general but is appropriate
     # here.
-    if nagents(model) / prod(size(model.space.s)) < cutoff
+    if clamp(nagents(model) / prod(size(model.space.s)), 0.0, 1.0) < cutoff
         # 0.998 has been benchmarked as a performant branching point
         # It sits close to where the maximum return time is better
         # than the code in the else loop runs. So we guarantee

--- a/test/model_access.jl
+++ b/test/model_access.jl
@@ -74,7 +74,7 @@ end
 
 @testset "Display" begin
     model = ABM(Agent0)
-    @test "nothing" in sprint(show, model)
+    @test occursin("no spatial structure", sprint(show, model))
     model = ABM(Agent3, GridSpace((5,5)))
     @test sprint(show, model)[1:29] == "AgentBasedModel with 0 agents"
     @test sprint(show, model.space) == "GridSpace with size (5, 5), metric=chebyshev, periodic=true"


### PR DESCRIPTION
`random_empty` and kin require a full filter of the board each time they're called regardless of how sparse the agents are populating it. This PR provides us quite a noticeable performance enhancement using guesses, that we stop using once we start failing too much.

The core concept is a loop that gives us a `random_position` and returns it, otherwise tries again.
```julia
while true
    pos = random_position(model)
    isempty(pos, model) && return pos
end
```

Benchmarking on the maximum time of our current and this proposed solution, we can find the place where we guarantee chance will win out to filtering/collecting.

```julia
function rand_mt(model)
    has_empty_positions(model) || return nothing
    while true
        pos = random_position(model)
        if isempty(pos, model)
            return pos
        end
    end
end

julia> nagents(model)
249999

julia> prod(size(model.space))
250000

function run_test(model)
    while true
        println(nagents(model))
        curr = @benchmark random_empty($model)
        prop = @benchmark rand_mt($model)
        max_curr = maximum(curr.times)*1e-6 # ms
        max_prop = maximum(prop.times)*1e-6 # ms
        println("Current: $max_curr ms, Proposed: $max_prop ms")
        if max_prop < max_curr
            return nagents(model)/prod(size(model.space))
        end
        kill_agent!(random_agent(model), model)
    end
end
```

The changeover point is close to 0.999 (!) on this model, and as we go lower, as performance matters less, 0.998.. So we set our cutoff there and we can compare our standard Schelling benchmark (which needs random_empty):

Current (my machine): 13.783 ms
This PR (my machine): 2.771 ms

Speedup: 4.98x

Comparisons against other frameworks for Schelling (est, need to bump some changes here):
Mesa: 31.5x -> 156.9x
Netlogo: 8x -> 39.8x
MASON: 14.3x -> 71.1x