### PR TITLE
Add using StatsBase to sir.jl example

### DIFF
--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -44,6 +44,7 @@
 cd(@__DIR__) #src
 using Agents, Random
 using Agents.DataFrames, Agents.Graphs
+using StatsBase: sample, Weights
 using DrWatson: @dict
 using CairoMakie
 CairoMakie.activate!() # hide
@@ -172,8 +173,6 @@ model = model_initiation(; params...)
 # ## SIR Stepping functions
 
 # Now we define the functions for modelling the virus spread in time
-
-using StatsBase
 
 function agent_step!(agent, model)
     migrate!(agent, model)

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -173,6 +173,8 @@ model = model_initiation(; params...)
 
 # Now we define the functions for modelling the virus spread in time
 
+using StatsBase
+
 function agent_step!(agent, model)
     migrate!(agent, model)
     transmit!(agent, model)


### PR DESCRIPTION
In sir.jl example, ```sample()``` and ```Weights()``` functions were used without ```using StatsBase```.
