### PR TITLE
Add try-catch to finding first agent instance in multi_agent_types!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - `add_node!` and `rem_node!` have been renamed to `add_vertex!` and `rem_vertex!` extending Graphs.jl homonymous methods to help standardise names across ecosystems. Therefore `add_node!` and `rem_node!` have been deprecated.  
 - The signature of `add_edge!` has been generalised with `args...` and `kwargs...` to be compatible with all the implementations the underlying graph supports. 
 - New function `rem_edge!` that removes an edge from the graph.
+- `multi_agents_type!` has been updated to handle edge case where agents of one (or more) type are absent at the beginning of the simulation. 
 
 # v5.5
 - The `@agent` macro has been re-written and is now more general and more safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
+# main
+- `multi_agents_type!` has been updated to handle edge case where agents of one (or more) type are absent at the beginning of the simulation. 
+
 # v5.6
 - `add_node!` and `rem_node!` have been renamed to `add_vertex!` and `rem_vertex!` extending Graphs.jl homonymous methods to help standardise names across ecosystems. Therefore `add_node!` and `rem_node!` have been deprecated.  
 - The signature of `add_edge!` has been generalised with `args...` and `kwargs...` to be compatible with all the implementations the underlying graph supports. 
 - New function `rem_edge!` that removes an edge from the graph.
-- `multi_agents_type!` has been updated to handle edge case where agents of one (or more) type are absent at the beginning of the simulation. 
 
 # v5.5
 - The `@agent` macro has been re-written and is now more general and more safe.

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -241,7 +241,12 @@ function multi_agent_types!(
     for (i, k) in enumerate(properties)
         current_types = DataType[]
         for atype in utypes
-            a = first(Iterators.filter(a -> a isa atype, allagents(model)))
+            a = try 
+                first(Iterators.filter(a -> a isa atype, allagents(model)))
+            catch
+                nothing
+            end 
+            
             if k isa Symbol
                 current_type =
                     hasproperty(a, k) ? typeof(get_data(a, k, identity)) : Missing

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -222,7 +222,7 @@ function single_agent_types!(
     a = first(model.agents).second
     for (i, k) in enumerate(properties)
         current_type = typeof(get_data(a, k, identity))
-        isconcretetype(current_type) || warn(
+        isconcretetype(current_type) || @warn(
             "Type is not concrete when using $(k) " *
             "on agents. Consider narrowning the type signature of $(k).",
         )
@@ -248,8 +248,11 @@ function multi_agent_types!(
             end 
             
             if k isa Symbol
-                current_type =
-                    hasproperty(a, k) ? typeof(get_data(a, k, identity)) : Missing
+                current_type = if hasproperty(a, k) 
+                    typeof(get_data(a, k, identity))
+                else 
+                    hasfield(atype, k) ? fieldtype(atype, k) : Missing
+                end
             else
                 current_type = try
                     typeof(get_data(a, k, identity))
@@ -257,9 +260,9 @@ function multi_agent_types!(
                     Missing
                 end
             end
-            isconcretetype(current_type) || warn(
+            isconcretetype(current_type) || @warn(
                 "Type is not concrete when using $(k) " *
-                "on $(atype) agents. Consider narrowning the type signature of $(k).",
+                "on $(atype) agents. Consider narrowing the type signature of $(k).",
             )
             push!(current_types, current_type)
         end
@@ -348,7 +351,7 @@ function single_agent_agg_types!(
         current_type = typeof(agg(
             get_data(a, k, identity) for a in Iterators.take(allagents(model), 1)
         ))
-        isconcretetype(current_type) || warn(
+        isconcretetype(current_type) || @warn(
             "Type is not concrete when using function $(agg) " *
             "on key $(k). Consider using type annotation, e.g. $(agg)(a)::Float64 = ...",
         )
@@ -368,7 +371,12 @@ function multi_agent_agg_types!(
         headers[i+1] = dataname(property)
         current_types = DataType[]
         for atype in utypes
-            a = first(Iterators.filter(a -> a isa atype, allagents(model)))
+            a = try 
+                first(Iterators.filter(a -> a isa atype, allagents(model)))
+            catch
+                nothing
+            end 
+
             if k isa Symbol
                 current_type =
                     hasproperty(a, k) ? typeof(agg(get_data(a, k, identity))) : Missing
@@ -379,7 +387,7 @@ function multi_agent_agg_types!(
                     Missing
                 end
             end
-            isconcretetype(current_type) || warn(
+            isconcretetype(current_type) || @warn(
                 "Type is not concrete when using function $(agg) " *
                 "on key $(k) for $(atype) agents. Consider using type annotation, e.g. $(agg)(a)::Float64 = ...",
             )
@@ -482,7 +490,7 @@ function init_model_dataframe(model::ABM, properties::Vector)
             end
         else
             current_type = typeof(k(model))
-            isconcretetype(current_type) || warn(
+            isconcretetype(current_type) || @warn(
                 "Type is not concrete when using $(k)" *
                 "on the model. Considering narrowing the type signature of $(k).",
             )

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -378,6 +378,24 @@ end
         collect_agent_data!(df, model, props)
         @test size(df) == (1, 2)
         @test df[1, :sum_fweight] ≈ 82.46
+
+        # Handle dataframe initialization when one agent type is absent
+        model = ABM(Union{Agent3,Agent4}, GridSpace((10, 10)); warn = false)
+        add_agent_pos!(Agent3(1, (6, 8), 54.65), model)
+
+        # get fieldtype from Agent4 struct definition when agent is absent 
+        props = [:weight, :p]
+        df = init_agent_dataframe(model, props)
+        @test eltype(df[!, :p]) == Union{Int, Missing}
+        
+        # Add Agent4 and check data collection
+        add_agent_pos!(Agent4(2, (4, 1), 3), model)
+        collect_agent_data!(df, model, props)
+        @test size(df) == (2, 5)
+        @test df[1, :weight] == model[1].weight
+        @test df[2, :p] == model[2].p
+        @test ismissing(df[1, :p])
+        @test ismissing(df[2, :weight])
     end
 
     @testset "Observers" begin


### PR DESCRIPTION
When initializing the `adata` dataframe for multi-agents, code tries to look for the first object instance of the different agent types., so that it can be used to extract the desired property types for dataframe header. 

In the specific case where one agent type doesn't yet exist at model initialization (to be added later on while stepping the simulation), this will cause an error. 

The behavior now is to default the missing agent type's properties to `Missing`. If desired, I can also leverage `hasfield` and `fieldtype` when the desired property is a `Symbol`