### PR TITLE
Refactor of some scheduler operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # main
 
-- The `ByProperty` scheduler can now accept any type of properties, while before it was restricted to only floats. The `ByID` scheduler of an `UnremovableABM` is now as fast as the `Fastest` scheduler since in this case they are actually equivalent.
+- The `ByProperty` scheduler can now accept any type of (ordered) properties, while before it was restricted to only floats. The `ByID` scheduler of an `UnremovableABM` is now as fast as the `Fastest` scheduler since in this case they are actually equivalent.
 
 # v5.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+- The `ByProperty` scheduler can now accept any type of properties, while before it was restricted to only floats. The `ByID` scheduler of an `UnremovableABM` is now as fast as the `Fastest` scheduler since in this case they are actually equivalent.
+
 # v5.14
 
 - New optional filtering functionality to restrict the sampling added to `random_nearby_position`, `random_nearby_id` and `random_nearby_agent`.

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -301,3 +301,11 @@ function (sched::ByType)(model::ABM)
 
     return Iterators.flatten(it for it in sched.ids)
 end
+
+@deprecate by_id ById
+@deprecate randomly Randomly
+@deprecate partially Partially
+@deprecate by_property ByProperty
+@deprecate by_type ByType
+
+end # Schedulers submodule

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -158,11 +158,10 @@ function by_property(p)
     end
 end
 
-mutable struct ByProperty{P}
+struct ByProperty{P}
     p::P
     ids::Vector{Int}
     perm::Vector{Int}
-    properties::Vector
 end
 
 """
@@ -177,7 +176,7 @@ ByProperty(p::P) where {P} = ByProperty{P}(p, Int[], Int[], [])
 function (sched::ByProperty)(model::ABM)
     get_ids!(sched.ids, model)
     
-    sched.properties = [Agents.get_data(model[id], sched.p) for id in sched.ids]
+    properties = [Agents.get_data(model[id], sched.p) for id in sched.ids]
 
     initialized = true
     if length(sched.perm) != length(sched.ids)
@@ -185,7 +184,7 @@ function (sched::ByProperty)(model::ABM)
         initialized = false
     end
 
-    sortperm!(sched.perm, sched.properties; initialized)
+    sortperm!(sched.perm, properties; initialized)
     return Iterators.map(i -> sched.ids[i], sched.perm)
 end
 

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -171,7 +171,7 @@ their `property`, with agents with greater `property` acting first. `property` c
 `Symbol`, which just dictates which field of the agents to compare, or a function which
 inputs an agent and outputs a real number.
 """
-ByProperty(p::P) where {P} = ByProperty{P}(p, Int[], Int[], [])
+ByProperty(p::P) where {P} = ByProperty{P}(p, Int[], Int[])
 
 function (sched::ByProperty)(model::ABM)
     get_ids!(sched.ids, model)


### PR DESCRIPTION
I refactored some operations:

- Added a faster `get_ids!` function in the case of a `UnremovableABM`
- Changed the ByID for an `UnremovableABM` in the simple call of the id container, now it is much faster and equivalent to the fastest scheduler
- `ByProperty` now can accept any properties values, not just floats, but it reallocates each time the vector `properties`, it seems like reallocating is better since doing this 

```julia
    if isempty(sched.properties)
        sched.properties = [Agents.get_data(model[id], sched.p) for id in sched.ids]
    else
        resize!(sched.properties, length(sched.ids))
        for (i, id) in enumerate(sched.ids)
            sched.properties[i] = Agents.get_data(model[id], sched.p)
        end
    end
```

instead of  `sched.properties = [Agents.get_data(model[id], sched.p) for id in sched.ids]`

makes the code slower than before (anyway I will remove the properties field from the struct since it's unnecessary but this is used here just to show that a non allocating version was possible, but actually slower!). Also, I tested the new `ByProperty` on wolfsheep and the time is nearly the same with the used `by_property` scheduler, don't know if in other situation this `ByProperty` scheduler can have an advantage on the old one since it allocates less