### PR TITLE
Refactor schedulers, reduce allocations

### DIFF
--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -57,7 +57,7 @@ function initialize_model(;
     spacing = visual_distance / 1.5,
 )
     space2d = ContinuousSpace(extent, spacing)
-    model = ABM(Bird, space2d, scheduler = Schedulers.randomly)
+    model = ABM(Bird, space2d, scheduler = Schedulers.randomly())
     for _ in 1:n_birds
         vel = Tuple(rand(model.rng, 2) * 2 .- 1)
         add_agent!(

--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -97,7 +97,7 @@ function initialize(; numagents = 320, griddims = (20, 20), min_to_be_happy = 3,
     rng = Random.MersenneTwister(seed)
     model = ABM(
         SchellingAgent, space;
-        properties, rng, scheduler = Schedulers.randomly
+        properties, rng, scheduler = Schedulers.randomly()
     )
 
     ## populate the model with agents, adding equal amount of the two types of agents

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -243,7 +243,7 @@ e.g. `(agent1, agent7, agent8)`. `order` must be larger than `1` but has no uppe
 Index order is provided by the [`Schedulers.by_id`](@ref) scheduler by default, but can be altered
 with the `scheduler` keyword.
 """
-iter_agent_groups(order::Int, model::ABM; scheduler = Schedulers.by_id) =
+iter_agent_groups(order::Int, model::ABM; scheduler = Schedulers.by_id()) =
     Iterators.product((map(i -> model[i], scheduler(model)) for _ in 1:order)...)
 
 """
@@ -270,9 +270,9 @@ map_agent_groups(order::Int, f::Function, model::ABM, filter::Function; kwargs..
     index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler = Schedulers.by_id)
 Return an iterable of agent ids in the model, meeting the `filter` criterea if used.
 """
-index_mapped_groups(order::Int, model::ABM; scheduler = Schedulers.by_id) =
+index_mapped_groups(order::Int, model::ABM; scheduler = Schedulers.by_id()) =
     Iterators.product((scheduler(model) for _ in 1:order)...)
-index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler = Schedulers.by_id) =
+index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler = Schedulers.by_id()) =
     Iterators.filter(filter, Iterators.product((scheduler(model) for _ in 1:order)...))
 
 #######################################################################################

--- a/src/models/flocking.jl
+++ b/src/models/flocking.jl
@@ -37,7 +37,7 @@ function flocking(;
     spacing = visual_distance / 1.5,
 )
     space2d = ContinuousSpace(extent, spacing)
-    model = ABM(Bird, space2d, scheduler = Schedulers.randomly)
+    model = ABM(Bird, space2d, scheduler = Schedulers.randomly())
     for _ in 1:n_birds
         vel = Tuple(rand(model.rng, 2) * 2 .- 1)
         add_agent!(

--- a/src/models/schelling.jl
+++ b/src/models/schelling.jl
@@ -17,7 +17,7 @@ function schelling(; numagents = 320, griddims = (20, 20), min_to_be_happy = 3)
     @assert numagents < prod(griddims)
     space = GridSpace(griddims, periodic = false)
     properties = Dict(:min_to_be_happy => min_to_be_happy)
-    model = ABM(SchellingAgent, space; properties, scheduler = Schedulers.randomly)
+    model = ABM(SchellingAgent, space; properties, scheduler = Schedulers.randomly())
     for n in 1:numagents
         agent = SchellingAgent(n, (1, 1), false, n < numagents / 2 ? 1 : 2)
         add_agent_single!(agent, model)

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -26,13 +26,21 @@ Notice that schedulers can be given directly to model creation, and thus become 
 """
 module Schedulers
 using Agents
-using Random: shuffle!, randsubseq
+using Random: shuffle!, randsubseq!
 
 export randomly, by_id, fastest, partially, by_property, by_type
 
 ####################################
 # Schedulers
 ####################################
+
+function get_ids!(ids::Vector{Int}, model::ABM)
+    resize!(ids, nagents(model))
+    for (i, id) in enumerate(keys(model.agents))
+        ids[i] = id
+    end
+end
+
 """
     Schedulers.fastest
 A scheduler that activates all agents once per step in the order dictated by the
@@ -45,9 +53,15 @@ fastest(model::ABM) = keys(model.agents)
     Schedulers.by_id
 A scheduler that activates all agents agents at each step according to their id.
 """
-function by_id(model::ABM)
-    agent_ids = sort(collect(keys(model.agents)))
-    return agent_ids
+struct by_id
+    ids::Vector{Int}
+end
+
+by_id() = by_id(Int[])
+
+function (sched::by_id)(model::ABM)
+    get_ids!(sched.ids, model)
+    sort!(sched.ids)
 end
 
 """
@@ -55,20 +69,31 @@ end
 A scheduler that activates all agents once per step in a random order.
 Different random ordering is used at each different step.
 """
-function randomly(model::ABM)
-    order = shuffle!(model.rng, collect(keys(model.agents)))
+struct randomly
+    ids::Vector{Int}
+end
+
+randomly() = randomly(Int[])
+function (sched::randomly)(model::ABM)
+    get_ids!(sched.ids, model)
+    shuffle!(model.rng, sched.ids)
 end
 
 """
     Schedulers.partially(p)
 A scheduler that at each step activates only `p` percentage of randomly chosen agents.
 """
-function partially(p::Real)
-    function partial(model::ABM)
-        ids = collect(keys(model.agents))
-        return randsubseq(model.rng, ids, p)
-    end
-    return partial
+struct partially{R<:Real}
+    p::R
+    all_ids::Vector{Int}
+    schedule::Vector{Int}
+end
+
+partially(p::R) where {R<:Real} = partially{R}(p, Int[], Int[])
+
+function (sched::partially)(model::ABM)
+    get_ids!(sched.all_ids, model)
+    randsubseq!(model.rng, sched.schedule, sched.all_ids, sched.p)
 end
 
 
@@ -79,40 +104,58 @@ with agents with greater `property` acting first. `property` can be a `Symbol`, 
 just dictates which field of the agents to compare, or a function which inputs an agent
 and outputs a real number.
 """
-function by_property(p)
-    function property(model::ABM)
-        ids = collect(keys(model.agents))
-        properties = [Agents.get_data(model[id], p) for id in ids]
-        s = sortperm(properties)
-        return ids[s]
+struct by_property{P}
+    p::P
+    properties::Vector{Float64} # TODO: don't assume Float64
+    ids::Vector{Int}
+    perm::Vector{Int}
+end
+
+by_property(p::P) where {P} = by_property{P}(p, Float64[], Int[], Int[])
+
+function (sched::by_property)(model::ABM)
+    get_ids!(sched.ids, model)
+    resize!(sched.properties, length(sched.ids))
+
+    for (i, id) in enumerate(sched.ids)
+        sched.properties[i] = Agents.get_data(model[id], sched.p)
     end
+
+    initialized = true
+    if length(sched.perm) != length(sched.ids)
+        resize!(sched.perm, length(sched.ids))
+        initialized = false
+    end
+
+    sortperm!(sched.perm, sched.properties; initialized)
+    return Iterators.map(i -> sched.ids[i], sched.perm)
 end
 
 
+
+struct by_type
+    shuffle_types::Bool
+    shuffle_agents::Bool
+    type_inds::Dict{DataType,Int}
+    ids::Vector{Vector{Int}}
+end
+
 """
-    Schedulers.by_type(shuffle_types::Bool, shuffle_agents::Bool)
-A scheduler useful only for mixed agent models using `Union` types.
+    Schedulers.by_type(shuffle_types::Bool, shuffle_agents::Bool, agent_union)
+A scheduler useful only for mixed agent models using `Union` types (`agent_union`).
 - Setting `shuffle_types = true` groups by agent type, but randomizes the type order.
 Otherwise returns agents grouped in order of appearance in the `Union`.
 - `shuffle_agents = true` randomizes the order of agents within each group, `false` returns
 the default order of the container (equivalent to [`Schedulers.fastest`](@ref)).
 """
-function by_type(shuffle_types::Bool, shuffle_agents::Bool)
-    function by_union(model::ABM{S,A}) where {S,A}
-        types = Agents.union_types(A)
-        sets = [Integer[] for _ in types]
-        for agent in allagents(model)
-            idx = findfirst(t -> t == typeof(agent), types)
-            push!(sets[idx], agent.id)
-        end
-        shuffle_types && shuffle!(model.rng, sets)
-        if shuffle_agents
-            for set in sets
-                shuffle!(model.rng, set)
-            end
-        end
-        vcat(sets...)
-    end
+function by_type(shuffle_types::Bool, shuffle_agents::Bool, agent_union)
+    types = Agents.union_types(agent_union)
+    return by_type(
+        shuffle_types,
+        shuffle_agents,
+        Dict(t => i for (i, t) in enumerate(types)),
+        [Int[] for _ in 1:length(types)]
+    )
 end
 
 """
@@ -121,24 +164,32 @@ A scheduler that activates agents by type in specified order (since `Union`s are
 preserving). `shuffle_agents = true` randomizes the order of agents within each group.
 """
 function by_type(order::Tuple{Type,Vararg{Type}}, shuffle_agents::Bool)
-    function by_ordered_union(model::ABM{S,A}) where {S,A}
-        types = Agents.union_types(A)
-        if order !== nothing
-            @assert length(types) == length(order) "Invalid dimension for `order`"
-            types = order
-        end
-        sets = [Integer[] for _ in types]
-        for agent in allagents(model)
-            idx = findfirst(t -> t == typeof(agent), types)
-            push!(sets[idx], agent.id)
-        end
-        if shuffle_agents
-            for set in sets
-                shuffle!(model.rng, set)
-            end
-        end
-        vcat(sets...)
+    return by_type(
+        false,
+        shuffle_agents,
+        Dict(t => i for (i, t) in enumerate(order)),
+        [Int[] for _ in 1:length(order)]
+    )
+end
+
+function (sched::by_type)(model::ABM)
+    for i in 1:length(sched.ids)
+        empty!(sched.ids[i])
     end
+
+    for agent in allagents(model)
+        push!(sched.ids[sched.type_inds[typeof(agent)]], agent.id)
+    end
+    
+    sched.shuffle_types && shuffle!(model.rng, sched.ids)
+
+    if sched.shuffle_agents
+        for i in 1:length(sched.ids)
+            shuffle!(model.rng, sched.ids[i])
+        end
+    end
+
+    return Iterators.flatten(it for it in sched.ids)
 end
 
 end # Schedulers submodule

--- a/test/continuousSpace_tests.jl
+++ b/test/continuousSpace_tests.jl
@@ -102,7 +102,7 @@ end
   @test (3, 6) ∉ pairs
 
   space2 = ContinuousSpace((10, 10), 0.1,periodic = false)
-  model2 = ABM(Agent6, space2; scheduler = Schedulers.by_id)
+  model2 = ABM(Agent6, space2; scheduler = Schedulers.by_id())
   for i in 1:4
     add_agent_pos!(Agent6(i, pos[i], (0.0, 0.0), 0), model2)
   end

--- a/test/jld2_tests.jl
+++ b/test/jld2_tests.jl
@@ -1,7 +1,7 @@
 @testset "JLD2" begin
 
     function test_model_data(model, other)
-        @test model.scheduler == other.scheduler
+        @test (model.scheduler isa Schedulers.AbstractScheduler && typeof(model.scheduler) == typeof(other.scheduler)) || model.scheduler == other.scheduler
         @test model.rng == other.rng
         @test model.maxid.x == other.maxid.x
     end
@@ -90,7 +90,7 @@
         model, astep, mstep = Models.schelling()
         step!(model, astep, mstep, 50)
         AgentsIO.save_checkpoint("test.jld2", model)
-        other = AgentsIO.load_checkpoint("test.jld2"; scheduler = Schedulers.randomly)
+        other = AgentsIO.load_checkpoint("test.jld2"; scheduler = Schedulers.randomly())
 
         # agent data
         @test nagents(other) == nagents(model)
@@ -112,7 +112,7 @@
         model, astep, mstep = Models.flocking(n_birds = 300)
         step!(model, astep, mstep, 100)
         AgentsIO.save_checkpoint("test.jld2", model)
-        other = AgentsIO.load_checkpoint("test.jld2"; scheduler = Schedulers.randomly)
+        other = AgentsIO.load_checkpoint("test.jld2"; scheduler = Schedulers.randomly())
 
         # agent data
         @test nagents(other) == nagents(model)

--- a/test/scheduler_tests.jl
+++ b/test/scheduler_tests.jl
@@ -4,7 +4,7 @@
     N = 1000
 
     # Schedulers.by_id
-    model = ABM(Agent0; scheduler = Schedulers.by_id)
+    model = ABM(Agent0; scheduler = Schedulers.by_id())
     for i in 1:N
         add_agent!(model)
     end
@@ -20,7 +20,7 @@
     @test sort!(collect(model.scheduler(model))) == 1:N
 
     # random
-    model = ABM(Agent0; scheduler = Schedulers.randomly, rng = StableRNG(12))
+    model = ABM(Agent0; scheduler = Schedulers.randomly(), rng = StableRNG(12))
     for i in 1:N
         add_agent!(model)
     end
@@ -48,7 +48,7 @@
     ids = collect(keys(model.agents))
     properties = [model.agents[id].weight for id in ids]
 
-    @test ids[sortperm(properties)] == a
+    @test ids[sortperm(properties)] == collect(a)
 end
 
 @testset "Union Types" begin
@@ -97,9 +97,10 @@ end
 
     # shuffling types scheduler
     Random.seed!(12)
-    model = init_mixed_model(scheduler = Schedulers.by_type(true, false))
+    model = init_mixed_model(scheduler = Schedulers.by_type(true, false, Union{Agent0,Agent1,Agent2,Agent3}))
     s1 = model.scheduler(model)
     s2 = model.scheduler(model)
+    
     @test unique([typeof(model[id]) for id in s1]) != unique([typeof(model[id]) for id in s2])
     @test count(model[id] isa Agent2 for id in model.scheduler(model)) == 3
     c = begin
@@ -113,16 +114,16 @@ end
 
     # NOT shuffling types scheduler
     Random.seed!(12)
-    model = init_mixed_model(scheduler = Schedulers.by_type(false, false))
+    model = init_mixed_model(scheduler = Schedulers.by_type(false, false, Union{Agent0,Agent1,Agent2,Agent3}))
     s1 = model.scheduler(model)
     s2 = model.scheduler(model)
     @test unique([typeof(model[id]) for id in s1]) == unique([typeof(model[id]) for id in s2])
 
     # Not shuffling types, but shuffling agents
     Random.seed!(12)
-    model = init_mixed_model(scheduler = Schedulers.by_type(false, true))
-    s1 = model.scheduler(model)
-    s2 = model.scheduler(model)
+    model = init_mixed_model(scheduler = Schedulers.by_type(false, true, Union{Agent0,Agent1,Agent2,Agent3}))
+    s1 = collect(model.scheduler(model))
+    s2 = collect(model.scheduler(model))
     @test [typeof(model[id]) for id in s1] == [typeof(model[id]) for id in s2]
     # here we actually check whether agents of same type are shuffled
     @test model[s1[1]].id ≠ model[s2[1]] || model[s1[2]].id ≠ model[s2[2]]
@@ -139,7 +140,7 @@ end
         a0 = Agent0(id)
         add_agent!(a0, model)
     end
-    s = model.scheduler(model)
+    s = collect(model.scheduler(model))
     @test [typeof(model[id]) for id in s] ==
           [Agent1, Agent1, Agent1, Agent0, Agent0, Agent0]
     @test all(x -> x < 4, s[1:3])


### PR DESCRIPTION
Closes #581 

- [x] turn schedulers into function-like objects
- [ ] update docs
- [x] update examples
- [ ] update tests
- [ ] Update models

So far I've chosen to keep the names of the schedulers the same, which isn't the best practice for code style but would require less API changes. `by_type` now also takes the type-union in the constructor.

There's some weird behaviour with `by_type` where `shuffle_types` only works if you `collect` the output of the iterator, I'm not really sure why. Adding `print` statements before and after the `shuffle!` line shows that it works, but the test doesn't pass.