### PR TITLE
Improve performance of nearby_positions for graphspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main
-- Huge improvement of performance of the `get_direction` function in the periodic case.
+- Thanks to the use of a new algorithm, the `nearby_positions` function for graphspaces is now much faster.
+- Huge performance improvement in `get_direction` function for periodic spaces.
 
 # v5.7
 - Internals of `AgentBasedModel` got reworked. It is now an abstract type, defining an abstract interface that concrete implementations may satisfy. This paves the way for flexibly defining new variants of `AgentBasedModel` that are more specialized in their applications.

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -116,30 +116,28 @@ function nearby_positions(
     radius::Integer;
     kwargs...,
 )   
-    neighbors = copy(nearby_positions(position, model; kwargs...))
-    if radius == 1
-        return neighbors
-    end
-    seen = Set{Int}(neighbors)
+    nearby = copy(nearby_positions(position, model; kwargs...))
+    radius == 1 && return nearby
+    seen = Set{Int}(nearby)
     push!(seen, position)
-    k, n = 1, nv(model)
+    k, n = 0, nv(model)
     for _ in 2:radius
-        thislevel = @view neighbors[k:end]
-        k = length(neighbors)
-        if isempty(thislevel) || k == n
-    	    return neighbors
-    	end
+        thislevel = @view nearby[k+1:end]
+        isempty(thislevel) && return nearby
+        k = length(nearby)
+        k == n && return nearby
     	for v in thislevel
     	    for w in nearby_positions(v, model; kwargs...)
     	        if w ∉ seen
-    	            push!(neighbors, w)
-    	            push!(seen, w)  
+    	            push!(seen, w)
+    	            push!(nearby, w)
     	        end
     	    end
     	end
     end  
-    return neighbors
-end
+    return nearby
+end	    
+
 
 #######################################################################################
 # %% Walking

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -123,8 +123,7 @@ function nearby_positions(
     
     seen = Set{Int}(neighbors)
     push!(seen, position)
-    n = nv(model)
-    k = 1
+    k, n = 1, nv(model)
     for _ in 2:radius
         thislevel = @view neighbors[k:end]
         k = length(neighbors)

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -120,7 +120,6 @@ function nearby_positions(
     if radius == 1
         return neighbors
     end
-    
     seen = Set{Int}(neighbors)
     push!(seen, position)
     k, n = 1, nv(model)


### PR DESCRIPTION
Tried to come up with something better for this particular function, this new function gives some big speed-up:

<details> <summary> Benchmark </summary>

```julia
# normalize_position contains the new method
using Agents, Graphs, BenchmarkTools
using Agents: nearby_positions, nearby_positions2

graph_1 = GraphSpace(cycle_graph(200))
graph_2 = GraphSpace(erdos_renyi(500, 0.3))

mutable struct a <: AbstractAgent
    id::Int
    pos::Int
end

model_1 = ABM(a, graph_1)
model_2 = ABM(a, graph_2)

@btime nearby_positions(1, $model_1, 1)
@btime nearby_positions(1, $model_2, 1)
@btime nearby_positions2(1, $model_1, 1)
@btime nearby_positions2(1, $model_2, 1)

@btime nearby_positions(1, $model_1, 2)
@btime nearby_positions(1, $model_2, 2)
@btime nearby_positions2(1, $model_1, 2)
@btime nearby_positions2(1, $model_2, 2)

@btime nearby_positions(1, $model_1, 50)
@btime nearby_positions(1, $model_2, 50)
@btime nearby_positions2(1, $model_1, 50)
@btime nearby_positions2(1, $model_2, 50)
```

</details>

with this two particular graphs: `cycle_graph(200) # sparse connected graph` and `erdos_renyi(500, 0.3) #dense connected graph` we obtain the following speed-ups:

```julia
julia> @btime nearby_positions(1, $model_1, 1)
  20.479 ns (1 allocation: 80 bytes)
julia> @btime nearby_positions(1, $model_2, 1)
  60.394 ns (1 allocation: 1.33 KiB)
julia> @btime nearby_positions2(1, $model_1, 1)
  21.907 ns (1 allocation: 80 bytes)
julia> @btime nearby_positions2(1, $model_2, 1)
  142.612 ns (1 allocation: 1.33 KiB)
julia> @btime nearby_positions(1, $model_1, 2)
  151.930 ns (6 allocations: 560 bytes)
julia> @btime nearby_positions(1, $model_2, 2)
  161.855 μs (12 allocations: 18.73 KiB)
julia> @btime nearby_positions2(1, $model_1, 2)
  298.762 ns (8 allocations: 704 bytes)
julia> @btime nearby_positions2(1, $model_2, 2)
  1.310 ms (310 allocations: 13.87 MiB)
julia> @btime nearby_positions(1, $model_1, 50)
  2.843 μs (14 allocations: 5.56 KiB)
julia> @btime nearby_positions(1, $model_2, 50)
  562.258 μs (12 allocations: 18.73 KiB)
julia> @btime nearby_positions2(1, $model_1, 50)
  269.708 μs (2879 allocations: 1.62 MiB)
julia> @btime nearby_positions2(1, $model_2, 50)
  680.997 ms (48263 allocations: 6.74 GiB)
```
where `nearby_positions` is the updated one. With radius 2 we have a 2x speed-up for a cycle graph and a 10x speed-up for the other, and for radius 50 we get a 100x speed-up for the cycle graph and a 1000x speed-up for the other. Also the number of allocations is much better.

The algorithm is better than the previous one because it doesn't store the neighbors unless not visited, also it has some optimizations: it stops when there are no more neighbors even if the for loop on radius hasn't terminated, and it also returns if all nodes of the graph have been visited. I think this algorithm could be a good candidate for `Graphs.jl` itself to look for neighbors with a radius greater than 1, will try to add it there in the future :-)
