### PR TITLE
Improve speed of Nearby Look-ups in GridSpaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main
 
+- Nearby look-ups with `nearby_positions`, `nearby_ids` and derivatives are now incrementally faster than before more the radius increases.
 - The `randomwalk!` function is now supported for any number of dimensions in ContinuousSpace when used to create isotropic/uniform random walks. For all type of `AbstractGridSpace`, the `randomwalk!` function supports a new keyword `force_motion`, which is false by default. See the docs to be informed on the effect of setting this keyword. Besides, in the continuous space default case random walks are up to 2 times faster than before.
 - The `ByProperty` scheduler can now accept any type of (ordered) properties, while before it was restricted to only floats. The `ByID` scheduler of an `UnremovableABM` is now as fast as the `Fastest` scheduler since in this case they are actually equivalent.
 

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -146,12 +146,15 @@ function nearby_positions(
         pos::ValidPos, space::AbstractGridSpace{D,true}, r = 1,
         get_indices_f = offsets_within_radius_no_0 # NOT PUBLIC API! For `ContinuousSpace`.
     ) where {D}
+    stored_ids = space.stored_ids
     nindices = get_indices_f(space, r)
     space_size = size(space)
+    # check if we are far from the wall to skip bounds checks
     if all(i -> r < pos[i] <= space_size[i] - r, 1:D)
         return (n .+ pos for n in nindices)
     else
-        return (mod1.(n .+ pos, space_size) for n in nindices)
+        return (checkbounds(Bool, stored_ids, (n .+ pos)...) ? 
+                n .+ pos : mod1.(n .+ pos, space_size) for n in nindices)
     end
 end
 

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -134,10 +134,12 @@ function nearby_positions(
     ) where {D}
     stored_ids = space.stored_ids
     nindices = get_indices_f(space, r)
-    positions_iterator = (n .+ pos for n in nindices)
-    return Base.Iterators.filter(
-        pos -> checkbounds(Bool, stored_ids, pos...), positions_iterator
-    )
+    space_size = size(stored_ids)
+    if all(i -> r < pos[i] <= space_size[i] - r, 1:D)
+        return (n .+ pos for n in nindices)
+    else
+        return (n .+ pos for n in nindices if checkbounds(Bool, stored_ids, (n .+ pos)...))
+    end
 end
 function nearby_positions(
         pos::ValidPos, space::AbstractGridSpace{D,true}, r = 1,
@@ -145,7 +147,11 @@ function nearby_positions(
     ) where {D}
     nindices = get_indices_f(space, r)
     space_size = size(space)
-    return (mod1.(n .+ pos, space_size) for n in nindices)
+    if all(i -> r < pos[i] <= space_size[i] - r, 1:D)
+        return (n .+ pos for n in nindices)
+    else
+        return (mod1.(n .+ pos, space_size) for n in nindices)
+    end
 end
 
 function random_nearby_position(pos::ValidPos, model::ABM{<:AbstractGridSpace{D,false}}, r=1; kwargs...) where {D}

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -135,6 +135,7 @@ function nearby_positions(
     stored_ids = space.stored_ids
     nindices = get_indices_f(space, r)
     space_size = size(stored_ids)
+    # check if we are far from the wall to skip bounds checks
     if all(i -> r < pos[i] <= space_size[i] - r, 1:D)
         return (n .+ pos for n in nindices)
     else

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -139,8 +139,7 @@ function combine_positions(pos, origin, iter::GridSpaceIdIterator{true}, nocheck
     # the mod function is not needed for many positions and it's expensive compared
     # with checking for bounds so it is better to apply it only as a fallback.
     off_pos = pos .+ origin
-    nocheck && return off_pos
-    checkbounds(Bool, iter.stored_ids, off_pos...) && return off_pos
+    (nocheck || checkbounds(Bool, iter.stored_ids, off_pos...)) && return off_pos
     return mod1.(off_pos, iter.space_size)
 end
 

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -122,7 +122,7 @@ struct GridSpaceIdIterator{P,D}
     origin::NTuple{D,Int}             # origin position nearby is measured from
     L::Int                            # length of `indices`
     space_size::NTuple{D,Int}         # size of `stored_ids`
-    nocheck::Bool
+    nocheck::Bool                          # skip bound checks if we are far from the edges
 end
 function GridSpaceIdIterator{P}(stored_ids, indices, origin::NTuple{D,Int}, nocheck) where {P,D}
     L = length(indices)

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -202,7 +202,7 @@ function Base.iterate(iter::GridSpaceIdIterator, state)
             pos_i > L && return nothing
             pos_index = combine_positions(indices[pos_i], origin, iter, nocheck)
         end
-        ids_in_pos = @inbounds stored_ids[pos_index...]
+        ids_in_pos = stored_ids[pos_index...]
     end
     # We reached the next valid position and non-empty position
     id = ids_in_pos[inner_i]

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -138,9 +138,8 @@ combine_positions(pos, origin, ::GridSpaceIdIterator{false}, ::Bool) = pos .+ or
 function combine_positions(pos, origin, iter::GridSpaceIdIterator{true}, nocheck)
     # the mod function is not needed for many positions and it's expensive compared
     # with checking for bounds so it is better to apply it only as a fallback.
-    off_pos = pos .+ origin
-    (nocheck || checkbounds(Bool, iter.stored_ids, off_pos...)) && return off_pos
-    return mod1.(off_pos, iter.space_size)
+    npos = pos .+ origin
+    (nocheck || checkbounds(Bool, iter.stored_ids, npos...)) ? npos : mod1.(npos, iter.space_size)
 end
 
 # Initialize iteration

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -87,12 +87,14 @@ function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,true}}, 
     stored_ids = model.space.stored_ids
     space_size = size(stored_ids)
     position_iterator = (pos .+ β for β in nindices)
+    # check if we are far from the wall to skip bounds checks
     if all(i -> r < pos[i] <= space_size[i] - r, 1:D)
         ids_iterator = (stored_ids[p...] for p in position_iterator 
                         if stored_ids[p...] != 0)
     else
-        ids_iterator = (stored_ids[mod1.(p, space_size)...] for p in position_iterator
-                        if stored_ids[mod1.(p, space_size)...] != 0)
+        ids_iterator = (checkbounds(Bool, stored_ids, p...) ? 
+                        stored_ids[p...] : stored_ids[mod1.(p, space_size)...]
+                        for p in position_iterator if stored_ids[mod1.(p, space_size)...] != 0)
     end
     return ids_iterator
 end
@@ -104,6 +106,7 @@ function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,false}},
     stored_ids = model.space.stored_ids
     space_size = size(stored_ids)
     position_iterator = (pos .+ β for β in nindices)
+    # check if we are far from the wall to skip bounds checks
     if all(i -> r < pos[i] <= space_size[i] - r, 1:D)
         ids_iterator = (stored_ids[p...] for p in position_iterator 
                         if stored_ids[p...] != 0)

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -123,15 +123,3 @@ function nearby_ids(
     a::A, model::ABM{<:GridSpaceSingle{D},A}, r = 1) where {D,A<:AbstractAgent}
     return nearby_ids(a.pos, model, r, offsets_within_radius_no_0)
 end
-
-# Method for walking on GridSpaceSingle, similar to `walk!` in spaces/utilities.jl
-function walk!(
-    agent::AbstractAgent,
-    direction::NTuple{D,Int},
-    model::ABM{<:GridSpaceSingle}
-) where {D}
-    target = normalize_position(agent.pos .+ direction, model)
-    if isempty(target, model) # if target unoccupied
-        move_agent!(agent, target, model)
-    end
-end

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -113,7 +113,7 @@ function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,false}},
     end
     return ids_iterator
 end
- 
+
 # Contrary to `GridSpace`, we also extend here `nearby_ids(a::Agent)`.
 # Because, we know that one agent exists per position, and hence we can skip the
 # call to `filter(id -> id ≠ a.id, ...)` that happens in core/space_interaction_API.jl.


### PR DESCRIPTION
This came to my mind today, it's a simple change but has a big impact: 
Flocking in the large version is 1.5x faster now! edit: but with a big catch :D, see below

In general it has a good impact when periodic is true and just a slight impact when it is false.

It's time for 5.15 I guess  :D
