### PR TITLE
Filtering for random_nearby_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 # v5.14
 
-- New optional filtering functionality to restrict the sampling added to `random_nearby_position`, `random_nearby_ids` and `random_nearby_agent`.
+- New optional filtering functionality to restrict the sampling added to `random_nearby_position`, `random_nearby_id` and `random_nearby_agent`.
 
 # v5.13
 
-- `random_nearby_position`, `random_nearby_ids` and `random_nearby_agent` are up to 2 times faster thanks to a faster sampling function.
+- `random_nearby_position`, `random_nearby_id` and `random_nearby_agent` are up to 2 times faster thanks to a faster sampling function.
 
 # v5.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # main
 
+# v5.14
+
+- New optional filtering functionality to restrict the sampling added to `random_nearby_position`, `random_nearby_ids` and `random_nearby_agent`.
+
 # v5.13
 
 - `random_nearby_position`, `random_nearby_ids` and `random_nearby_agent` are up to 2 times faster thanks to a faster sampling function.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati"]
-version = "5.13.0"
+version = "5.14.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -257,4 +257,3 @@ function Base.setindex!(m::ABM, args...; kwargs...)
     error("`setindex!` or `model[id] = agent` are invalid. Use `add_agent!(model, agent)` "*
     "or other variants of an `add_agent_...` function to add agents to an ABM.")
 end
-

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -162,21 +162,8 @@ function random_agent(model, condition; optimistic=false)
     if optimistic
         return optimistic_random_agent(model, condition)
     else
-        return allocating_random_agent(model, condition)
+        return sampling_with_condition_agents_single(allids(model), condition, model)
     end
-end
-
-function allocating_random_agent(model, condition)
-    ids = collect(allids(model))
-    rng = abmrng(model)
-    while !isempty(ids)
-        index_id = rand(rng, eachindex(ids))
-        id = ids[index_id]
-        condition(model[id]) && return model[id]
-        ids[index_id], ids[end] = ids[end], ids[index_id]
-        pop!(ids)
-    end
-    return nothing
 end
 
 function optimistic_random_agent(model, condition; n_attempts = 3*nagents(model))
@@ -186,7 +173,7 @@ function optimistic_random_agent(model, condition; n_attempts = 3*nagents(model)
         condition(model[idx]) && return model[idx]
     end
     # Fallback after n_attempts tries to find an agent
-    return allocating_random_agent(model, condition)
+    return sampling_with_condition_agents_single(allids(model), condition, model)
 end
 
 # TODO: In the future, it is INVALID to access space, agents, etc., with the .field syntax.

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -257,3 +257,4 @@ function Base.setindex!(m::ABM, args...; kwargs...)
     error("`setindex!` or `model[id] = agent` are invalid. Use `add_agent!(model, agent)` "*
     "or other variants of an `add_agent_...` function to add agents to an ABM.")
 end
+

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -323,7 +323,7 @@ nearby_agents(a, model, r = 1; kwargs...) =
     (model[id] for id in nearby_ids(a, model, r; kwargs...))
 
 """
-    random_nearby_id(agent, model::ABM, r = 1, f=nothing; kwargs...) → id
+    random_nearby_id(agent, model::ABM, r = 1, f = nothing; kwargs...) → id
 Return the `id` of a random agent near the position of the given `agent` using an optimized
 algorithm from [Reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling#An_optimal_algorithm).
 Return `nothing` if no agents are nearby.
@@ -343,7 +343,7 @@ function random_nearby_id(a, model, r = 1, f = nothing; kwargs...)
 end
 
 """
-    random_nearby_agent(agent, model::ABM, r = 1, f=nothing; kwargs...) → agent
+    random_nearby_agent(agent, model::ABM, r = 1, f = nothing; kwargs...) → agent
 Return a random agent near the position of the given `agent` or `nothing` if no agent
 is nearby.
 
@@ -364,7 +364,7 @@ function random_nearby_agent(a, model, r = 1, f = nothing; kwargs...)
 end
 
 """
-    random_nearby_position(position, model::ABM, r=1, f=nothing; kwargs...) → position
+    random_nearby_position(position, model::ABM, r=1, f = nothing; kwargs...) → position
 Return a random position near the given `position`. Return `nothing` if the space doesn't allow for nearby positions.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_positions`](@ref).

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -323,47 +323,100 @@ nearby_agents(a, model, r = 1; kwargs...) =
     (model[id] for id in nearby_ids(a, model, r; kwargs...))
 
 """
-    random_nearby_id(agent, model::ABM, r = 1; kwargs...) → id
+    random_nearby_id(agent, model::ABM, r = 1, f=nothing; kwargs...) → id
 
 Return the `id` of a random agent near the position of the given `agent` using an optimized
 algorithm from [Reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling#An_optimal_algorithm).
 Return `nothing` if no agents are nearby.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_ids`](@ref).
+
+A filter function `f` can be passed so that to restrict the sampling on only those ids for which
+the function returns true.
 """
-function random_nearby_id(a, model, r = 1; kwargs...)
-    # Uses Reservoir sampling (https://en.wikipedia.org/wiki/Reservoir_sampling)
+function random_nearby_id(a, model, r = 1, f = nothing; kwargs...)
     iter = nearby_ids(a, model, r; kwargs...)
-    return resorvoir_sampling_single(iter, model)
+    if isnothing(f)
+        return resorvoir_sampling_single(iter, model)
+    else
+        return sampling_with_condition_single(iter, f, model)
+    end
 end
 
 """
-    random_nearby_agent(agent, model::ABM, r = 1; kwargs...) → agent
+    random_nearby_agent(agent, model::ABM, r = 1, f=nothing; kwargs...) → agent
 
 Return a random agent near the position of the given `agent` or `nothing` if no agent
 is nearby.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_ids`](@ref).
+
+A filter function `f` can be passed so that to restrict the sampling on only those agents for which
+the function returns true.
 """
-function random_nearby_agent(a, model, r = 1; kwargs...)
-    id = random_nearby_id(a, model, r; kwargs...)
-    isnothing(id) && return
-    return model[id]
+function random_nearby_agent(a, model, r = 1, f = nothing; kwargs...)
+    if isnothing(f)
+        id = random_nearby_id(a, model, r; kwargs...)
+        isnothing(id) && return nothing
+        return model[id]
+    else
+        iter = nearby_ids(a, model, r; kwargs...)
+        return sampling_with_condition_agents_single(iter, f, model)
+    end
 end
 
 """
-    random_nearby_position(position, model::ABM, r=1; kwargs...) → position
+    random_nearby_position(position, model::ABM, r=1, f=nothing; kwargs...) → position
 
 Return a random position near the given `position`. Return `nothing` if the space doesn't allow for nearby positions.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_positions`](@ref).
+
+A filter function `f` can be passed so that to restrict the sampling on only those positions for which
+the function returns true.
 """
-function random_nearby_position(pos, model, r=1; kwargs...)
-    # Uses the same Reservoir Sampling algorithm than nearby_ids
+function random_nearby_position(pos, model, r=1, f = nothing; kwargs...)
     iter = nearby_positions(pos, model, r; kwargs...)
-    return resorvoir_sampling_single(iter, model)
+    if isnothing(f)
+        return resorvoir_sampling_single(iter, model)
+    else
+        return sampling_with_condition_single(iter, f, model)
+    end
 end
 
+#######################################################################################
+# %% sampling functions
+#######################################################################################
+
+function sampling_with_condition_single(iter, condition, model)
+    population = collect(iter)
+    rng = abmrng(model)
+    while !isempty(population)
+        index_id = rand(rng, eachindex(population))
+        el = population[index_id]
+        condition(el, model) && return el
+        population[index_id], population[end] = population[end], population[index_id]
+        pop!(population)
+    end
+    return nothing
+end
+
+# almost a copy of sampling_with_condition_single, but it's better to call this one
+# when selecting an agent since collecting ids is less costly than collecting agents
+function sampling_with_condition_agents_single(iter, condition, model)
+    population = collect(iter)
+    rng = abmrng(model)
+    while !isempty(population)
+        index_id = rand(rng, eachindex(population))
+        el = population[index_id]
+        condition(model[el], model) && return model[el]
+        population[index_id], population[end] = population[end], population[index_id]
+        pop!(population)
+    end
+    return nothing
+end
+
+# Reservoir sampling function (https://en.wikipedia.org/wiki/Reservoir_sampling)
 function resorvoir_sampling_single(iter, model)
     res = iterate(iter)
     isnothing(res) && return nothing  # `iterate` returns `nothing` when it ends
@@ -383,3 +436,4 @@ function resorvoir_sampling_single(iter, model)
         w *= max(rand(rng), eps())
     end
 end
+

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -324,15 +324,14 @@ nearby_agents(a, model, r = 1; kwargs...) =
 
 """
     random_nearby_id(agent, model::ABM, r = 1, f=nothing; kwargs...) → id
-
 Return the `id` of a random agent near the position of the given `agent` using an optimized
 algorithm from [Reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling#An_optimal_algorithm).
 Return `nothing` if no agents are nearby.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_ids`](@ref).
 
-A filter function `f(id, model)` can be passed so that to restrict the sampling on only those ids for which
-the function returns true.
+A filter function `f(id)` can be passed so that to restrict the sampling on only those ids for which
+the function returns `true`.
 """
 function random_nearby_id(a, model, r = 1, f = nothing; kwargs...)
     iter = nearby_ids(a, model, r; kwargs...)
@@ -345,14 +344,13 @@ end
 
 """
     random_nearby_agent(agent, model::ABM, r = 1, f=nothing; kwargs...) → agent
-
 Return a random agent near the position of the given `agent` or `nothing` if no agent
 is nearby.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_ids`](@ref).
 
-A filter function `f(agent, model)` can be passed so that to restrict the sampling on only those agents for which
-the function returns true.
+A filter function `f(agent)` can be passed so that to restrict the sampling on only those agents for which
+the function returns `true`.
 """
 function random_nearby_agent(a, model, r = 1, f = nothing; kwargs...)
     if isnothing(f)
@@ -367,13 +365,12 @@ end
 
 """
     random_nearby_position(position, model::ABM, r=1, f=nothing; kwargs...) → position
-
 Return a random position near the given `position`. Return `nothing` if the space doesn't allow for nearby positions.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_positions`](@ref).
 
-A filter function `f(pos, model)` can be passed so that to restrict the sampling on only those positions for which
-the function returns true.
+A filter function `f(pos)` can be passed so that to restrict the sampling on only those positions for which
+the function returns `true`.
 """
 function random_nearby_position(pos, model, r=1, f = nothing; kwargs...)
     iter = nearby_positions(pos, model, r; kwargs...)
@@ -394,7 +391,7 @@ function sampling_with_condition_single(iter, condition, model)
     while !isempty(population)
         index_id = rand(rng, eachindex(population))
         el = population[index_id]
-        condition(el, model) && return el
+        condition(el) && return el
         population[index_id], population[end] = population[end], population[index_id]
         pop!(population)
     end
@@ -409,7 +406,7 @@ function sampling_with_condition_agents_single(iter, condition, model)
     while !isempty(population)
         index_id = rand(rng, eachindex(population))
         el = population[index_id]
-        condition(model[el], model) && return model[el]
+        condition(model[el]) && return model[el]
         population[index_id], population[end] = population[end], population[index_id]
         pop!(population)
     end

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -331,7 +331,7 @@ Return `nothing` if no agents are nearby.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_ids`](@ref).
 
-A filter function `f` can be passed so that to restrict the sampling on only those ids for which
+A filter function `f(id, model)` can be passed so that to restrict the sampling on only those ids for which
 the function returns true.
 """
 function random_nearby_id(a, model, r = 1, f = nothing; kwargs...)
@@ -351,7 +351,7 @@ is nearby.
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_ids`](@ref).
 
-A filter function `f` can be passed so that to restrict the sampling on only those agents for which
+A filter function `f(agent, model)` can be passed so that to restrict the sampling on only those agents for which
 the function returns true.
 """
 function random_nearby_agent(a, model, r = 1, f = nothing; kwargs...)
@@ -372,7 +372,7 @@ Return a random position near the given `position`. Return `nothing` if the spac
 
 The value of the argument `r` and possible keywords operate identically to [`nearby_positions`](@ref).
 
-A filter function `f` can be passed so that to restrict the sampling on only those positions for which
+A filter function `f(pos, model)` can be passed so that to restrict the sampling on only those positions for which
 the function returns true.
 """
 function random_nearby_position(pos, model, r=1, f = nothing; kwargs...)
@@ -436,4 +436,3 @@ function resorvoir_sampling_single(iter, model)
         w *= max(rand(rng), eps())
     end
 end
-

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -198,19 +198,33 @@ using StableRNGs
 
     @testset "$(periodic)" for periodic in (true, false)
         @testset "Random nearby" begin
-            # Test random_nearby_*
             abm = ABM(GridAgent{2}, SpaceType((10, 10), periodic=periodic); rng = StableRNG(42))
             fill_space!(abm)
-
+            # test random_nearby_id
             nearby_id = random_nearby_id(abm[1], abm, 5)
             valid_ids = collect(nearby_ids(abm[1], abm, 5))
             @test nearby_id in valid_ids
-            nearby_agent = random_nearby_agent(abm[1], abm, 5)
-            @test nearby_agent.id in valid_ids
-
+            some_ids = valid_ids[1:3]
+            f(id, model) = id in some_ids
+            filtered_nearby_id = random_nearby_id(abm[1], abm, 5, f)
+            @test filtered_nearby_id in some_ids
+            # test random_nearby_position
             valid_positions = collect(nearby_positions(abm[1].pos, abm, 3))
             nearby_position = random_nearby_position(abm[1].pos, abm, 3)
             @test nearby_position in valid_positions
+            some_positions = valid_positions[3:5]
+            g(pos, model) = pos in some_positions
+            filtered_nearby_position = random_nearby_position(abm[1].pos, abm, 3, g)
+            @test filtered_nearby_position in some_positions
+            # test random_nearby_agent
+            valid_agents = collect(nearby_agents(abm[1], abm, 2))
+            nearby_agent = random_nearby_agent(abm[1], abm, 2)
+            @test nearby_agent in valid_agents
+            some_agents = valid_agents[2:4]
+            h(agent, model) = agent in some_agents
+            filtered_nearby_agent = random_nearby_agent(abm[1], abm, 2, h)
+            @test filtered_nearby_agent in some_agents
+            # test methods after removal of all agents
             remove_all!(abm)
             a = add_agent!((1, 1), abm)
             @test isnothing(random_nearby_id(a, abm))

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -205,7 +205,7 @@ using StableRNGs
             valid_ids = collect(nearby_ids(abm[1], abm, 5))
             @test nearby_id in valid_ids
             some_ids = valid_ids[1:3]
-            f(id, model) = id in some_ids
+            f(id) = id in some_ids
             filtered_nearby_id = random_nearby_id(abm[1], abm, 5, f)
             @test filtered_nearby_id in some_ids
             # test random_nearby_position
@@ -213,7 +213,7 @@ using StableRNGs
             nearby_position = random_nearby_position(abm[1].pos, abm, 3)
             @test nearby_position in valid_positions
             some_positions = valid_positions[3:5]
-            g(pos, model) = pos in some_positions
+            g(pos) = pos in some_positions
             filtered_nearby_position = random_nearby_position(abm[1].pos, abm, 3, g)
             @test filtered_nearby_position in some_positions
             # test random_nearby_agent
@@ -221,7 +221,7 @@ using StableRNGs
             nearby_agent = random_nearby_agent(abm[1], abm, 2)
             @test nearby_agent in valid_agents
             some_agents = valid_agents[2:4]
-            h(agent, model) = agent in some_agents
+            h(agent) = agent in some_agents
             filtered_nearby_agent = random_nearby_agent(abm[1], abm, 2, h)
             @test filtered_nearby_agent in some_agents
             # test methods after removal of all agents


### PR DESCRIPTION
This implements the filtering feature discussed in #650, in the process I created two new function `sampling_with_condition_single` and `sampling_with_condition_agents_single` so that to reuse the code. Some benchmarks using the code posted in #650 seem good:

```julia
julia> @btime random_nearby_id($(25,25), model, 10) setup=(model=periodic_model())
  171.405 μs (17884 allocations: 845.36 KiB)
54290

julia> f(x, y) = true
f (generic function with 1 method)

julia> @btime random_nearby_id($(25,25), model, 10, f) setup=(model=periodic_model())
  242.911 μs (17893 allocations: 1.14 MiB)
66712

julia> f(x, y) = false
f (generic function with 1 method)

julia> @btime random_nearby_id($(25,25), model, 10, f) setup=(model=periodic_model())
  354.953 μs (17893 allocations: 1.14 MiB)
```

But this PR still needs some tests for the new functionality, which I will implement soon --> test added
