### PR TITLE
stardardize metric functions

### DIFF
--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -29,31 +29,10 @@ end
 function euclidean_distance(
     p1::ValidPos,
     p2::ValidPos,
-    model::ABM{<:ContinuousSpace{D,true}},
+    model::ABM{<:Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}},
 ) where {D}
-    total = 0.0
-    for (a, b, d) in zip(p1, p2, spacesize(model))
-        delta = abs(b - a)
-        if delta > d - delta
-            delta = d - delta
-        end
-        total += delta^2
-    end
-    sqrt(total)
-end
-
-function euclidean_distance(
-        p1::ValidPos, p2::ValidPos, model::ABM{<:AbstractGridSpace{D,true}}
-    ) where {D}
-    total = 0.0
-    for (a, b, d) in zip(p1, p2, size(model.space))
-        delta = abs(b - a)
-        if delta > d - delta
-            delta = d - delta
-        end
-        total += delta^2
-    end
-    sqrt(total)
+    direct = abs.(p1 .- p2)
+    sqrt(sum(min.(direct, spacesize(model) .- direct).^2))
 end
 
 """
@@ -82,13 +61,8 @@ function manhattan_distance(
     p2::ValidPos,
     model::ABM{<:Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}}
 ) where {D}
-    total = 0.0
-    # find minimum distance for each dimension, add to total
-    for dim in 1:D
-        direct = abs(p1[dim] - p2[dim])
-        total += min(size(model.space)[dim] - direct, direct)
-    end
-    return total
+    direct = abs.(p1 .- p2)
+    sum(min.(direct, spacesize(model) .- direct))
 end
 
 """


### PR DESCRIPTION
I noticed that the metrics code was not standardized: different methods (for loop, element-wise operations, ...) were used. I tried to simplify the code while mantaining/improving performance. Runned this benchmark

<details> <summary> Benchmark </summary>

```julia
using Agents, BenchmarkTools
using Agents: euclidean_distance, manhattan_distance, euclidean_distance2, manhattan_distance2

@agent Ag GridAgent{2} begin end

function model_setup()
    multigrid = GridSpace((10, 10), periodic=true)
    model = ABM(Ag, multigrid)
    return model
end

a, b = (2,3), (5,4)
@btime euclidean_distance($a, $b, model) setup=(model=model_setup())
@btime manhattan_distance($a, $b, model) setup=(model=model_setup())
@btime euclidean_distance2($a, $b, model) setup=(model=model_setup())
@btime manhattan_distance2($a, $b, model) setup=(model=model_setup())
```
</details>

where `euclidean_distance2`, `manhattan_distance2` had the original code inside, which resulted in

```julia
@btime euclidean_distance($a, $b, model) setup=(model=model_setup())
  2.665 ns (0 allocations: 0 bytes)
@btime manhattan_distance($a, $b, model) setup=(model=model_setup())
  2.314 ns (0 allocations: 0 bytes)
@btime euclidean_distance2($a, $b, model) setup=(model=model_setup())
  6.141 ns (0 allocations: 0 bytes)
@btime manhattan_distance2($a, $b, model) setup=(model=model_setup())
  2.364 ns (0 allocations: 0 bytes)
```

Read some discussions saying that broadcasting can be slower sometimes, but doesn't seem the case here, it is actually two times faster in one case and roughly the same in the other. Alternatively, we can use for loops in all dispatched methods instead of broadcasting (also on the functions used when periodic=false).



