### PR TITLE
Add `:manhattan` metric and `manhattan_distance` utility function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Manifest.toml
 *.osm.cache
 src/update_*
 agents_visualizations.md
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v5.4
 - New keyword `showprogress` in `run!` function that displays a progress bar.
+- New `:manhattan` metric for `GridSpace` models.
+- New `manhattan_distance` utility function.
 
 # v5.3
 - Rework schedulers to prefer returning iterators over arrays, resulting in fewer allocations and improved performance. Most scheduler names are now types instead of functions:

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -125,7 +125,8 @@ nearby_agents
 nearby_positions
 random_nearby_id
 random_nearby_agent
-edistance
+euclidean_distance
+manhattan_distance
 ```
 
 ## A note on iteration

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,6 +34,11 @@ GraphSpace
 GridSpace
 ```
 
+Here is a specification of how the metrics look like:
+```@example
+include("distances_example_plot.jl") # hide
+```
+
 ### Continuous spaces
 ```@docs
 ContinuousSpace

--- a/docs/src/distances_example_plot.jl
+++ b/docs/src/distances_example_plot.jl
@@ -1,0 +1,46 @@
+using CairoMakie
+fig = Figure(resolution = (850, 300))
+
+function circle!(ax, r, color, distance)
+    if distance == :euclidean
+        θ = 0:0.01:2π
+        lines!(ax, r .* cos.(θ), r .* sin.(θ); color)
+    elseif distance == :chebyshev
+        lines!(ax, [-r, -r], [-r, r]; color)
+        lines!(ax, [-r, r], [r, r]; color)
+        lines!(ax, [r, r], [r, -r]; color)
+        lines!(ax, [-r, r], [-r, -r]; color)
+    elseif distance == :manhattan
+        lines!(ax, [-r, 0], [0, r]; color)
+        lines!(ax, [0, r], [r, 0]; color)
+        lines!(ax, [r, 0], [0, -r]; color)
+        lines!(ax, [0, -r], [-r, 0]; color)
+    end
+end
+
+function scatter_dots!(ax, r)
+    r0 = ceil(r)
+    X = -r0:r0
+    points = [Point2f(x, y) for x in X for y in X]
+    scatter!(ax, points; color = :black)
+end
+
+rs = [1, 2, 3.4]
+colors = [:blue, :red, :orange]
+
+for (i, distance) in enumerate((:euclidean, :chebyshev, :manhattan))
+    ax = Axis(fig[1, i]; title = string(distance))
+    scatter_dots!(ax, maximum(rs))
+    for (j, r) in enumerate(rs)
+        label = j == i ? "r = $(r)" : ""
+        circle!(ax, r, colors[j], distance)
+    end
+    ax.xticks = ax.yticks = -4:2:4
+    i > 1 && hideydecorations!(ax; grid = false)
+end
+
+elems = [LineElement(color = c, linestyle = nothing) for c in colors]
+
+fig[1, 4] = Legend(fig[1,4], elems, string.(rs), "radius", framevisible = false)
+
+fig

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -91,7 +91,7 @@ function agent_step!(bird, model)
 
         ## `cohere` computes the average position of neighboring birds
         cohere = cohere .+ heading
-        if edistance(bird.pos, neighbor, model) < bird.separation
+        if euclidean_distance(bird.pos, neighbor, model) < bird.separation
             ## `separate` repels the bird away from neighboring birds
             separate = separate .- heading
         end

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -63,21 +63,20 @@ remove_agent_from_space!(agent, model) = notimplemented(model)
 """
     nearby_ids(position, model::ABM, r; kwargs...) → ids
 
-Return an iterable of the ids of the agents within "radius" `r` of the given `position`
-(which must match type with the spatial structure of the `model`)
+Return an iterable of the ids of the agents within radius `r` (inclusive) of the given
+`position`. The `position` must match type with the spatial structure of the `model`.
 
 What the "radius" means depends on the space type:
 - `GraphSpace`: the degree of neighbors in the graph (thus `r` is always an integer),
   always including ids of the same node as `position`.
   For example, for `r=2` include first and second degree neighbors.
   If `r=0`, only ids in the same node as `position` are returned.
-- `GridSpace`: Either Chebyshev (also called Moore) or Euclidean distance,
-  in the space of cartesian indices.
-- `GridSpace` can also take a tuple argument, e.g. `r = (5, 2)` for a 2D space, which
-  extends 5 positions in the x direction and 2 in the y. Only possible with Chebyshev
-  spaces. This can be useful when different coordinates in the space need to be searched
+- `GridSpace`: Distance of position indices according to the space metric.
+- `GridSpace` can also take a tuple argument, e.g. `r = (5, 2)` for a 2D space, meaning
+  a distance of 5 in the x direction and 2 in the y. Only possible with `:chebyshev`
+  metric. This can be useful when different coordinates in the space need to be searched
   with different ranges, e.g., if the space corresponds to a full building, with the
-  third dimension the floor number. See also the 
+  third dimension the floor number. See also the
   [Battle Royale](https://juliadynamics.github.io/AgentsExampleZoo.jl/dev/examples/battle/)
   for advanced usage where one dimension is used as a categorical one.
 - `ContinuousSpace`: Standard distance according to the space metric.
@@ -383,7 +382,7 @@ function random_nearby_id(a, model, r = 1; kwargs...)
 
     choice, state = res         # random ID to return, and the state of the iterator
     w = max(rand(model.rng), eps())  # rand returns in range [0,1)
-    
+
     skip_counter = 0            # skip entries in the iterator
     while !isnothing(state) && !isnothing(iter)
         res = iterate(iter, state)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,3 @@
 # Some deprecations exist in submodules Pathfinding, OSM
 
-@deprecate edistance euclidean_distance
+@deprecate euclidean_distance euclidean_distance

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,1 +1,3 @@
 # Some deprecations exist in submodules Pathfinding, OSM
+
+@deprecate edistance euclidean_distance

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,3 @@
 # Some deprecations exist in submodules Pathfinding, OSM
 
-@deprecate euclidean_distance euclidean_distance
+@deprecate edistance euclidean_distance

--- a/src/models/flocking.jl
+++ b/src/models/flocking.jl
@@ -63,7 +63,7 @@ function flocking_agent_step!(bird, model)
         neighbor = model[id].pos
         heading = neighbor .- bird.pos
         cohere = cohere .+ heading
-        if edistance(bird.pos, neighbor, model) < bird.separation
+        if euclidean_distance(bird.pos, neighbor, model) < bird.separation
             separate = separate .- heading
         end
         match = match .+ model[id].vel

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -148,14 +148,14 @@ function nearby_ids(
                 Iterators.flatten(ids_in_position(cell, model) for cell in uncertain_cells)
 
             additional_ids = Iterators.filter(
-                i -> edistance(pos, model[i].pos, model) ≤ r,
+                i -> euclidean_distance(pos, model[i].pos, model) ≤ r,
                 uncertain_ids,
             )
 
             return Iterators.flatten((certain_ids, additional_ids))
         else
             all_ids = Iterators.flatten(ids_in_position(cell, model) for cell in allcells)
-            return Iterators.filter(i -> edistance(pos, model[i].pos, model) ≤ r, all_ids)
+            return Iterators.filter(i -> euclidean_distance(pos, model[i].pos, model) ≤ r, all_ids)
         end
     else
         δ = distance_from_cell_center(pos, cell_center(pos, model))
@@ -219,7 +219,7 @@ function nearest_neighbor(
     length(n) == 0 && return nothing
     d, j = Inf, 1
     for i in 1:length(n)
-        @inbounds dnew = edistance(agent.pos, model[n[i]].pos, model)
+        @inbounds dnew = euclidean_distance(agent.pos, model[n[i]].pos, model)
         if dnew < d
             d, j = dnew, i
         end
@@ -355,7 +355,7 @@ function true_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM{<:ContinuousSpace
             # We also need to check if our current pair is closer to each
             # other than any pair using our first id already in the list,
             # so we keep track of nn distances.
-            dist = edistance(a.pos, nn.pos, model)
+            dist = euclidean_distance(a.pos, nn.pos, model)
 
             idx = findfirst(x -> first(new_pair) == x, first.(pairs))
             if idx === nothing

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -37,6 +37,10 @@ Valid positions have indices in the range `1:d[i]` for the `i`th dimension.
 positions within the hypercube having side length of `2*floor(r)` and being centered in
 the origin position.
 
+`:manhattan` metric means that the `r`-neighborhood of a position are all positions whose 
+cartesian indices have Manhattan distance `≤ r` from the cartesian index of the given 
+position.
+
 `:euclidean` metric means that the `r`-neighborhood of a position are all positions whose
 cartesian indices have Euclidean distance `≤ r` from the cartesian index of the given
 position.

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -118,11 +118,14 @@ end
 function initialize_neighborhood!(space::GridSpace{D}, r::Real) where {D}
     d = size(space.s)
     r0 = floor(Int, r)
-    if space.metric in (:euclidean, :manhattan)
+    if space.metric == :euclidean
         # hypercube of indices
         hypercube = CartesianIndices((repeat([(-r0):r0], D)...,))
         # select subset of hc which is in Hypersphere
         βs = [β for β ∈ hypercube if LinearAlgebra.norm(β.I) ≤ r]
+    elseif space.metric == :manhattan
+        hypercube = CartesianIndices((repeat([(-r0):r0], D)...,))
+        βs = [β for β ∈ hypercube if sum(abs.(β.I)) <= r0]
     elseif space.metric == :chebyshev
         βs = vec([CartesianIndex(a) for a in Iterators.product([(-r0):r0 for φ in 1:D]...)])
     else

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -118,7 +118,7 @@ end
 function initialize_neighborhood!(space::GridSpace{D}, r::Real) where {D}
     d = size(space.s)
     r0 = floor(Int, r)
-    if space.metric == :euclidean
+    if space.metric in (:euclidean, :manhattan)
         # hypercube of indices
         hypercube = CartesianIndices((repeat([(-r0):r0], D)...,))
         # select subset of hc which is in Hypersphere
@@ -135,7 +135,7 @@ function initialize_neighborhood!(space::GridSpace{D}, r::Real) where {D}
 end
 
 function initialize_neighborhood!(space::GridSpace{D}, r::NTuple{D,Real}) where {D}
-    @assert space.metric == :chebyshev "Cannot use tuple based neighbor search with the Euclidean metric."
+    @assert space.metric == :chebyshev "Can only use tuple based neighbor search with the Chebyshev metric."
     d = size(space.s)
     r0 = (floor(Int, i) for i in r)
     βs = vec([CartesianIndex(a) for a in Iterators.product([(-ri):ri for ri in r0]...)])

--- a/src/spaces/grid.jl
+++ b/src/spaces/grid.jl
@@ -27,23 +27,32 @@ end
 """
     GridSpace(d::NTuple{D, Int}; periodic = true, metric = :chebyshev)
 Create a `GridSpace` that has size given by the tuple `d`, having `D ≥ 1` dimensions.
-Optionally decide whether the space will be periodic and what will be the distance metric
-used, which decides the behavior of e.g. [`nearby_ids`](@ref).
+Optionally decide whether the space will be periodic and what will be the distance metric.
 The position type for this space is `NTuple{D, Int}`, use [`GridAgent`](@ref) for convenience.
-In our examples we typically use `Dims{D}` instead of `NTuple{D, Int}` (they are equivalent).
-Valid positions have indices in the range `1:d[i]` for the `i`th dimension.
+Valid positions have indices in the range `1:d[i]` for the `i`-th dimension.
 
-`:chebyshev` metric means that the `r`-neighborhood of a position are all
-positions within the hypercube having side length of `2*floor(r)` and being centered in
-the origin position.
+## Distance metric
+The typical terminology when searching neighbors in agent based modelling is
+"Von Neumann" neighborhood or "Moore" neighborhoods. However, because Agents.jl
+provides a much more powerful infastructure for finding neighbors, both in
+arbitrary dimensions but also of arbitrary neighborhood size, this established
+terminology is no longer appropriate.
+Instead, distances that define neighborhoods are specified according to a proper metric
+space, that is both well defined for any distance, and applicable to any dimensionality.
 
-`:manhattan` metric means that the `r`-neighborhood of a position are all positions whose 
-cartesian indices have Manhattan distance `≤ r` from the cartesian index of the given 
-position.
+The allowed metrics are (and see docs online for a plotted example):
 
-`:euclidean` metric means that the `r`-neighborhood of a position are all positions whose
-cartesian indices have Euclidean distance `≤ r` from the cartesian index of the given
-position.
+- `:chebyshev` metric means that the `r`-neighborhood of a position are all
+  positions within the hypercube having side length of `2*floor(r)` and being centered in
+  the origin position. This is similar to "Moore" for `r = 1` and two dimensions.
+
+- `:manhattan` metric means that the `r`-neighborhood of a position are all positions whose
+  cartesian indices have Manhattan distance `≤ r` from the cartesian index of the given
+  position. This similar to "Von Neumann" for `r = 1` and two dimensions.
+
+- `:euclidean` metric means that the `r`-neighborhood of a position are all positions whose
+  cartesian indices have Euclidean distance `≤ r` from the cartesian index of the given
+  position.
 
 An example using `GridSpace` is [Schelling's segregation model](@ref).
 """

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -1,10 +1,10 @@
-export edistance, mdistance, get_direction, walk!
+export euclidean_distance, manhattan_distance, get_direction, walk!
 
 #######################################################################################
 # %% Distances and directions in Grid/Continuous space
 #######################################################################################
 """
-    edistance(a, b, model::ABM)
+    euclidean_distance(a, b, model::ABM)
 
 Return the euclidean distance between `a` and `b` (either agents or agent positions),
 respecting periodic boundary conditions (if in use). Works with any space where it makes
@@ -12,13 +12,13 @@ sense: currently `GridSpace` and `ContinuousSpace`.
 
 Example usage in the [Flocking model](@ref).
 """
-edistance(
+euclidean_distance(
     a::A,
     b::B,
     model::ABM{<:Union{ContinuousSpace,GridSpace}},
-) where {A <: AbstractAgent,B <: AbstractAgent} = edistance(a.pos, b.pos, model)
+) where {A <: AbstractAgent,B <: AbstractAgent} = euclidean_distance(a.pos, b.pos, model)
 
-function edistance(
+function euclidean_distance(
     p1::ValidPos,
     p2::ValidPos,
     model::ABM{<:Union{ContinuousSpace{D,false},GridSpace{D,false}}},
@@ -26,7 +26,7 @@ function edistance(
     sqrt(sum(abs2.(p1 .- p2)))
 end
 
-function edistance(
+function euclidean_distance(
     p1::ValidPos,
     p2::ValidPos,
     model::ABM{<:ContinuousSpace{D,true}},
@@ -42,7 +42,7 @@ function edistance(
     sqrt(total)
 end
 
-function edistance(p1::ValidPos, p2::ValidPos, model::ABM{<:GridSpace{D,true}}) where {D}
+function euclidean_distance(p1::ValidPos, p2::ValidPos, model::ABM{<:GridSpace{D,true}}) where {D}
     total = 0.0
     for (a, b, d) in zip(p1, p2, size(model.space))
         delta = abs(b - a)
@@ -55,19 +55,19 @@ function edistance(p1::ValidPos, p2::ValidPos, model::ABM{<:GridSpace{D,true}}) 
 end
 
 """
-    mdistance(a, b, model::ABM)
+    manhattan_distance(a, b, model::ABM)
 
 Return the manhattan distance between `a` and `b` (either agents or agent positions),
 respecting periodic boundary conditions (if in use). Works with any space where it makes
 sense: currently `GridSpace` and `ContinuousSpace`.
 """
-mdistance(
+manhattan_distance(
     a::A,
     b::B,
     model::ABM{<:Union{ContinuousSpace,GridSpace}},
-) where {A <: AbstractAgent,B <: AbstractAgent} = mdistance(a.pos, b.pos, model)
+) where {A <: AbstractAgent,B <: AbstractAgent} = manhattan_distance(a.pos, b.pos, model)
 
-function mdistance(
+function manhattan_distance(
     p1::ValidPos,
     p2::ValidPos,
     model::ABM{<:Union{ContinuousSpace{D,false},GridSpace{D,false}}},
@@ -75,7 +75,7 @@ function mdistance(
     sum(abs.(p1 .- p2))
 end
 
-function mdistance(
+function manhattan_distance(
     p1::ValidPos,
     p2::ValidPos,
     model::ABM{<:Union{ContinuousSpace{D,true},GridSpace{D,true}}}

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -1,4 +1,4 @@
-export edistance, get_direction, walk!
+export edistance, mdistance, get_direction, walk!
 
 #######################################################################################
 # %% Distances and directions in Grid/Continuous space
@@ -19,11 +19,11 @@ edistance(
 ) where {A <: AbstractAgent,B <: AbstractAgent} = edistance(a.pos, b.pos, model)
 
 function edistance(
-    a::ValidPos,
-    b::ValidPos,
+    p1::ValidPos,
+    p2::ValidPos,
     model::ABM{<:Union{ContinuousSpace{D,false},GridSpace{D,false}}},
 ) where {D}
-    sqrt(sum(abs2.(a .- b)))
+    sqrt(sum(abs2.(p1 .- p2)))
 end
 
 function edistance(
@@ -52,6 +52,41 @@ function edistance(p1::ValidPos, p2::ValidPos, model::ABM{<:GridSpace{D,true}}) 
         total += delta^2
     end
     sqrt(total)
+end
+
+"""
+    mdistance(a, b, model::ABM)
+
+Return the manhattan distance between `a` and `b` (either agents or agent positions),
+respecting periodic boundary conditions (if in use). Works with any space where it makes
+sense: currently `GridSpace` and `ContinuousSpace`.
+"""
+mdistance(
+    a::A,
+    b::B,
+    model::ABM{<:Union{ContinuousSpace,GridSpace}},
+) where {A <: AbstractAgent,B <: AbstractAgent} = mdistance(a.pos, b.pos, model)
+
+function mdistance(
+    p1::ValidPos,
+    p2::ValidPos,
+    model::ABM{<:Union{ContinuousSpace{D,false},GridSpace{D,false}}},
+) where {D}
+    sum(abs.(p1 .- p2))
+end
+
+function mdistance(
+    p1::ValidPos,
+    p2::ValidPos,
+    model::ABM{<:Union{ContinuousSpace{D,true},GridSpace{D,true}}}
+) where {D}
+    total = 0.0
+    # find minimum distance for each dimension, add to total
+    for dim in 1:D
+        direct = abs(p1[dim] - p2[dim])
+        total += min(size(model.space)[dim] - direct, direct)
+    end
+    return total
 end
 
 """

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -124,7 +124,7 @@ function Agents.move_along_route!(
         dir = dir ./ dist_to_target
         next_pos = from .+ dir .* (speed * dt)
         # overshooting means we reached the waypoint
-        dist_to_next = edistance(from, next_pos, model)
+        dist_to_next = euclidean_distance(from, next_pos, model)
         if dist_to_next > dist_to_target
             # change from and dt so it appears we're coming from the waypoint just skipped, instead
             # of directly where the agent was. E.g:
@@ -198,7 +198,7 @@ function random_walkable(
     half_cell_size = model.space.extent ./ size(pathfinder.walkmap) ./ 2.
     cts_rand = to_continuous_position(discrete_rand, pathfinder) .+
         Tuple(rand(model.rng, D) .- 0.5) .* half_cell_size
-    dist = edistance(pos, cts_rand, model)
+    dist = euclidean_distance(pos, cts_rand, model)
     dist > r && (cts_rand = mod1.(
         pos .+ get_direction(pos, cts_rand, model) ./ dist .* r,
         model.space.extent

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -120,7 +120,7 @@
         model.pf.walkmap[:, 3] .= 0
         @test all(get_spatial_property(random_walkable(model, model.pf), model.pf.walkmap, model) for _ in 1:10)
         rpos = [random_walkable((2.5, 0.75), model, model.pf, 2.0) for _ in 1:50]
-        @test all(get_spatial_property(x, model.pf.walkmap, model) && edistance(x, (2.5, 0.75), model) <= 2.0 + atol for x in rpos)
+        @test all(get_spatial_property(x, model.pf.walkmap, model) && euclidean_distance(x, (2.5, 0.75), model) <= 2.0 + atol for x in rpos)
 
         pcspace = ContinuousSpace((5., 5.); periodic = false)
         pathfinder = AStar(pcspace; walkmap = trues(10, 10))
@@ -146,7 +146,7 @@
 
         @test all(get_spatial_property(random_walkable(model, model.pf), model.pf.walkmap, model) for _ in 1:10)
         rpos = [random_walkable((2.5, 0.75), model, model.pf, 2.0) for _ in 1:50]
-        @test all(get_spatial_property(x, model.pf.walkmap, model) && edistance(x, (2.5, 0.75), model) <= 2.0 + atol for x in rpos)
+        @test all(get_spatial_property(x, model.pf.walkmap, model) && euclidean_distance(x, (2.5, 0.75), model) <= 2.0 + atol for x in rpos)
     end
 
     @testset "metrics" begin

--- a/test/performance/branching_faster_than_dispatch.jl
+++ b/test/performance/branching_faster_than_dispatch.jl
@@ -81,7 +81,7 @@ function agent_step!(agent::GridAgentFour, model1)
 end
 function agent_step!(agent::GridAgentFive, model1)
     targets = filter!(a->a.one > 0.8, collect(nearby_agents(agent, model1, 3)))
-    idx = argmax(map(t->edistance(agent, t, model1), targets))
+    idx = argmax(map(t->euclidean_distance(agent, t, model1), targets))
     farthest = targets[idx]
     walk!(agent, sign.(farthest.pos .- agent.pos), model1)
 end
@@ -146,7 +146,7 @@ end
 function agent_step_five!(agent, model2)
     targets = filter!(a->a.one > 1.0, collect(nearby_agents(agent, model2, 3)))
     if !isempty(targets)
-        idx = argmax(map(t->edistance(agent, t, model2), targets))
+        idx = argmax(map(t->euclidean_distance(agent, t, model2), targets))
         farthest = targets[idx]
         walk!(agent, sign.(farthest.pos .- agent.pos), model2)
     end

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -179,18 +179,35 @@
         @test sort!(collect(nearby_ids(directed[2], directed; neighbor_type = :all))) ==
               [1, 3]
 
-        gridspace = ABM(Agent3, GridSpace((3, 3); metric = :euclidean, periodic = false))
-        @test collect(nearby_positions((2, 2), gridspace)) ==
+        grid_euclidean = ABM(Agent3, GridSpace((3, 3); metric = :euclidean, periodic = false))
+        @test collect(nearby_positions((2, 2), grid_euclidean)) ==
               [(2, 1), (1, 2), (3, 2), (2, 3)]
-        @test collect(nearby_positions((1, 1), gridspace)) == [(2, 1), (1, 2)]
-        a = add_agent!((2, 2), gridspace, rand(gridspace.rng))
-        add_agent!((3, 2), gridspace, rand(gridspace.rng))
-        @test collect(nearby_ids((1, 2), gridspace)) == [1]
-        @test sort!(collect(nearby_ids((1, 2), gridspace, 2))) == [1, 2]
-        @test sort!(collect(nearby_ids((2, 2), gridspace))) == [1, 2]
-        @test collect(nearby_ids(a, gridspace)) == [2]
+        @test collect(nearby_positions((1, 1), grid_euclidean)) == [(2, 1), (1, 2)]
+        a = add_agent!((2, 2), grid_euclidean, rand(grid_euclidean.rng))
+        add_agent!((3, 2), grid_euclidean, rand(grid_euclidean.rng))
+        @test collect(nearby_ids((1, 2), grid_euclidean)) == [1]
+        @test sort!(collect(nearby_ids((1, 2), grid_euclidean, 2))) == [1, 2]
+        @test sort!(collect(nearby_ids((2, 2), grid_euclidean))) == [1, 2]
+        @test collect(nearby_ids(a, grid_euclidean)) == [2]
 
-        @test_throws AssertionError nearby_positions((2, 2), gridspace, (1, 2))
+        @test_throws AssertionError nearby_positions((2, 2), grid_euclidean, (1, 2))
+
+        grid_manhattan = ABM(Agent3, GridSpace((6, 6); metric = :manhattan, periodic = false))
+        @test sort!(collect(nearby_positions((3, 3), grid_manhattan))) == 
+            [(2, 3), (3, 2), (3, 4), (4, 3)]
+        @test sort!(collect(nearby_positions((3, 3), grid_manhattan, 3))) ==
+            [(1, 2), (1, 3), (1, 4), (2, 1), (2, 2), (2, 3), (2, 4), (2, 5), (3, 1), (3, 2),
+             (3, 4), (3, 5), (3, 6), (4, 1), (4, 2), (4, 3), (4, 4), (4, 5), (5, 2), (5, 3),
+             (5, 4), (6, 3)]
+        @test collect(nearby_positions((1, 1), grid_manhattan)) == [(2, 1), (1, 2)]
+        a = add_agent!((2, 2), grid_manhattan, rand(grid_manhattan.rng))
+        add_agent!((3, 2), grid_manhattan, rand(grid_manhattan.rng))
+        @test collect(nearby_ids((1, 2), grid_manhattan)) == [1]
+        @test collect(nearby_ids((4, 3), grid_manhattan)) == []
+        @test sort!(collect(nearby_ids((4, 3), grid_manhattan, 3))) == [1, 2]
+        @test collect(nearby_ids(a, grid_manhattan)) == [2]
+
+        @test_throws AssertionError nearby_positions((2, 2), grid_manhattan, (1, 2))
 
         model = ABM(Agent3, GridSpace((10, 5); periodic = false))
         nearby_positions((5, 5), model, (1, 2))

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -122,6 +122,23 @@
         @test_throws MethodError euclidean_distance(a, b, model)
     end
 
+    @testset "Manhattan Distance" begin
+        model = ABM(Agent3, GridSpace((12, 10); metric = :manhattan, periodic = true))
+        a = add_agent!((1.0, 6.0), model, 2.0)
+        b = add_agent!((11.0, 4.0), model, 3.0)
+        @test manhattan_distance(a, b, model) ≈ 4
+
+        model = ABM(Agent3, GridSpace((12, 10); metric = :manhattan, periodic = false))
+        a = add_agent!((1.0, 6.0), model, 2.0)
+        b = add_agent!((11.0, 4.0), model, 3.0)
+        @test manhattan_distance(a, b, model) ≈ 12
+
+        model = ABM(Agent5, GraphSpace(path_graph(5)))
+        a = add_agent!(1, model, rand(model.rng))
+        b = add_agent!(2, model, rand(model.rng))
+        @test_throws MethodError manhattan_distance(a, b, model)
+    end
+
     @testset "Nearby Agents" begin
         undirected = ABM(Agent5, GraphSpace(path_graph(5)))
         @test nearby_positions(3, undirected) == [2, 4]

--- a/test/space_test.jl
+++ b/test/space_test.jl
@@ -99,27 +99,27 @@
         model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic = true))
         a = add_agent!((1.0, 6.0), model, (0.5, 0.5), 2.0)
         b = add_agent!((11.0, 4.0), model, (0.5, 0.7), 3.0)
-        @test edistance(a, b, model) ≈ 2.82842712
+        @test euclidean_distance(a, b, model) ≈ 2.82842712
 
         model = ABM(Agent6, ContinuousSpace((12, 10), 0.2; periodic = false))
         a = add_agent!((1.0, 6.0), model, (0.5, 0.5), 2.0)
         b = add_agent!((11.0, 4.0), model, (0.5, 0.7), 3.0)
-        @test edistance(a, b, model) ≈ 10.198039
+        @test euclidean_distance(a, b, model) ≈ 10.198039
 
         model = ABM(Agent3, GridSpace((12, 10); periodic = true))
         a = add_agent!((1.0, 6.0), model, 2.0)
         b = add_agent!((11.0, 4.0), model, 3.0)
-        @test edistance(a, b, model) ≈ 2.82842712
+        @test euclidean_distance(a, b, model) ≈ 2.82842712
 
         model = ABM(Agent3, GridSpace((12, 10); periodic = false))
         a = add_agent!((1.0, 6.0), model, 2.0)
         b = add_agent!((11.0, 4.0), model, 3.0)
-        @test edistance(a, b, model) ≈ 10.198039
+        @test euclidean_distance(a, b, model) ≈ 10.198039
 
         model = ABM(Agent5, GraphSpace(path_graph(5)))
         a = add_agent!(1, model, rand(model.rng))
         b = add_agent!(2, model, rand(model.rng))
-        @test_throws MethodError edistance(a, b, model)
+        @test_throws MethodError euclidean_distance(a, b, model)
     end
 
     @testset "Nearby Agents" begin


### PR DESCRIPTION
Closes #632 

I've added some utility functions to calculate manhattan distance between two agent positions. Should work for both periodic/non-periodic. This allows users to easily use the distance metric in their models.

I have not integrated the manhattan distance as a new `metric` for GridSpace. Would that be necessary?

*Sidenote*: We should maybe change the `periodic` keyword to `toroidal` at some point because that word is a bit more common in this context as far as I know.

## To do:

- [x] Test `manhattan_distance`
- [x] Test `:manhattan` metric 
- [ ] Add plot explaining distances (task for @Datseris) 