### PR TITLE
add nearest_neighbor_ties

### DIFF
--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -306,7 +306,8 @@ function nearest_neighbor_ties(agent::A, model::ABM{<:ContinuousSpace,A}, r) whe
     for id in n
         dnew = euclidean_distance(agent.pos, model[id].pos, model)
         if dnew < d
-            d, j = dnew, Int[id]
+            empty!(j)
+            d, j = dnew, push!(j, id)
         elseif dnew == d && id ∉ j
             push!(j, id)
         end

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -1,6 +1,6 @@
 export ContinuousSpace, ContinuousAgent
 export nearby_ids_exact, nearby_agents_exact
-export nearest_neighbor, elastic_collision!, interacting_pairs
+export nearest_neighbor, nearest_neighbor_ties, elastic_collision!, interacting_pairs
 
 struct ContinuousSpace{D,P,T<:AbstractFloat,F} <: AbstractSpace
     grid::GridSpace{D,P}
@@ -291,6 +291,27 @@ function nearest_neighbor(agent::A, model::ABM{<:ContinuousSpace,A}, r) where {A
     else
         return model[j]
     end
+end
+
+"""
+    nearest_neighbor_ties(agent, model::ABM{<:ContinuousSpace}, r) → nearest
+Return a vector of agents that have the closest distance to given `agent`.
+Return empty vector if no agent is within distance `r`.
+Note: This function allows multiple agents to have closest distances to given
+`agent`.
+"""
+function nearest_neighbor_ties(agent::A, model::ABM{<:ContinuousSpace,A}, r) where {A}
+    n = nearby_ids(agent, model, r)
+    d, j = Inf, Int[]
+    for id in n
+        dnew = euclidean_distance(agent.pos, model[id].pos, model)
+        if dnew < d
+            d, j = dnew, Int[id]
+        elseif dnew == d && id ∉ j
+            push!(j, id)
+        end
+    end
+    return [model[id] for id in j]
 end
 
 using LinearAlgebra

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -220,12 +220,12 @@ using StableRNGs
         @test model[4].nn == 3
     end
 
-    @testset "nearest neighbor" begin
+    @testset "nearest neighbor ties" begin
         mutable struct AgentNNContinuous <: AbstractAgent
             id::Int
             pos::NTuple{2,Float64}
             vel::NTuple{2,Float64}
-            f1::Union{Int,Nothing}
+            nn::Union{Int,Nothing}
         end
         space = ContinuousSpace((1,1); spacing = 0.1, periodic = true)
         model = ABM(AgentNNContinuous, space)
@@ -235,13 +235,13 @@ using StableRNGs
         end
 
         for agent in allagents(model)
-            agent.f1 = nearest_neighbor(agent, model, sqrt(2)).id
+            agent.nn = [id for i in nearest_neighbor(agent, model, sqrt(2))]
         end
 
-        @test model[1].f1 == 2
-        @test model[2].f1 == 1
-        @test model[3].f1 == 2
-        @test model[4].f1 == 3
+        @test model[1].nn == [2]
+        @test Set(model[2].nn) == Set([1,3])
+        @test model[3].nn == [2]
+        @test model[4].nn == [3]
     end
 
     @testset "walk" begin

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -201,6 +201,30 @@ using StableRNGs
             id::Int
             pos::NTuple{2,Float64}
             vel::NTuple{2,Float64}
+            nn::Union{Int,Nothing}
+        end
+        space = ContinuousSpace((1,1); spacing = 0.1, periodic = true)
+        model = ABM(AgentNNContinuous, space)
+        pos = [(0.01, 0.01),(0.2, 0.01),(0.2, 0.2),(0.5, 0.5)]
+        for i in pos
+            add_agent!(i,model,(0.0,0.0),nothing)
+        end
+
+        for agent in allagents(model)
+            agent.nn = nearest_neighbor(agent, model, sqrt(2)).id
+        end
+
+        @test model[1].nn == 2
+        @test model[2].nn in [1,3] ## tied
+        @test model[3].nn == 2
+        @test model[4].nn == 3
+    end
+
+    @testset "nearest neighbor" begin
+        mutable struct AgentNNContinuous <: AbstractAgent
+            id::Int
+            pos::NTuple{2,Float64}
+            vel::NTuple{2,Float64}
             f1::Union{Int,Nothing}
         end
         space = ContinuousSpace((1,1); spacing = 0.1, periodic = true)


### PR DESCRIPTION
pretty simple, this just adds a function in continuous space that does the same thing as `nearest_neighbor`, except ties are allowed, and it returns a vector of agents instead of a single agent (or returns an empty vector).

tests added as well.

running a simple benchmark to one of the tests (which I stole from benchmark/benchmarks.jl) we see they hover about within 500ns of each other, and of course returning a vector means that we allocate a tiny bit of memory:
```bash
julia> @btime nearest_neighbor($a, $continuous_model, 5)
  54.917 μs (0 allocations: 0 bytes)
ContinuousAgent(138, (3.33, 8.325, 6.66), (0.8, 0.7, 1.3), 6.5, false)

julia> @btime nearest_neighbor_ties($a, $continuous_model, 5)
  55.372 μs (3 allocations: 208 bytes)
2-element Vector{ContinuousAgent}:
 ContinuousAgent(138, (3.33, 8.325, 6.66), (0.8, 0.7, 1.3), 6.5, false)
 ContinuousAgent(132, (3.33, 6.66, 8.325), (0.8, 0.7, 1.3), 6.5, false)
```

benchmark:
```julia
mutable struct AgentNNBContinuous <: AbstractAgent
    id::Int
    pos::NTuple{3,Float64}
    vel::NTuple{3,Float64}
    one::Float64
    two::Bool
end

continuous_model = ABM(AgentNNBContinuous, ContinuousSpace((10.0, 10.0, 10.0); spacing = 0.5))
continuous_agent = AgentNNBContinuous(1, (2.2, 1.9, 7.5), (0.5, 1.0, 0.01), 6.5, false)

for x in range(0, stop = 9.99, length = 7)
    for y in range(0, stop = 9.99, length = 7)
        for z in range(0, stop = 9.99, length = 7)
            add_agent!((x, y, z), continuous_model, (0.8, 0.7, 1.3), 6.5, false)
        end
    end
end

a = continuous_model[139]
pos = (7.07, 8.10, 6.58)
```

See https://github.com/JuliaDynamics/Agents.jl/issues/684 for some discussion on the issue.