### PR TITLE
Add docstring to AMB

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -22,6 +22,9 @@ struct AgentBasedModel{S<:SpaceType,A<:AbstractAgent,F,P,R<:AbstractRNG}
     maxid::Base.RefValue{Int64}
 end
 
+"""
+`ABM` is an alias for `AgentBasedModel`.
+"""
 const ABM = AgentBasedModel
 
 agenttype(::ABM{S,A}) where {S,A} = A


### PR DESCRIPTION
I saw `ABM` used in an example, so I checked its docstring, but I had to search the codebase for `const ABM =` to find its docstring. This should expedite that process.