### PR TITLE
Some small improvements to continuous space methods

### DIFF
--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -16,7 +16,7 @@ Time taken is presented in normalised units, measured against the runtime of Age
 
 For LOC, we use the following convention: code is formatted using standard practices & linting for the associated language. Documentation strings and in-line comments (residing on lines of their own) are discarded, as well as any benchmark infrastructure. NetLogo is assigned two values since its files have a code base section and an encoding of the GUI. Since many parameters live in the GUI, we must take this into account. Thus `375 (785)` in a NetLogo count means 375 lines in the code section, 785 lines total in the file. An additional complication to this value in NetLogo is that it stores plotting information (colours, shapes, sizes) as agent properties, and as such the number outside of the bracket may be slightly inflated.
 
-| Model/Framework | Agents 4.5.3 | Mesa 0.8.9| Netlogo 6.2 | MASON 20.0 |
+| Model/Framework | Agents 5.12.0 | Mesa 1.2.0 | Netlogo 6.3.0 | MASON 21.0 |
 |---|---|---|---|---|
 |Wolf Sheep Grass|1|21.5x|12.4x|NA|
 |(LOC)|122|227|137 (871)| . |

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -106,6 +106,9 @@ function cell_center(pos::NTuple{D,<:AbstractFloat}, model) where {D}
     model.space.spacing .* (pos2cell(pos, model) .- 0.5)
 end
 
+distance_from_cell_center(pos, model::ABM) =
+    euclidean_distance(pos, cell_center(pos, model), model)
+
 function add_agent_to_space!(
     a::A, model::ABM{<:ContinuousSpace,A}, cell_index = pos2cell(a, model)) where {A<:AbstractAgent}
     push!(model.space.grid.stored_ids[cell_index...], a.id)
@@ -188,7 +191,7 @@ function nearby_ids(pos::ValidPos, model::ABM{<:ContinuousSpace{D,A,T}}, r = 1;
         nearby_ids_exact(pos, model, r)
     end
     # Calculate maximum grid distance (distance + distance from cell center)
-    δ = euclidean_distance(pos, cell_center(pos, model), model)
+    δ = distance_from_cell_center(pos, model)
     # Ceiling since we want always to overestimate the number of ids
     grid_r = ceil(Int, (r + δ) / model.space.spacing)
     # Then return the ids within this distance, using the internal grid space

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -98,19 +98,12 @@ function random_position(model::ABM{<:ContinuousSpace})
 end
 
 "given position in continuous space, return cell coordinates in grid space."
-pos2cell(pos::Tuple, model::ABM) = @. floor(Int, pos/model.space.spacing) + 1
 pos2cell(a::AbstractAgent, model::ABM) = pos2cell(a.pos, model)
+pos2cell(pos::Tuple, model::ABM) = @. floor(Int, pos/model.space.spacing) + 1
 
 "given position in continuous space, return continuous space coordinates of cell center."
 function cell_center(pos::NTuple{D,<:AbstractFloat}, model) where {D}
-    ε = model.space.spacing
-    (pos2cell(pos, model) .- 1) .* ε .+ ε/2
-end
-
-distance_from_cell_center(pos, model::ABM) =
-    distance_from_cell_center(pos, cell_center(pos, model))
-function distance_from_cell_center(pos::Tuple, center::Tuple)
-    sqrt(sum(abs2.(pos .- center)))
+    model.space.spacing .* (pos2cell(pos, model) .- 0.5)
 end
 
 function add_agent_to_space!(
@@ -134,9 +127,8 @@ end
 # move the agent in the GridSpace; only change its position field
 function move_agent!(agent::A, pos::ValidPos, model::ABM{<:ContinuousSpace{D},A}
     ) where {D, A<:AbstractAgent}
-    for i in 1:D
-        pos[i] > spacesize(model)[i] && error("position is outside space extent!")
-    end
+    space_size = spacesize(model)
+    all(i -> 0 <= pos[i] < space_size[i], 1:D) || error("position is outside space extent!")
     oldcell = pos2cell(agent, model)
     newcell = pos2cell(pos, model)
     if oldcell ≠ newcell
@@ -196,8 +188,8 @@ function nearby_ids(pos::ValidPos, model::ABM{<:ContinuousSpace{D,A,T}}, r = 1;
         nearby_ids_exact(pos, model, r)
     end
     # Calculate maximum grid distance (distance + distance from cell center)
-    δ = distance_from_cell_center(pos, cell_center(pos, model))
-    # Ceiling since the grid has euclidean metric
+    δ = euclidean_distance(pos, cell_center(pos, model), model)
+    # Ceiling since we want always to overestimate the number of ids
     grid_r = ceil(Int, (r + δ) / model.space.spacing)
     # Then return the ids within this distance, using the internal grid space
     # and iteration via `GridSpaceIdIterator`, see spaces/grid_multi.jl

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -141,7 +141,6 @@ end
 
 
 
-
 """
     move_agent!(agent::A, model::ABM{<:ContinuousSpace,A}, dt::Real)
 Propagate the agent forwards one step according to its velocity, _after_ updating the

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -141,6 +141,7 @@ end
 
 
 
+
 """
     move_agent!(agent::A, model::ABM{<:ContinuousSpace,A}, dt::Real)
 Propagate the agent forwards one step according to its velocity, _after_ updating the

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -192,7 +192,7 @@ function nearby_ids(pos::ValidPos, model::ABM{<:ContinuousSpace{D,A,T}}, r = 1;
     end
     # Calculate maximum grid distance (distance + distance from cell center)
     δ = distance_from_cell_center(pos, model)
-    # Ceiling since we want always to overestimate the number of ids
+    # Ceiling since we want always to overestimate the radius
     grid_r = ceil(Int, (r + δ) / model.space.spacing)
     # Then return the ids within this distance, using the internal grid space
     # and iteration via `GridSpaceIdIterator`, see spaces/grid_multi.jl


### PR DESCRIPTION
Some little improvements to the methods, maybe most notably the test if the pos is inside the space in `move_agent` now tests also the lower bound as it was supposed to do.

edit: also changed netlogo version which I incorrectly reported as 6.4 but the lastest one, which I used to run the benchmark, it's actually the 6.3.0 :Q