### PR TITLE
Rename add/rem_node! to Graphs.add/rem_vertex!, implement rem_edge!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v5.6
+- `add_node!` and `rem_node!` have been renamed to `add_vertex!` and `rem_vertex!` extending Graphs.jl homonymous methods to help standardise names across ecosystems. Therefore `add_node!` and `rem_node!` have been deprecated.  
+- The signature of `add_edge!` has been generalised with `args...` and `kwargs...` to be compatible with all the implementations the underlying graph supports. 
+- New function `rem_edge!` that removes an edge from the graph.
+
 # v5.5
 - The `@agent` macro has been re-written and is now more general and more safe.
   It now also allows inhereting fields from any other type.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.5.0"
+version = "5.6.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -92,8 +92,9 @@ isempty(::Integer, ::ABM)
 ## `GraphSpace` exclusives
 ```@docs
 add_edge!
-add_node!
-rem_node!
+rem_edge!
+add_vertex!
+rem_vertex!
 ```
 
 ## `ContinuousSpace` exclusives

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,6 +1,8 @@
 # Some deprecations exist in submodules Pathfinding, OSM
 
 @deprecate edistance euclidean_distance
+@deprecate rem_node! rem_vertex! 
+@deprecate add_node! add_vertex!
 
 function ContinuousSpace(extent, spacing; kwargs...)
     @warn "Specifying `spacing` by position is deprecated. Use keyword `spacing` instead."

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -126,7 +126,7 @@ end
 #######################################################################################
 # Mutable graph functions
 #######################################################################################
-export rem_node!, add_node!, add_edge!
+export rem_vertex!, add_vertex!, add_edge!, rem_edge!
 
 """
     rem_node!(model::ABM{<: GraphSpace}, n::Int)
@@ -137,7 +137,7 @@ that of the one to be removed, while every other node remains as is. This means 
 when doing `rem_node!(n, model)` the last node becomes the `n`-th node while the previous
 `n`-th node (and all its edges and agents) are deleted.
 """
-function rem_node!(model::ABM{<:GraphSpace}, n::Int)
+function Graphs.rem_vertex!(model::ABM{<:GraphSpace}, n::Int)
     for id in copy(ids_in_position(n, model))
         kill_agent!(model[id], model)
     end
@@ -154,15 +154,29 @@ end
 Add a new node (i.e. possible position) to the model's graph and return it.
 You can connect this new node with existing ones using [`add_edge!`](@ref).
 """
-function add_node!(model::ABM{<:GraphSpace})
+function Graphs.add_vertex!(model::ABM{<:GraphSpace})
     add_vertex!(model.space.graph)
     push!(model.space.stored_ids, Int[])
     return nv(model)
 end
 
 """
-    add_edge!(model::ABM{<: GraphSpace}, n::Int, m::Int)
+    add_edge!(model::ABM{<:GraphSpace},  args...; kwargs...)
 Add a new edge (relationship between two positions) to the graph.
-Returns a boolean, true if the operation was succesful.
+Returns a boolean, true if the operation was succesful. 
+
+`args` and `kwargs` are directly passed to the `add_edge!` dispatch that acts the underlying graph type.
 """
-Graphs.add_edge!(model::ABM{<:GraphSpace}, n, m) = add_edge!(model.space.graph, n, m)
+Graphs.add_edge!(model::ABM{<:GraphSpace}, args...; kwargs...) = add_edge!(model.space.graph, args...; kwargs...)
+
+
+"""
+    rem_edge!(model::ABM{<:GraphSpace}, n, m)
+Remove an edge (relationship between two positions) to the graph.
+Returns a boolean, true if the operation was succesful. 
+"""
+Graphs.rem_edge!(model::ABM{<:GraphSpace}, n, m) = rem_edge!(model.space.graph, n, m)
+
+
+
+

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -19,7 +19,7 @@ The position type for this space is `Int`, use [`GraphAgent`](@ref) for convenie
 
 `Graphs.nv` and `Graphs.ne` can be used in a model with a `GraphSpace` to obtain
 the number of nodes or edges in the graph.
-The underlying graph can be altered using [`add_node!`](@ref) and [`rem_node!`](@ref).
+The underlying graph can be altered using [`add_vertex!`](@ref) and [`rem_vertex!`](@ref).
 
 An example using `GraphSpace` is [SIR model for the spread of COVID-19](@ref).
 
@@ -126,15 +126,46 @@ end
 #######################################################################################
 # Mutable graph functions
 #######################################################################################
-export rem_vertex!, add_vertex!, add_edge!, rem_edge!
+export rem_node!, add_node!, rem_vertex!, add_vertex!, add_edge!, rem_edge!
 
 """
-    rem_node!(model::ABM{<: GraphSpace}, n::Int)
+     rem_node!(model::ABM{<: GraphSpace}, n::Int)
+Remove node (i.e. position) `n` from the model's graph. All agents in that node are killed.
+**Warning:** Graphs.jl (and thus Agents.jl) swaps the index of the last node with
+that of the one to be removed, while every other node remains as is. This means that
+ when doing `rem_node!(n, model)` the last node becomes the `n`-th node while the previous
+ `n`-th node (and all its edges and agents) are deleted.
+ """
+ function rem_node!(model::ABM{<:GraphSpace}, n::Int)
+     for id in copy(ids_in_position(n, model))
+         kill_agent!(model[id], model)
+     end
+    V = nv(model)
+    success = Graphs.rem_vertex!(model.space.graph, n)
+    n > V && error("Node number exceeds amount of nodes in graph!")
+    s = model.space.stored_ids
+    s[V], s[n] = s[n], s[V]
+    pop!(s)
+end
+
+"""
+    add_node!(model::ABM{<: GraphSpace})
+ Add a new node (i.e. possible position) to the model's graph and return it.
+ You can connect this new node with existing ones using [`add_edge!`](@ref).
+ """
+ function add_node!(model::ABM{<:GraphSpace})
+     add_vertex!(model.space.graph)
+     push!(model.space.stored_ids, Int[])
+     return nv(model)
+ end
+
+"""
+    rem_vertex!(model::ABM{<:GraphSpace}, n::Int)
 Remove node (i.e. position) `n` from the model's graph. All agents in that node are killed.
 
 **Warning:** Graphs.jl (and thus Agents.jl) swaps the index of the last node with
 that of the one to be removed, while every other node remains as is. This means that
-when doing `rem_node!(n, model)` the last node becomes the `n`-th node while the previous
+when doing `rem_vertex!(n, model)` the last node becomes the `n`-th node while the previous
 `n`-th node (and all its edges and agents) are deleted.
 """
 function Graphs.rem_vertex!(model::ABM{<:GraphSpace}, n::Int)
@@ -150,7 +181,7 @@ function Graphs.rem_vertex!(model::ABM{<:GraphSpace}, n::Int)
 end
 
 """
-    add_node!(model::ABM{<: GraphSpace})
+    add_vertex!(model::ABM{<:GraphSpace})
 Add a new node (i.e. possible position) to the model's graph and return it.
 You can connect this new node with existing ones using [`add_edge!`](@ref).
 """
@@ -163,20 +194,15 @@ end
 """
     add_edge!(model::ABM{<:GraphSpace},  args...; kwargs...)
 Add a new edge (relationship between two positions) to the graph.
-Returns a boolean, true if the operation was succesful. 
+Returns a boolean, true if the operation was successful. 
 
 `args` and `kwargs` are directly passed to the `add_edge!` dispatch that acts the underlying graph type.
 """
 Graphs.add_edge!(model::ABM{<:GraphSpace}, args...; kwargs...) = add_edge!(model.space.graph, args...; kwargs...)
 
-
 """
     rem_edge!(model::ABM{<:GraphSpace}, n, m)
-Remove an edge (relationship between two positions) to the graph.
-Returns a boolean, true if the operation was succesful. 
+Remove an edge (relationship between two positions) from the graph.
+Returns a boolean, true if the operation was successful. 
 """
 Graphs.rem_edge!(model::ABM{<:GraphSpace}, n, m) = rem_edge!(model.space.graph, n, m)
-
-
-
-

--- a/test/graph_tests.jl
+++ b/test/graph_tests.jl
@@ -11,14 +11,14 @@
     ids_in_position(1, abm) == 1:5
     ids_in_position(2, abm) == 6:10
 
-    rem_node!(abm, 2)
+    rem_vertex!(abm, 2)
     @test nv(abm) == 4
     @test nagents(abm) == 20
     # Last node became 2nd node (swapped places as per Graphs.jl)
     @test ids_in_position(2, abm) == 21:25
     @test nv(abm) == 4
 
-    n = add_node!(abm)
+    n = add_vertex!(abm)
     @test n == 5
     @test nv(abm) == 5
 
@@ -27,12 +27,17 @@
     ids = nearby_ids(a, abm)
     @test sort(ids) == 21:25
 
+
+    rem_edge!(abm, n, 2)
+    ids = nearby_ids(a, abm)
+    @test isempty(ids)
+
     abm = ABM(Agent5, GraphSpace(SimpleGraph()))
     @test_throws ArgumentError add_agent!(abm, rand(abm.rng))
-    add_node!(abm)
+    add_vertex!(abm)
     @test nv(abm) == 1
     @test add_edge!(abm, 1, 2) == false
-    add_node!(abm)
+    add_vertex!(abm)
     @test add_edge!(abm, 1, 2) == true
 
 end


### PR DESCRIPTION
Hello,

We are the developers of [MultilayerGraphs.jl](https://github.com/JuliaGraphs/MultilayerGraphs.jl). 

We're looking towards publishing a new release that, among other things, integrates our package with Agents.jl. In doing so, we noticed that Agents.jl [implements](https://github.com/JuliaDynamics/Agents.jl/blob/5258c1bceeed41342e3ac36526bf7932b083c9ea/src/spaces/graph.jl#L129) the methods  `add_node!`,`rem_node!` and `add_edge!`.

We propose to rename `add_node!`,`rem_node!` to `add_vertex!`,`rem_vertex!` and have them extend `Graphs.jl`'s homonymous methods, for the following two reasons:

1. They effectively add and remove vertices, so this would help standardize names across ecosystems;
2. Our package needs to distinguish between nodes and vertices, and so `add/rem_node!` is drastically different from `add/rem_vertex!`.

We furthermore modify the implementation of `add_edge!` from:

```julia
Graphs.add_edge!(model::ABM{<:GraphSpace}, n, m) = add_edge!(model.space.graph, n, m)
```
to
```julia
Graphs.add_edge!(model::ABM{<:GraphSpace}, args...; kwargs...) = add_edge!(model.space.graph, args...; kwargs...)
```
in order to comply with all possible implementations of `add_edge!` that the underlying graph supports.

Finally, we implement

```julia
Graphs.rem_edge!(model::ABM{<:GraphSpace}, n, m) = rem_edge!(model.space.graph, n, m)
```

Docstrings and tests have been updated.

CC: @pitmonticone @ClaudMor
