### PR TITLE
Fix return variables of abmexploration

### DIFF
--- a/examples/schelling.jl
+++ b/examples/schelling.jl
@@ -273,7 +273,7 @@ model = initialize(; numagents = 300) # fresh model, noone happy
 # ```julia
 # using GLMakie # using a different plotting backend that enables interactive plots
 #
-# figure, adf, mdf = abmexploration(
+# figure, abmobs = abmexploration(
 #     model, agent_step!, dummystep, parange;
 #     ac = groupcolor, am = groupmarker, as = 10,
 #     adata, alabels


### PR DESCRIPTION
Closes #667 

Docs should show `fig, abmobs` instead of `fig, adf, mdf` as it has been in previous version of InteractiveDynamics.