### PR TITLE
Faster resorvoir_sampling_single function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # main
 
+# v5.13
+
+- `random_nearby_position`, `random_nearby_ids` and `random_nearby_agent` are up to 2 times faster thanks to a faster sampling function.
+
 # v5.12
 
 - The `random_nearby_position` function is now much faster for GridSpaces.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.12.0"
+version = "5.13.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -367,23 +367,19 @@ end
 function resorvoir_sampling_single(iter, model)
     res = iterate(iter)
     isnothing(res) && return nothing  # `iterate` returns `nothing` when it ends
-    
     rng = abmrng(model)
-    choice, state = res               # random position to return, and the state of the iterator
     w = max(rand(rng), eps())         # rand returns in range [0,1)
-
-    skip_counter = 0                  # skip entries in the iterator
-    while !isnothing(state) && !isnothing(iter)
-        if skip_counter == 0
-            choice, state = res
-            skip_counter = floor(log(rand(rng)) / log(1 - w))
-            w *= max(rand(rng), eps())
-        else
-            _, state = res
+    while true
+        choice, state = res           # random position to return, and the state of the iterator
+        skip_counter = floor(log(rand(rng)) / log(1 - w))
+        w *= max(rand(rng), eps())
+        while skip_counter != 0
+            skip_res = iterate(iter, state)
+            isnothing(skip_res) && return choice
+            state = skip_res[2]
             skip_counter -= 1
         end
         res = iterate(iter, state)
-        isnothing(res) && break
+        isnothing(res) && return choice
     end
-    return choice
 end

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -371,8 +371,7 @@ function resorvoir_sampling_single(iter, model)
     w = max(rand(rng), eps())         # rand returns in range [0,1)
     while true
         choice, state = res           # random position to return, and the state of the iterator
-        skip_counter = floor(log(rand(rng)) / log(1 - w))
-        w *= max(rand(rng), eps())
+        skip_counter = floor(log(rand(rng)) / log(1 - w))  # skip entries in the iterator
         while skip_counter != 0
             skip_res = iterate(iter, state)
             isnothing(skip_res) && return choice
@@ -381,5 +380,6 @@ function resorvoir_sampling_single(iter, model)
         end
         res = iterate(iter, state)
         isnothing(res) && return choice
+        w *= max(rand(rng), eps())
     end
 end


### PR DESCRIPTION
This is a bit faster than before, something like 2x faster, this is for a r=10 on a grid using the same benchmark as the one in in #784 (even if the sampling method was changed in #784 for a better method I used the old one which used the function):

before:

```julia
 Range (min … max):  4.288 μs …   8.639 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.467 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.497 μs ± 131.984 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

               ▅▄█▇▇▇▄▅▂                                       
  ▁▁▁▁▁▁▂▂▂▄▅▇████████████▆▅▄▅▄▃▄▄▄▄▃▄▃▃▃▂▂▂▂▂▂▁▁▁▂▁▁▁▁▁▁▁▁▁▁ ▃
  4.29 μs         Histogram: frequency by time        4.84 μs <
```
 
now:

```julia
 Range (min … max):  2.096 μs …   6.704 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.228 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.251 μs ± 149.042 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

             ▁▂▆▆██▆▇▂▃                                        
  ▁▁▁▁▁▁▁▂▃▄▆███████████▇▆▄▅▄▃▃▃▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁ ▃
  2.1 μs          Histogram: frequency by time        2.54 μs <
```
This is better since it consumes the not to choose elements faster without the if-else branching! 

For r=1 I found a negligible worse time instead (1-2 ns), but already nearly 1.5x faster with r=2.