### PR TITLE
Improve performance of get_direction function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # main
+- Huge improvement of performance of the `get_direction` function in the periodic case.
 
 # v5.7
 - Internals of `AgentBasedModel` got reworked. It is now an abstract type, defining an abstract interface that concrete implementations may satisfy. This paves the way for flexibly defining new variants of `AgentBasedModel` that are more specialized in their applications.

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -79,7 +79,7 @@ function get_direction(
 ) where {D}
     direct_dir = to .- from
     inverse_dir = direct_dir .- sign.(direct_dir) .* spacesize(space)
-    return map((x, y) -> minimum(abs, (x, y)), direct_dir, inverse_dir)
+    return map((x, y) -> abs(x) < abs(y) ? x : y, direct_dir, inverse_dir)
 end
 
 function get_direction(

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -79,7 +79,7 @@ function get_direction(
 ) where {D}
     direct_dir = to .- from
     inverse_dir = direct_dir .- sign.(direct_dir) .* spacesize(space)
-    return map((x, y) -> abs(x) < abs(y) ? x : y, direct_dir, inverse_dir)
+    return map((x, y) -> minimum(abs, (x, y)), direct_dir, inverse_dir)
 end
 
 function get_direction(

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -73,19 +73,20 @@ periodicity of the space.
 get_direction(from, to, model::ABM) = get_direction(from, to, model.space)
 # Periodic spaces version
 function get_direction(
-    from::NTuple{D,Float64},
-    to::NTuple{D,Float64},
+    from::ValidPos,
+    to::ValidPos,
     space::Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}
 ) where {D}
-    best = to .- from
-    for offset in Iterators.product([-1:1 for _ in 1:D]...)
-        dir = to .+ offset .* spacesize(space) .- from
-        sum(dir.^2) < sum(best.^2) && (best = dir)
-    end
-    return best
+    direct_dir = to .- from
+    inverse_dir = direct_dir .- sign.(direct_dir) .* spacesize(space)
+    return map((x, y) -> abs(x) < abs(y) ? x : y, direct_dir, inverse_dir)
 end
 
-function get_direction(from, to, ::Union{AbstractGridSpace,ContinuousSpace})
+function get_direction(
+    from::ValidPos, 
+    to::ValidPos, 
+    space::Union{AbstractGridSpace{D,false},ContinuousSpace{D,false}}
+) where {D}
     return to .- from
 end
 

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -79,7 +79,7 @@ function get_direction(
 ) where {D}
     direct_dir = to .- from
     inverse_dir = direct_dir .- sign.(direct_dir) .* spacesize(space)
-    return map((x, y) -> abs(x) < abs(y) ? x : y, direct_dir, inverse_dir)
+    return map((x, y) -> argmin(abs, (x, y)), direct_dir, inverse_dir)
 end
 
 function get_direction(


### PR DESCRIPTION
Saw that there was some huge room for improvement for the algorithm used in this particular function so I tried to come up with something better:

<details> <summary> Correctness verification + benchmark code </summary>

```julia
# get_direction2 contains the new method
using Agents, BenchmarkTools, Random
using Agents: get_direction, get_direction2

@agent Ag GridAgent{2} begin end

function model_setup()
    multigrid = GridSpace((10, 10), periodic=true)
    model = ABM(Ag, multigrid)
    return model
end

function model_setup2()
    multigrid = GridSpace((10, 10, 10), periodic=true)
    model = ABM(Ag, multigrid)
    return model
end

# verify correctness
model = model_setup()
for _ in 1:10000
    a, b = (rand()*10, rand()*10), (rand()*10, rand()*10)
    @assert get_direction(a, b, model) == get_direction2(a, b, model)
end

# 2d benchmark
a, b = (2.0, 3.7), (5.8, 4.7)
@benchmark get_direction($a, $b, model) setup=(model=model_setup())
@benchmark get_direction2($a, $b, model) setup=(model=model_setup())

# 3d benchmark
a, b = (2.0, 3.7, 5.8), (5.8, 4.7, 5.9)
@benchmark get_direction($a, $b, model) setup=(model=model_setup2())
@benchmark get_direction2($a, $b, model) setup=(model=model_setup2())
```

 </details>

the results:

```julia
#2d
julia> @benchmark get_direction($a, $b, model) setup=(model=model_setup())
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  14.798 μs …  4.115 ms  ┊ GC (min … max): 0.00% … 99.41%
 Time  (median):     15.550 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   16.284 μs ± 41.000 μs  ┊ GC (mean ± σ):  2.51% ±  0.99%

       ▁▅▇█▅▄▂                                                 
  ▁▁▂▄▇███████▇▅▄▄▃▃▃▃▃▃▃▃▃▃▂▃▂▂▂▂▂▂▂▂▂▁▁▂▂▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  14.8 μs         Histogram: frequency by time        19.1 μs <

 Memory estimate: 7.73 KiB, allocs estimate: 222.

julia> @benchmark get_direction2($a, $b, model) setup=(model=model_setup())
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.777 ns … 7.294 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.788 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.798 ns ± 0.066 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂       █       ▆▅      ▂▁      ▂▁      ▁▁      ▄▃        ▁
  █▁▁▁▁▁▁▁█▁▁▁▁▁▁▁██▁▁▁▁▁▁██▁▁▁▁▁▁██▁▁▁▁▁▁██▁▁▁▁▁▁██▁▁▁▁▁▁▇ █
  3.78 ns     Histogram: log(frequency) by time     3.85 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

#3d
julia> @benchmark get_direction($a, $b, model) setup=(model=model_setup2())
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  43.084 μs …  4.267 ms  ┊ GC (min … max): 0.00% … 98.73%
 Time  (median):     44.885 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   47.124 μs ± 82.765 μs  ┊ GC (mean ± σ):  3.50% ±  1.97%

       ▃▆██▇▆▅▂▂▁▁                                             
  ▁▁▂▃▆████████████▇▇▅▅▅▅▄▄▄▄▃▃▃▃▃▃▂▂▂▃▂▃▂▂▂▂▂▂▂▂▂▂▁▁▂▂▁▁▁▁▁▁ ▃
  43.1 μs         Histogram: frequency by time        51.3 μs <

 Memory estimate: 25.25 KiB, allocs estimate: 655.

julia> @benchmark get_direction2($a, $b, model) setup=(model=model_setup2())
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.386 ns … 12.211 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.027 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.000 ns ±  0.243 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▁▁▁▃  ▁                                      █▅ ▂▄▂▄▂▃  ▁
  ▅▆██████████▇▅▆▅▄▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁██▆███████ █
  3.39 ns      Histogram: log(frequency) by time     4.15 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

these benchmarks show that this new method is 5000x faster in 2d and 10000x faster in 3d !
