### PR TITLE
Reverted `n` parameter in ensemblerun! to correct pre-5.4.x version

### DIFF
--- a/src/simulations/ensemblerun.jl
+++ b/src/simulations/ensemblerun.jl
@@ -31,7 +31,7 @@ function ensemblerun!(
     models::Vector_or_Tuple,
     agent_step!,
     model_step!,
-    n::Int;
+    n;
     showprogress = false,
     parallel = false,
     kwargs...,

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -1,5 +1,4 @@
 @everywhere begin
-    import Pkg; Pkg.activate(".")
     using Agents.Models: schelling, schelling_agent_step!
 end
 @testset "DataCollection" begin


### PR DESCRIPTION
I added a small bug in my PR #624 for updating `ensemblerun!` for improved parallelism and progressbars. My change (reverted here) makes dispatching work incorrectly when `models` is a vector/tuple and `n` is a stopping function. This PR reverts that change so expected behavior is recovered. Sorry for this needless hassle!