### PR TITLE
id::Int field redundant: removed

### DIFF
--- a/examples/diffeq.jl
+++ b/examples/diffeq.jl
@@ -37,7 +37,6 @@ CairoMakie.activate!() # hide
 using Random # hide
 
 @agent Fisher NoSpaceAgent begin
-    id::Int
     competence::Int
     yearly_catch::Float64
 end


### PR DESCRIPTION
I believe the id field in the definition of a NoSpaceAgent is not necessary (and indeed it gives an error when trying to define it explicitly). Removed that, the example runs smoothly.