### PR TITLE
Substitute splice! with deleteat! in remove_agent_from_space for graphs

### DIFF
--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -71,7 +71,7 @@ function remove_agent_from_space!(
 ) where {A <: AbstractAgent}
     agentpos = agent.pos
     ids = ids_in_position(agentpos, model)
-    splice!(ids, findfirst(a -> a == agent.id, ids))
+    deleteat!(ids, findfirst(a -> a == agent.id, ids))
     return model
 end
 


### PR DESCRIPTION
Looking at the source code I found that `splice!` can be substituted with `deleteat!`, `deleteat!(a, findfirst(x -> x == b, a))` is 1.5x faster than `splice!(a, findfirst(x -> x == b, a))` 

```julia
function splice_test(a::Vector{Int}, b::Int)
    s = splice!(a, findfirst(x -> x == b, a))
    return nothing
end

function deleteat_test(a::Vector{Int}, b::Int)
    s = deleteat!(a, findfirst(x -> x == b, a))
    return nothing
end

using BenchmarkTools

s = 1000
with_splice = @benchmarkable (for i in 1:b splice_test(a,i) end) samples=1 evals=1 setup=(a = Int[1:$s;]; b = $s)
with_deleteat = @benchmarkable (for i in 1:b deleteat_test(a,i) end) samples=1 evals=1 setup=(a = Int[1:$s;]; b = $s) 

run(with_splice)
run(with_deleteat)
```
which returns

```julia
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 9.187 μs (0.00% GC) to evaluate,
 with a memory estimate of 0 bytes, over 0 allocations.
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 6.141 μs (0.00% GC) to evaluate,
 with a memory estimate of 0 bytes, over 0 allocations.
```

the benchmark wasn't a necessity I think but I did it to experiment with `BenchmarkTools` :-)
