### PR TITLE
Fix #652

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.4.1"
+version = "5.4.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -144,15 +144,14 @@ end
     move_agent!(agent::A, model::ABM{<:ContinuousSpace,A}, dt::Real)
 Propagate the agent forwards one step according to its velocity, _after_ updating the
 agent's velocity (if configured using `update_vel!`, see [`ContinuousSpace`](@ref)).
-Also take care of periodic boundary conditions.
 
-For this continuous space version of `move_agent!`, the "evolution algorithm"
+For this continuous space version of `move_agent!`, the "time evolution"
 is a trivial Euler scheme with `dt` the step size, i.e. the agent position is updated
 as `agent.pos += agent.vel * dt`.
 
-Unlike `move_agent!(agent, [pos,] model)`, this function respects the space size
-and if movement exceeds the extent in non-periodic spaces, the agent stops at the
-space end, while for periodic spaces it properly wraps around the end.
+Unlike `move_agent!(agent, [pos,] model)`, this function respects the space size.
+For non-periodic spaces, agents will walk up to, but not reach, the space extent.
+For periodic spaces movement properly wraps around the extent.
 """
 function move_agent!(
     agent::A,

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -157,7 +157,7 @@ end
     walk!(agent, direction::NTuple, model; ifempty = false)
 
 Move agent in the given `direction` respecting periodic boundary conditions.
-If `periodic = false`, agents will walk to, but not exceed the boundary value.
+For non-periodic spaces, agents will walk to, but not exceed the boundary value.
 Available for both `AbstractGridSpace` and `ContinuousSpace`s.
 
 The type of `direction` must be the same as the space position. `AbstractGridSpace` asks

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -207,6 +207,7 @@ function walk!(
     kwargs...,
 ) where {D}
     target = mod1.(agent.pos .+ direction, spacesize(model))
+    target = min.(target, prevfloat.(spacesize(model)))
     move_agent!(agent, target, model)
 end
 function walk!(

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -161,7 +161,7 @@ If `periodic = false`, agents will walk to, but not exceed the boundary value.
 Available for both `AbstractGridSpace` and `ContinuousSpace`s.
 
 The type of `direction` must be the same as the space position. `AbstractGridSpace` asks
-for `Int`, and `ContinuousSpace` for `Float64` vectors, describing the walk distance in
+for `Int`, and `ContinuousSpace` for `Float64` tuples, describing the walk distance in
 each direction. `direction = (2, -3)` is an example of a valid direction on a
 `AbstractGridSpace`, which moves the agent to the right 2 positions and down 3 positions.
 Agent velocity is ignored for this operation in `ContinuousSpace`.

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -253,7 +253,6 @@ using StableRNGs
             @test a.pos[2] == prevfloat(10.0)
         end
 
-        end
     end
 
     @testset "collisions" begin

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -244,6 +244,16 @@ using StableRNGs
         walk!(a, rand, model)
         @test a.pos[1] ≈ 6.5824829589163665
         @test a.pos[2] ≈ 4.842266936412905
+
+        @testset "periodic" begin
+            model = ABM(ContinuousAgent{2}, ContinuousSpace((12, 10); periodic = true))
+            a = add_agent!((11.0, 9.0), model, (3.0, 1.0))
+            move_agent!(a, model, 1.0)
+            @test a.pos[1] == 2
+            @test a.pos[2] == prevfloat(10.0)
+        end
+
+        end
     end
 
     @testset "collisions" begin


### PR DESCRIPTION
Fix #652 

By adding one more operation that ensures that we do not exceed the prevfloat of the extent.

This is rather expensive unfortunately, as it will occur in every `walk!` or `move_agent(a, model, dt::Real)` call. But I honestly can't come up with a cheaper way to do it.