### PR TITLE
Solve unbounded cache problem when r is not an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main
 - Two new variants of agent based models: `UnkillableABM` and `FixedMassABM`: they yield huge performance benefits (up to twice the speed!!!) on iterating over agents if the agents can't get killed, or even added, during model evolution!
+- Huge memory performance increase in continuous space by fixing a memory leak bug.
 - `multi_agents_type!` has been updated to handle edge case where agents of one (or more) type are absent at the beginning of the simulation.
 - New function `npositions` that returns the number of positions of a model with a discrete space.
 

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -198,10 +198,18 @@ function nearby_ids(pos::ValidPos, model::ABM{<:ContinuousSpace{D,A,T}}, r = 1;
     # Calculate maximum grid distance (distance + distance from cell center)
     δ = distance_from_cell_center(pos, cell_center(pos, model))
     grid_r = (r + δ) / model.space.spacing
+    metric = model.space.grid.metric
+    if metric == :euclidean
+        int_grid_r = ceil(Int, grid_r)
+    elseif metric == :manhattan
+        int_grid_r= floor(Int, grid_r)
+    elseif metric == :chebyshev
+        int_grid_r = floor(Int, grid_r)
+    end
     # Then return the ids within this distance, using the internal grid space
     # and iteration via `GridSpaceIdIterator`, see spaces/grid_multi.jl
     focal_cell = pos2cell(pos, model)
-    return nearby_ids(focal_cell, model.space.grid, grid_r)
+    return nearby_ids(focal_cell, model.space.grid, int_grid_r)
 end
 
 """

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -197,19 +197,13 @@ function nearby_ids(pos::ValidPos, model::ABM{<:ContinuousSpace{D,A,T}}, r = 1;
     end
     # Calculate maximum grid distance (distance + distance from cell center)
     δ = distance_from_cell_center(pos, cell_center(pos, model))
-    grid_r = (r + δ) / model.space.spacing
+    # Ceiling since the grid has euclidean metric
+    grid_r = ceil(Int, (r + δ) / model.space.spacing)
     metric = model.space.grid.metric
-    if metric == :euclidean
-        int_grid_r = ceil(Int, grid_r)
-    elseif metric == :manhattan
-        int_grid_r= floor(Int, grid_r)
-    elseif metric == :chebyshev
-        int_grid_r = floor(Int, grid_r)
-    end
     # Then return the ids within this distance, using the internal grid space
     # and iteration via `GridSpaceIdIterator`, see spaces/grid_multi.jl
     focal_cell = pos2cell(pos, model)
-    return nearby_ids(focal_cell, model.space.grid, int_grid_r)
+    return nearby_ids(focal_cell, model.space.grid, grid_r)
 end
 
 """

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -199,7 +199,6 @@ function nearby_ids(pos::ValidPos, model::ABM{<:ContinuousSpace{D,A,T}}, r = 1;
     δ = distance_from_cell_center(pos, cell_center(pos, model))
     # Ceiling since the grid has euclidean metric
     grid_r = ceil(Int, (r + δ) / model.space.spacing)
-    metric = model.space.grid.metric
     # Then return the ids within this distance, using the internal grid space
     # and iteration via `GridSpaceIdIterator`, see spaces/grid_multi.jl
     focal_cell = pos2cell(pos, model)

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -48,14 +48,22 @@ The function does two things:
 offsets_within_radius(model::ABM, r::Real) = offsets_within_radius(model.space, r::Real)
 function offsets_within_radius(
     space::AbstractGridSpace{D}, r::Real)::Vector{NTuple{D, Int}} where {D}
-    if haskey(space.offsets_within_radius, r)
-        βs = space.offsets_within_radius[r]
+    if space.metric == :euclidean
+        r0 = ceil(Int, r)
+    elseif space.metric == :manhattan
+        r0 = floor(Int, r)
+    elseif space.metric == :chebyshev
+        r0 = floor(Int, r)
+    end
+    if haskey(space.offsets_within_radius, r0)
+        βs = space.offsets_within_radius[r0]
     else
-        βs = calculate_offsets(space, r)
-        space.offsets_within_radius[float(r)] = βs
+        βs = calculate_offsets(space, r0)
+        space.offsets_within_radius[r0] = βs
     end
     return βs::Vector{NTuple{D, Int}}
 end
+
 
 # Make grid space Abstract if indeed faster
 function calculate_offsets(space::AbstractGridSpace{D}, r::Real) where {D}

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -53,7 +53,6 @@ function offsets_within_radius(
     else
         βs = calculate_offsets(space, r)
         space.offsets_within_radius[float(r)] = βs
-        #println(βs)
     end
     return βs::Vector{NTuple{D, Int}}
 end

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -48,22 +48,15 @@ The function does two things:
 offsets_within_radius(model::ABM, r::Real) = offsets_within_radius(model.space, r::Real)
 function offsets_within_radius(
     space::AbstractGridSpace{D}, r::Real)::Vector{NTuple{D, Int}} where {D}
-    if space.metric == :euclidean
-        r0 = ceil(Int, r)
-    elseif space.metric == :manhattan
-        r0 = floor(Int, r)
-    elseif space.metric == :chebyshev
-        r0 = floor(Int, r)
-    end
-    if haskey(space.offsets_within_radius, r0)
-        βs = space.offsets_within_radius[r0]
+    if haskey(space.offsets_within_radius, r)
+        βs = space.offsets_within_radius[r]
     else
-        βs = calculate_offsets(space, r0)
-        space.offsets_within_radius[r0] = βs
+        βs = calculate_offsets(space, r)
+        space.offsets_within_radius[float(r)] = βs
+        #println(βs)
     end
     return βs::Vector{NTuple{D, Int}}
 end
-
 
 # Make grid space Abstract if indeed faster
 function calculate_offsets(space::AbstractGridSpace{D}, r::Real) where {D}


### PR DESCRIPTION
This (still to be tested and adapted well) solves the memory bug described in https://github.com/JuliaDynamics/Agents.jl/issues/739, the problem was that we saved a float value which means that for a continuous space (with a grid behind it) it will grow and grow over all the simulation, but this can be avoided saving just the floored/ceiled values. The patch can surely be improved a bit in terms of code used.