### PR TITLE
Fix small return type instability in `walk!`

### DIFF
--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -38,6 +38,7 @@ function walk!(
     if !ifempty || isempty(target, model)
         move_agent!(agent, target, model)
     end
+    return agent
 end
 
 function walk!(
@@ -49,6 +50,7 @@ function walk!(
     if isempty(target, model) # if target unoccupied
         move_agent!(agent, target, model)
     end
+    return agent
 end
 
 function walk!(
@@ -58,6 +60,7 @@ function walk!(
 ) where {D}
     target = normalize_position(agent.pos .+ direction, model)
     move_agent!(agent, target, model)
+    return agent
 end
 
 """


### PR DESCRIPTION
This makes `walk!` a little bit more performant (something like 5%), there was no specification for return values in the docs so I think it should be fine to return the `agent`