### PR TITLE
Allow writing data during `run!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ julia = "1.5"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 
 [targets]
-test = ["Test", "BenchmarkTools", "StableRNGs"]
+test = ["Test", "BenchmarkTools", "StableRNGs", "CSV"]

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -5,6 +5,7 @@ using Distributed
 using DataStructures
 using Graphs
 using DataFrames
+using CSV
 using Random
 import ProgressMeter
 import Base.length

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -199,6 +199,31 @@
             mdata = [(m) -> (m.deep.data[i]) for i in 1:length(model.deep.data)],
         )
         @test Array{Float64,1}(model_data[1, 2:end]) == model.deep.data
+
+        @testset "Writing to file while running" begin
+
+            agent_data, model_data = run!(
+                model,
+                agent_step!,
+                model_step!,
+                365 * 5;
+                when_model=each_year,
+                when=six_months,
+                mdata=[:flag, :year],
+                adata=[(:weight, mean)],
+                write_during_run=true,
+                writing_interval=3
+            )
+
+            adata_saved = CSV.read("adata.csv", DataFrame)
+            @test size(adata_saved) == (11, 2)
+            @test propertynames(adata_saved) == [:step, :mean_weight]
+            
+            mdata_saved = CSV.read("mdata.csv", DataFrame)
+            @test size(mdata_saved) == (6, 3)
+            @test propertynames(mdata_saved) == [:step, :flag, :year]
+
+        end
     end
 
     @testset "Low-level API for Collections" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Agents, Random, Graphs, DataFrames
+using Test, Agents, Random, Graphs, DataFrames, CSV
 using StatsBase:mean
 using StableRNGs
 


### PR DESCRIPTION
Adds an option to `run!` so that collected data can be written to file during the simulation. It is useful when collected data are too large to fit the memory by the end of the simulation. 