### PR TITLE
Update schoolyard.jl

### DIFF
--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -57,7 +57,7 @@ function schoolyard(;
 )
     model = ABM(
         Student,
-        ContinuousSpace((100, 100), spacing; periodic = false);
+        ContinuousSpace((100, 100); spacing=spacing, periodic=false);
         properties = Dict(
             :teacher_attractor => teacher_attractor,
             :noise => noise,


### PR DESCRIPTION
As described in the issue #810
Schoolyard Example gives the following error:

┌ Warning: Specifying spacing by position is deprecated. Use keyword spacing instead. └ @ Agents C:\Users\Username.julia\packages\Agents\PhazO\src\deprecations.jl:11

The problem seems to be:

ContinuousSpace((100, 100), spacing; periodic = false);

a solution:

ContinuousSpace((100, 100); spacing=spacing, periodic=false);