### PR TITLE
Make model serialization more general

### DIFF
--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -219,7 +219,7 @@ function single_agent_types!(
     model::ABM,
     properties::AbstractArray,
 )
-    a = first(model.agents).second
+    a = model[first(allids(model))]
     for (i, k) in enumerate(properties)
         current_type = typeof(get_data(a, k, identity))
         isconcretetype(current_type) || @warn(

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -219,7 +219,7 @@ function single_agent_types!(
     model::ABM,
     properties::AbstractArray,
 )
-    a = model[first(allids(model))]
+    a = first(allagents(model))
     for (i, k) in enumerate(properties)
         current_type = typeof(get_data(a, k, identity))
         isconcretetype(current_type) || @warn(

--- a/src/submodules/io/jld2_integration.jl
+++ b/src/submodules/io/jld2_integration.jl
@@ -42,9 +42,10 @@ Refer to [`AgentsIO.to_serializable`](@ref) for more info.
 """
 from_serializable(t; kwargs...) = t
 
-struct SerializableABM{S,A<:AbstractAgent,P,R<:AbstractRNG}
+struct SerializableABM{S,A<:AbstractAgent,C,P,R<:AbstractRNG}
     agents::Vector{A}
     space::S
+    agents_container::C
     properties::P
     rng::R
     maxid::Int64
@@ -88,6 +89,7 @@ function to_serializable(t::ABM{S}) where {S}
     sabm = SerializableABM(
         collect(allagents(t)),
         to_serializable(t.space),
+        typeof(t.agents),
         to_serializable(t.properties),
         t.rng,
         t.maxid.x,
@@ -120,7 +122,8 @@ JLD2.wconvert(::Type{SerializableAStar{D,P,M,T,C}}, t::Pathfinding.AStar{D,P,M,T
 function from_serializable(t::SerializableABM{S,A}; kwargs...) where {S,A}
     abm = ABM(
         A,
-        from_serializable(t.space; kwargs...);
+        from_serializable(t.space; kwargs...),
+        container = t.agents_container,
         scheduler = get(kwargs, :scheduler, Schedulers.fastest),
         properties = from_serializable(t.properties; kwargs...),
         rng = t.rng,


### PR DESCRIPTION
This solves #773 since now the serialization includes the type of the agents_container so that we can reinstantiate the model with the correct container in `from_serializable`, it should now be possible to use it with all models implementations