### PR TITLE
Not check presence of id for UnremovableABM models in step!

### DIFF
--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -14,9 +14,9 @@ struct SingleContainerABM{S<:SpaceType,A<:AbstractAgent,C<:ContainerType{A},F,P,
 end
 
 const SCABM = SingleContainerABM
-const StandardABM{A,S} = SingleContainerABM{A,S,Dict{Int,A}}
-const UnremovableABM{A,S} = SingleContainerABM{A,S,Vector{A}}
-const FixedMassABM{A,S} = SingleContainerABM{A,S,SizedVector{A}}
+const StandardABM = SingleContainerABM{S,A,Dict{Int,A}} where {S,A,C}
+const UnremovableABM = SingleContainerABM{S,A,Vector{A}} where {S,A,C}
+const FixedMassABM = SingleContainerABM{S,A,SizedVector{A}} where {S,A,C}
 
 containertype(::SingleContainerABM{S,A,C}) where {S,A,C} = C
 

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -39,23 +39,34 @@ Use instead of `agent_step!` in [`step!`](@ref) if no function is useful to be d
 """
 dummystep(agent, model) = nothing
 
-until(s, n::Integer, model) = s < n
+until(s, n::Int, model) = s < n
 until(s, n, model) = !n(model, s)
 
-step!(model::ABM, agent_step!, n::Integer=1, agents_first::Bool=true) = step!(model, agent_step!, dummystep, n, agents_first)
+step!(model::ABM, agent_step!, n::Int=1, agents_first::Bool=true) = step!(model, agent_step!, dummystep, n, agents_first)
 
 function step!(model::ABM, agent_step!, model_step!, n = 1, agents_first=true)
     s = 0
     while until(s, n, model)
         !agents_first && model_step!(model)
         if agent_step! ≠ dummystep
-            activation_order = schedule(model)
-            for index in activation_order
-                index in allids(model) || continue
-                agent_step!(model.agents[index], model)
-            end
+            activate_agents(model::ABM, agent_step!)
         end
         agents_first && model_step!(model)
         s += 1
+    end
+end
+
+function activate_agents(model::ABM, agent_step!)
+    activation_order = schedule(model)
+    for id in activation_order
+        id in allids(model) || continue
+        agent_step!(model[id], model)
+    end
+end
+
+function activate_agents(model::UnremovableABM, agent_step!)
+    activation_order = schedule(model)
+    for id in activation_order
+        agent_step!(model[id], model)
     end
 end

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -49,7 +49,7 @@ function step!(model::ABM, agent_step!, model_step!, n = 1, agents_first=true)
     while until(s, n, model)
         !agents_first && model_step!(model)
         if agent_step! ≠ dummystep
-            activate_agents(model::ABM, agent_step!)
+            activate_agents(model, agent_step!)
         end
         agents_first && model_step!(model)
         s += 1


### PR DESCRIPTION
The presence of the id can be spared to be checked when using an UnremovableABM. I also had to change the definition of the aliases in `model_concrete.jl` because previously referring to different ABM implementation wasn't possible, but I'm not sure if this is the right way to do it even if it works. Consider also that for an UnremovableABM checking if an id is present is much more costly than for a StandardABM since the vector has to be scanned.