### PR TITLE
removed `::Int` so that `paramscan` take `n::Function`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.6.1"
+version = "5.6.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -89,7 +89,7 @@ mutable struct Baker{T} <: AbstractAgent
     breadz_per_day::T
 end
 ```
-### Exaple with optional hierachy
+### Example with optional hierachy
 An alternative way to make the above structs, that also establishes
 a user-specific subtyping hierachy would be to do:
 ```julia
@@ -104,7 +104,16 @@ end
     fish_per_day::Float64
 end
 ```
-which would now make both `Human, Fisher` subtypes of `AbstractHuman`.
+which would now make both `Fisher` and `Worker` subtypes of `AbstractHuman`.
+```julia
+julia> supertypes(Fisher)
+(Fisher, AbstractHuman, AbstractAgent, Any)
+
+julia> supertypes(Worker)
+(Worker, AbstractHuman, AbstractAgent, Any)
+```
+Note that `Fisher` will *not* be a subtype of `Worker` although `Fisher` has
+inherited the fields from `Worker`.
 
 ### Example highlighting problems with parametric types
 Notice that in Julia parametric types are union types.

--- a/src/simulations/paramscan.jl
+++ b/src/simulations/paramscan.jl
@@ -79,7 +79,7 @@ function paramscan(
     parallel::Bool = false,
     agent_step! = dummystep,
     model_step! = dummystep,
-    n::Int = 1,
+    n = 1,
     showprogress::Bool = false,
     kwargs...,
 )

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -536,6 +536,7 @@ end
 
     burnt(f) = count(t == 3 for t in f.trees)
     unburnt(f) = count(t == 1 for t in f.trees)
+    terminate(m, s) = s >= 3 ? true : false
     @testset "Serial Scan" begin
         mdata = [unburnt, burnt]
         _, mdf = paramscan(
@@ -568,6 +569,16 @@ end
         )
         @test unique(mdf.step) == 0:10
         @test unique(mdf.density) == [0.6, 0.7, 0.8]
+
+        # test whether paramscan accepts n::Function
+        mdata = []
+        _, mdf = paramscan(
+            parameters,
+            forest_fire;
+            n = terminate,
+            model_step! = forest_model_step!,
+            mdata)
+        @test unique(mdf.step) == 0:3
     end
 
     @testset "Parallel Scan" begin
@@ -604,6 +615,17 @@ end
         )
         @test unique(mdf.step) == 0:10
         @test unique(mdf.density) == [0.6, 0.7, 0.8]
+
+        # test whether paramscan accepts n::Function
+        mdata = []
+        _, mdf = paramscan(
+            parameters,
+            forest_fire;
+            n = terminate,
+            model_step! = forest_model_step!,
+            mdata,
+            parallel = true)
+        @test unique(mdf.step) == 0:3
     end
 end
 


### PR DESCRIPTION
This PR addresses https://github.com/JuliaDynamics/Agents.jl/issues/706