### PR TITLE
fix latitude and longitude of first zombie in zombie example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.1.1"
+version = "5.1.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/examples/zombies.jl
+++ b/examples/zombies.jl
@@ -55,9 +55,9 @@ function initialise(; seed = 1234)
         add_agent_pos!(human, model)
         OSM.plan_random_route!(human, model; limit = 50) # try 50 times to find a random route
     end
-    ## We'll add patient zero at a specific (latitude, longitude)
-    start = OSM.nearest_road((51.5328328, 9.9351811), model)
-    finish = OSM.nearest_node((51.530876112711745, 9.945125635913511), model)
+    ## We'll add patient zero at a specific (longitude, latitude)
+    start = OSM.nearest_road((9.9351811, 51.5328328), model)
+    finish = OSM.nearest_node((9.945125635913511, 51.530876112711745), model)
 
     speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
     zombie = add_agent!(start, model, true, speed)


### PR DESCRIPTION
Hello,
according to the zombie outbreak tutorial, OSM.nearest_road and OSM.nearest_node take a position in form of (latitude, longitude).

However, it seems to be the case that they actually take data in form of (longitude, latitude) (see docstrings of the functions as defined in openstreetmap.jl). Consequently, the video which is produced by the tutorial is different from what one would expect from the tutorial code. The zombie starts at the top left corner, while from (51.5328328, 9.9351811) one would expect the zombie to start on the right, if the format was (latitude, longitude).

The reason why I discovered this issue was because I wanted to let a zombie start from my house - I don't think I will be the last one to try this :D. 