### PR TITLE
CI: Include run using Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
         os:  [ubuntu-latest, windows-latest, macos-latest]
         arch:
           - x64
+        include:
+          - version: nightly 
+            os: ubuntu-latest
+            arch: x64
+            
     steps:
       # Cancel ongoing CI test runs if pushing to branch again before the previous tests
       # have finished


### PR DESCRIPTION
Add a run to the test job of the CI which uses the latest nightly build of Julia. This allows to detect issues with upcoming Julia releases in advance.