### PR TITLE
Improve the speed of GridSpaceIdIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+# v5.11
+
 - Iterating in neighborhood searches (with `nearby_ids` and derivative functions) is now about 2 times faster than before.
 
 # v5.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # main
 
-- Iterating over ids in a `GridSpace` is now 2 times faster than before.
+- Iterating in neighborhood searches (with `nearby_ids` and derivative functions) is now about 2 times faster than before.
 
 # v5.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v5.11
 
-- Iterating in neighborhood searches (with `nearby_ids` and derivative functions) is now about 2 times faster than before.
+- Iterating in neighborhood searches (with `nearby_ids` and derivative functions) in `GridSpace` and `ContinuousSpace` is now about 2 times faster than before.
 
 # v5.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+- Iterating over ids in a `GridSpace` is now 2 times faster than before.
+
 # v5.10
 
 - `FixedMassABM` is now deprecated and will be removed in future versions. Turns out, there is no performance benefit of using it over `UnremovableABM`. In fact, there is a performance **deficit** in doing so.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.10.0"
+version = "5.11.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -133,6 +133,8 @@ Base.IteratorSize(::Type{<:GridSpaceIdIterator}) = Base.SizeUnknown()
 # Instructs how to combine two positions. Just to avoid code duplication for periodic
 combine_positions(pos, origin, ::GridSpaceIdIterator{false}) = pos .+ origin
 function combine_positions(pos, origin, iter::GridSpaceIdIterator{true})
+    # the mod function is not needed for many positions and it's expensive compared
+    # with checking for bounds so it is better to apply it only as a fallback.
     off_pos = pos .+ origin
     checkbounds(Bool, iter.stored_ids, off_pos...) && return off_pos
     return mod1.(off_pos, iter.space_size)

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -133,7 +133,9 @@ Base.IteratorSize(::Type{<:GridSpaceIdIterator}) = Base.SizeUnknown()
 # Instructs how to combine two positions. Just to avoid code duplication for periodic
 combine_positions(pos, origin, ::GridSpaceIdIterator{false}) = pos .+ origin
 function combine_positions(pos, origin, iter::GridSpaceIdIterator{true})
-    mod1.(pos .+ origin, iter.space_size)
+    off_pos = pos .+ origin
+    checkbounds(Bool, iter.stored_ids, off_pos...) && return off_pos
+    return mod1.(off_pos, iter.space_size)
 end
 
 # Initialize iteration
@@ -154,16 +156,14 @@ function Base.iterate(iter::GridSpaceIdIterator)
     # We have a valid position index and a non-empty position
     ids_in_pos = stored_ids[pos_index...]
     id = ids_in_pos[1]
-    return (id, (pos_i, 2))
     end
+    return (id, (pos_i, 2, ids_in_pos))
 end
 
 # Must return `true` if the access is invalid
 function invalid_access(pos_index, iter::GridSpaceIdIterator{false})
     valid_bounds = checkbounds(Bool, iter.stored_ids, pos_index...)
-    empty_pos = valid_bounds && @inbounds isempty(iter.stored_ids[pos_index...])
-    valid = valid_bounds && !empty_pos
-    return !valid
+    return !valid_bounds || @inbounds isempty(iter.stored_ids[pos_index...])
 end
 function invalid_access(pos_index, iter::GridSpaceIdIterator{true})
     @inbounds isempty(iter.stored_ids[pos_index...])
@@ -176,10 +176,7 @@ function Base.iterate(iter::GridSpaceIdIterator, state)
     @inbounds begin
     stored_ids, indices, L, origin = getproperty.(
         Ref(iter), (:stored_ids, :indices, :L, :origin))
-    pos_i, inner_i = state
-    pos_index = combine_positions(indices[pos_i], origin, iter)
-    # We know guaranteed from previous iteration that `pos_index` is valid index
-    ids_in_pos = stored_ids[pos_index...]
+    pos_i, inner_i, ids_in_pos = state
     X = length(ids_in_pos)
     if inner_i > X
         # we have exhausted IDs in current position, so we reset and go to next
@@ -198,10 +195,9 @@ function Base.iterate(iter::GridSpaceIdIterator, state)
     end
     # We reached the next valid position and non-empty position
     id = ids_in_pos[inner_i]
-    return (id, (pos_i, inner_i + 1))
+    return (id, (pos_i, inner_i + 1, ids_in_pos))
     end
 end
-
 
 
 ##########################################################################################


### PR DESCRIPTION
Found some little optimizations for the iterator, running some benchmark it is more or less 2x faster to iterate over results now!

<details>

```julia
using Agents, BenchmarkTools

@agent A GridAgent{2} begin
end

function periodic_model(; numagents = 1000, griddims = (20, 20))
    space = GridSpace(griddims, periodic = true)
    model = ABM(A, space)
    for _ in 1:numagents
        add_agent!(A, model)
    end
    return model
end

function aperiodic_model(; numagents = 1000, griddims = (20, 20))
    space = GridSpace(griddims, periodic = false)
    model = ABM(A, space)
    for _ in 1:numagents
        add_agent!(A, model)
    end
    return model
end

@benchmark collect(nearby_ids($(10,10), model, 1)) setup=(model=periodic_model())
@benchmark collect(nearby_ids($(10,10), model, 1)) setup=(model=aperiodic_model())
@benchmark collect(nearby_ids($(10,10), model, 10)) setup=(model=periodic_model())
@benchmark collect(nearby_ids($(10,10), model, 10)) setup=(model=aperiodic_model())
```

</details>


These are the results for medians

```julia
radius 1 nonperiodic -> before pr 260.688 ns after pr 189.850 ns
radius 1 periodic -> before pr 669.392 ns after pr 378.476 ns
radius 10 nonperiodic -> before pr 16.481 μs after pr 8.131 μs
radius 10 periodic -> before pr 37.990 μs after pr μs 21.661 μs
```
