### PR TITLE
`move_along_route!` change, zombies update

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -111,7 +111,7 @@ OSM.lonlat
 OSM.intersection
 OSM.road
 OSM.random_road_position
-OSM.random_route!
+OSM.plan_random_route!
 OSM.road_length
 OSM.test_map
 OSM.download_osm_network

--- a/examples/zombies.jl
+++ b/examples/zombies.jl
@@ -52,7 +52,7 @@ function initialise(; seed = 1234)
         speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
         human = Zombie(id, start, false, speed)
         add_agent_pos!(human, model)
-        OSM.random_route!(human, model; limit = 50) # try 50 times to find a random route
+        OSM.plan_random_route!(human, model; limit = 50) # try 50 times to find a random route
     end
     ## We'll add patient zero at a specific (latitude, longitude)
     start = OSM.road((51.5328328, 9.9351811), model)
@@ -77,7 +77,7 @@ function agent_step!(agent, model)
 
     if is_stationary(agent, model) && rand(model.rng) < 0.1
         ## When stationary, give the agent a 10% chance of going somewhere else
-        OSM.random_route!(agent, model; limit = 50)
+        OSM.plan_random_route!(agent, model; limit = 50)
         ## Start on new route, moving the remaining distance
         move_along_route!(agent, model, distance_left)
     end

--- a/examples/zombies.jl
+++ b/examples/zombies.jl
@@ -71,13 +71,15 @@ end
 
 function agent_step!(agent, model)
     ## Each agent will progress along their route
-    move_along_route!(agent, model, agent.speed * model.dt)
+    ## Keep track of distance left to move this step, in case the agent reaches its
+    ## destination early
+    distance_left = move_along_route!(agent, model, agent.speed * model.dt)
 
     if is_stationary(agent, model) && rand(model.rng) < 0.1
         ## When stationary, give the agent a 10% chance of going somewhere else
         OSM.random_route!(agent, model; limit = 50)
-        ## Start on new route
-        move_along_route!(agent, model, agent.speed * model.dt)
+        ## Start on new route, moving the remaining distance
+        move_along_route!(agent, model, distance_left)
     end
 
     if agent.infected

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,1 @@
+@deprecate OSM.random_route! OSM.plan_random_route!

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,1 +1,1 @@
-@deprecate OSM.random_route! OSM.plan_random_route!
+# @deprecate OSM.random_route! OSM.plan_random_route!

--- a/src/models/zombies.jl
+++ b/src/models/zombies.jl
@@ -24,7 +24,7 @@ function zombies(; seed = 1234)
         speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
         human = Zombie(id, start, false, speed)
         add_agent_pos!(human, model)
-        OSM.random_route!(human, model; limit = 50) # try 50 times to find a random route
+        OSM.plan_random_route!(human, model; limit = 50) # try 50 times to find a random route
     end
     ## We'll add patient zero at a specific (latitude, longitude)
     start = OSM.road((51.5328328, 9.9351811), model)
@@ -43,7 +43,7 @@ function zombie_agent_step!(agent, model)
 
     if is_stationary(agent, model) && rand(model.rng) < 0.1
         ## When stationary, give the agent a 10% chance of going somewhere else
-        OSM.random_route!(agent, model; limit = 50)
+        OSM.plan_random_route!(agent, model; limit = 50)
         ## Start on new route
         move_along_route!(agent, model, agent.speed * model.dt)
     end

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -666,7 +666,7 @@ function Agents.move_agent!(
 end
 
 """
-    move_along_route!(agent, model::ABM{<:OpenStreetMapSpace}, distance::Real)
+    move_along_route!(agent, model::ABM{<:OpenStreetMapSpace}, distance::Real) -> remaining
 
 Move an agent by `distance` along its planned route. Units of distance are as specified
 by the underlying graph's weight_type. If the provided `distance` is greater than the

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -669,7 +669,8 @@ end
     move_along_route!(agent, model::ABM{<:OpenStreetMapSpace}, distance::Real)
 
 Move an agent by `distance` along its planned route. Units of distance are as specified
-by the underlying graph's weight_type.
+by the underlying graph's weight_type. If the provided `distance` is greater than the
+distance to the end of the route, return the remaining distance. Otherwise, return 0.
 """
 function Agents.move_along_route!(
     agent::A,
@@ -740,6 +741,8 @@ function Agents.move_along_route!(
             # ensure we don't overshoot the destination
             result_pos = min(agent.pos[3] + distance, osmpath.dest[3])
             move_agent!(agent, (agent.pos[1:2]..., result_pos), model)
+            # distance left to move is 0
+            distance = 0.0
             break
             ## return
         end
@@ -810,9 +813,13 @@ function Agents.move_along_route!(
         # will not overshoot
         result_pos = min(agent.pos[3] + distance, road_length(agent.pos, model))
         move_agent!(agent, (agent.pos[1:2]..., result_pos), model)
+        # distance left to move is 0
+        distance = 0.0
         ## return
         break
     end
+
+    return distance
 end
 
 # Nearby positions must be intersections, since edges imply a direction.

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -19,7 +19,7 @@ export test_map,
     plan_route!,
     distance,
     road_length,
-    random_route!,
+    plan_random_route!,
     lonlat,
     intersection,
     road,
@@ -97,7 +97,7 @@ Use [`OSMAgent`](@ref) for convenience.
 There are two ways to generate a route, depending on the situation.
 1. Use [`plan_route!`](@ref) to plan a route from an agent's current position to a target
    destination. This also has the option of planning a return trip.
-2. [`random_route!`](@ref), choses a new random destination and plans a path to it.
+2. [`plan_random_route!`](@ref), choses a new random destination and plans a path to it.
 
 Both of these functions override any pre-existing route that may exist for an agent.
 To actually move along a planned route use [`move_along_route!`](@ref).
@@ -159,7 +159,7 @@ function random_road_position(model::ABM{<:OpenStreetMapSpace})
 end
 
 """
-    OSM.random_route!(agent, model::ABM{<:OpenStreetMapSpace}; kwargs...)
+    OSM.plan_random_route!(agent, model::ABM{<:OpenStreetMapSpace}; kwargs...)
 
 Plan a new random route for the agent, by selecting a random destination and
 planning a route from the agent's current position. Overwrite any existing route.
@@ -168,7 +168,7 @@ The keyword `limit = 10` specifies the limit on the number of attempts at planni
 a random route. Returns `true` if a route was successfully planned, `false` otherwise.
 All other keywords are passed to [`plan_route!`](@ref)
 """
-function random_route!(
+function plan_random_route!(
     agent::A,
     model::ABM{<:OpenStreetMapSpace,A};
     return_trip = false,

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -88,6 +88,11 @@ using Graphs
     plan_route!(model[1], finish_i, model; return_trip = true)
     move_along_route!(model[1], model, 1e5)
     @test all(model[1].pos .≈ start_i)
+    @test plan_random_route!(model[1], model; limit = 100)
+    @test is_stationary(model[1], model)
+    move_along_route!(model[1], model, 1e5)
+    @test all(model[1].pos .!= start_i)
+
 
     # distance checks
     pos_1 = start_i[1]

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -88,8 +88,8 @@ using Graphs
     plan_route!(model[1], finish_i, model; return_trip = true)
     move_along_route!(model[1], model, 1e5)
     @test all(model[1].pos .≈ start_i)
-    @test plan_random_route!(model[1], model; limit = 100)
-    @test is_stationary(model[1], model)
+    @test OSM.plan_random_route!(model[1], model; limit = 100)
+    @test !is_stationary(model[1], model)
     move_along_route!(model[1], model, 1e5)
     @test all(model[1].pos .!= start_i)
 


### PR DESCRIPTION
Closes #449 

- `move_along_route!` returns the remaining distance left to move
- Update docstring accordingly
- Update zombies example accordingly