### PR TITLE
Refactor some utilities functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main
 - Huge improvement of performance of the `get_direction` function in the periodic case.
+- `normalize_position` is now 50x faster for the case of a non-periodic grid. 
 
 # v5.7
 - Internals of `AgentBasedModel` got reworked. It is now an abstract type, defining an abstract interface that concrete implementations may satisfy. This paves the way for flexibly defining new variants of `AgentBasedModel` that are more specialized in their applications.

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -12,16 +12,15 @@ sense: currently `AbstractGridSpace` and `ContinuousSpace`.
 
 Example usage in the [Flocking model](@ref).
 """
-euclidean_distance(
-    a::A,
-    b::B,
-    model::ABM{<:Union{ContinuousSpace,AbstractGridSpace}},
-) where {A <: AbstractAgent,B <: AbstractAgent} = euclidean_distance(a.pos, b.pos, model)
+euclidean_distance(a::A, b::B, model::ABM,
+) where {A <: AbstractAgent,B <: AbstractAgent} = euclidean_distance(a.pos, b.pos, model.space)
+
+euclidean_distance(p1, p2, model::ABM) = euclidean_distance(p1, p2, model.space)
 
 function euclidean_distance(
     p1::ValidPos,
     p2::ValidPos,
-    model::ABM{<:Union{ContinuousSpace{D,false},AbstractGridSpace{D,false}}},
+    space::Union{ContinuousSpace{D,false},AbstractGridSpace{D,false}},
 ) where {D}
     sqrt(sum(abs2.(p1 .- p2)))
 end
@@ -29,10 +28,10 @@ end
 function euclidean_distance(
     p1::ValidPos,
     p2::ValidPos,
-    model::ABM{<:Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}},
+    space::Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}},
 ) where {D}
     direct = abs.(p1 .- p2)
-    sqrt(sum(min.(direct, spacesize(model) .- direct).^2))
+    sqrt(sum(min.(direct, spacesize(space) .- direct).^2))
 end
 
 """
@@ -42,16 +41,15 @@ Return the manhattan distance between `a` and `b` (either agents or agent positi
 respecting periodic boundary conditions (if in use). Works with any space where it makes
 sense: currently `AbstractGridSpace` and `ContinuousSpace`.
 """
-manhattan_distance(
-    a::A,
-    b::B,
-    model::ABM{<:Union{ContinuousSpace,AbstractGridSpace}},
-) where {A <: AbstractAgent,B <: AbstractAgent} = manhattan_distance(a.pos, b.pos, model)
+manhattan_distance(a::A, b::B, model::ABM
+) where {A <: AbstractAgent,B <: AbstractAgent} = manhattan_distance(a.pos, b.pos, model.space)
+
+manhattan_distance(p1, p2, model::ABM) = euclidean_distance(p1, p2, model.space)
 
 function manhattan_distance(
     p1::ValidPos,
     p2::ValidPos,
-    model::ABM{<:Union{ContinuousSpace{D,false},AbstractGridSpace{D,false}}},
+    space::Union{ContinuousSpace{D,false},AbstractGridSpace{D,false}},
 ) where {D}
     sum(abs.(p1 .- p2))
 end
@@ -59,10 +57,10 @@ end
 function manhattan_distance(
     p1::ValidPos,
     p2::ValidPos,
-    model::ABM{<:Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}}
+    space::Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}
 ) where {D}
     direct = abs.(p1 .- p2)
-    sum(min.(direct, spacesize(model) .- direct))
+    sum(min.(direct, spacesize(space) .- direct))
 end
 
 """
@@ -71,11 +69,11 @@ Return the direction vector from the position `from` to position `to` taking int
 periodicity of the space.
 """
 get_direction(from, to, model::ABM) = get_direction(from, to, model.space)
-# Periodic spaces version
+
 function get_direction(
     from::ValidPos,
     to::ValidPos,
-    space::Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}
+    space::Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}},
 ) where {D}
     direct_dir = to .- from
     inverse_dir = direct_dir .- sign.(direct_dir) .* spacesize(space)
@@ -85,7 +83,7 @@ end
 function get_direction(
     from::ValidPos, 
     to::ValidPos, 
-    space::Union{AbstractGridSpace{D,false},ContinuousSpace{D,false}}
+    space::Union{AbstractGridSpace{D,false},ContinuousSpace{D,false}},
 ) where {D}
     return to .- from
 end
@@ -137,22 +135,22 @@ spaces this clamps the position to the space extent.
 """
 normalize_position(pos, model::ABM) = normalize_position(pos, model.space)
 
-function normalize_position(pos, space::ContinuousSpace{D,true}) where {D}
+function normalize_position(pos::ValidPos, space::ContinuousSpace{D,true}) where {D}
     return mod.(pos, spacesize(space))
 end
 
-function normalize_position(pos, space::ContinuousSpace{D,false}) where {D}
-    ss = spacesize(space)
-    return Tuple(clamp.(pos, 0.0, prevfloat.(ss)))
+function normalize_position(pos::ValidPos, space::ContinuousSpace{D,false}) where {D}
+    return clamp.(pos, 0.0, prevfloat.(spacesize(space)))
 end
 
-function normalize_position(pos, space::AbstractGridSpace{D,true}) where {D}
+function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,true}) where {D}
     return mod1.(pos, spacesize(space))
 end
 
-function normalize_position(pos, space::AbstractGridSpace{D,false}) where {D}
-    return Tuple(clamp.(pos, ones(Int, D), spacesize(space)))
+function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,false}) where {D}
+    return clamp.(pos, 1, spacesize(space))
 end
+
 
 """
     walk!(agent, direction::NTuple, model; ifempty = true)


### PR DESCRIPTION
this is mostly a refactor where I added a dispatch to space instead to pass directly the model to some utilities function, but there is also an improvement in performance for normalize_position in the non periodic grid case, I calculated that this new function is 50x faster than the previous one since calling `ones(Int, D)` is avoided now!