### PR TITLE
Fix `nearest_way` not working

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.6.0"
+version = "5.6.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -136,6 +136,7 @@ end
 
 function OpenStreetMapSpace(path::AbstractString; kwargs...)
     m = graph_from_file(path; weight_type = :distance, kwargs...)
+    LightOSM.add_rtree!(m)
     agent_positions = [Int[] for _ in 1:Agents.nv(m.graph)]
     return OpenStreetMapSpace(m, agent_positions, Dict())
 end


### PR DESCRIPTION
Default `OSMGraph` constructor functions don't call `LightOSM.create_rtree!`