### PR TITLE
Faster random_nearby_position for GridSpaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+- The `random_nearby_position` function is now much faster for GridSpaces.
+
 # v5.11
 
 - Iterating in neighborhood searches (with `nearby_ids` and derivative functions) in `GridSpace` and `ContinuousSpace` is now about 2 times faster than before.
@@ -16,7 +18,6 @@
   - `genocide! -> remove_all!`
   - `kill_agent! -> remove_agent!`
   - `UnkillableABM -> UnremovableABM`
-- `random_agent` is now faster and has two options on how to find a random agent, each of which can offer a different performance benefit depending on the density of agents that satisfy the clause.
 - New function `random_nearby_position` that returns a random neighbouring position.
 - New function `empty_nearby_positions` that returns an iterable of all empty neighboring positions.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.11.0"
+version = "5.12.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -148,6 +148,24 @@ function nearby_positions(
     return (mod1.(n .+ pos, space_size) for n in nindices)
 end
 
+function random_nearby_position(pos::ValidPos, model::ABM{<:AbstractGridSpace{D,false}}, r=1; kwargs...) where {D}
+    nindices = offsets_within_radius_no_0(model.space, r)
+    stored_ids = model.space.stored_ids
+    rng = abmrng(model)
+    while true
+        chosen_offset = rand(rng, nindices)
+        chosen_pos = pos .+ chosen_offset
+        checkbounds(Bool, stored_ids, chosen_pos...) && return chosen_pos
+    end
+end
+
+function random_nearby_position(pos::ValidPos, model::ABM{<:AbstractGridSpace{D,true}}, r=1; kwargs...) where {D}
+    nindices = offsets_within_radius_no_0(model.space, r)
+    chosen_offset = rand(abmrng(model), nindices)
+    chosen_pos = mod1.(pos .+ chosen_offset, spacesize(model))
+    return chosen_pos
+end
+  
 ###################################################################
 # pretty printing
 ###################################################################

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -161,9 +161,11 @@ end
 
 function random_nearby_position(pos::ValidPos, model::ABM{<:AbstractGridSpace{D,true}}, r=1; kwargs...) where {D}
     nindices = offsets_within_radius_no_0(model.space, r)
+    stored_ids = model.space.stored_ids
     chosen_offset = rand(abmrng(model), nindices)
-    chosen_pos = mod1.(pos .+ chosen_offset, spacesize(model))
-    return chosen_pos
+    chosen_pos = pos .+ chosen_offset
+    checkbounds(Bool, stored_ids, chosen_pos...) && return chosen_pos
+    return mod1.(chosen_pos, spacesize(model))
 end
   
 ###################################################################

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -196,28 +196,30 @@ using StableRNGs
         end
     end
 
-    @testset "Random nearby" begin
-        # Test random_nearby_*
-        abm = ABM(GridAgent{2}, GridSpace((10, 10)); rng = StableRNG(42))
-        fill_space!(abm)
+    @testset "$(periodic)" for periodic in (true, false)
+        @testset "Random nearby" begin
+            # Test random_nearby_*
+            abm = ABM(GridAgent{2}, SpaceType((10, 10), periodic=periodic); rng = StableRNG(42))
+            fill_space!(abm)
 
-        nearby_id = random_nearby_id(abm[1], abm, 5)
-        valid_ids = collect(nearby_ids(abm[1], abm, 5))
-        @test nearby_id in valid_ids
-        nearby_agent = random_nearby_agent(abm[1], abm, 5)
-        @test nearby_agent.id in valid_ids
+            nearby_id = random_nearby_id(abm[1], abm, 5)
+            valid_ids = collect(nearby_ids(abm[1], abm, 5))
+            @test nearby_id in valid_ids
+            nearby_agent = random_nearby_agent(abm[1], abm, 5)
+            @test nearby_agent.id in valid_ids
 
-        valid_positions = collect(nearby_positions(abm[1].pos, abm, 3))
-        nearby_position = random_nearby_position(abm[1].pos, abm, 3)
-        @test nearby_position in valid_positions
-        remove_all!(abm)
-        a = add_agent!((1, 1), abm)
-        @test isnothing(random_nearby_id(a, abm))
-        @test isnothing(random_nearby_agent(a, abm))
-        add_agent!((1,2), abm)
-        add_agent!((2,1), abm)
-        rand_nearby_ids = Set([random_nearby_id(a, abm, 2) for _ in 1:100])
-        @test length(rand_nearby_ids) == 2
+            valid_positions = collect(nearby_positions(abm[1].pos, abm, 3))
+            nearby_position = random_nearby_position(abm[1].pos, abm, 3)
+            @test nearby_position in valid_positions
+            remove_all!(abm)
+            a = add_agent!((1, 1), abm)
+            @test isnothing(random_nearby_id(a, abm))
+            @test isnothing(random_nearby_agent(a, abm))
+            add_agent!((1,2), abm)
+            add_agent!((2,1), abm)
+            rand_nearby_ids = Set([random_nearby_id(a, abm, 2) for _ in 1:100])
+            @test length(rand_nearby_ids) == 2
+       end
     end
 
     @testset "walk!" begin


### PR DESCRIPTION
This functions are faster and faster than using a reservoir sampling technique, since this way the operations are O(1), benchmark code used 

<details> 

```julia
using Agents, BenchmarkTools

@agent A GridAgent{2} begin
end

function aperiodic_model(; griddims = (100, 100))
    space = GridSpaceSingle(griddims, periodic = false)
    model = ABM(A, space)
    return model
end

function periodic_model(; griddims = (100, 100))
    space = GridSpaceSingle(griddims, periodic = true)
    model = ABM(A, space)
    return model
end

@benchmark random_nearby_position($(1,1), model, 10) setup=(model=periodic_model())
@benchmark random_nearby_position($(50,50), model, 10) setup=(model=periodic_model())
@benchmark random_nearby_position($(1,1), model, 1) setup=(model=aperiodic_model())
@benchmark random_nearby_position($(50,50), model, 1) setup=(model=aperiodic_model())
```

</details> 

with r=1 it is from 2 to 10x faster but clearly almost always 10x, with r=10 it is more than 1000 times faster!