### PR TITLE
Roll back version once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
-# v5.4
-- New keyword `showprogress` in `run!` function that displays a progress bar.
-
 # v5.3
+- New keyword `showprogress` in `run!` function that displays a progress bar.
 - Rework schedulers to prefer returning iterators over arrays, resulting in fewer allocations and improved performance. Most scheduler names are now types instead of functions:
   - `Schedulers.by_id` is now `Schedulers.ByID`
   - `Schedulers.randomly` is now `Schedulers.Randomly`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.4.0"
+version = "5.3.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"


### PR DESCRIPTION
I just noticed 5.3 was never tagged, so there's no point in rolling out 5.4 now. I've merged the changelog for both, and after this PR I'll tag it.