### PR TITLE
simplify union_types and edit docstring

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -28,15 +28,11 @@ agenttype(::ABM{S,A}) where {S,A} = A
 spacetype(::ABM{S}) where {S} = S
 
 """
-    union_types(U)
-Return a set of types within a `Union`. Preserves order.
+    union_types(U::Type)
+Return a tuple of types within a `Union`.
 """
-union_types(x::Union) = union_types(x.a, x.b)
-union_types(a::Union, b::Type) = (union_types(a)..., b)
-union_types(a::Type, b::Type) = (a, b)
-union_types(x::Type) = (x,)
-# For completeness
-union_types(a::Type, b::Union) = (a, union_types(b)...)
+union_types(T::Type) = (T,)
+union_types(T::Union) = (union_types(T.a)..., union_types(T.b)...)
 
 """
     AgentBasedModel(AgentType [, space]; properties, kwargs...) → model


### PR DESCRIPTION
The code changes should be a no-op except for dropping support for the (now unused) two-argument version.

Docstring changes: 
1) The argument must be a type
2) The function returns a tuple, not a set
3) `Union`s don't have order. For example, 
```
julia> Agents.union_types(Union{Grass, Wolf, Sheep})
(Grass, Sheep, Wolf)
julia> Union{Grass, Wolf, Sheep} === Union{Grass, Sheep, Wolf}
true
```