### PR TITLE
Fix performance of some versions of add_agent

### DIFF
--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -254,20 +254,20 @@ add_agent!(5, model, 0.5, true) # add at position 5, w becomes 0.5
 add_agent!(model; w = 0.5) # use keywords: w becomes 0.5, k becomes false
 ```
 """
-function add_agent!(model::ABM{S,A}, properties...; kwargs...) where {S,A<:AbstractAgent}
+function add_agent!(model::ABM{S,A}, properties::Vararg{Any, N}; kwargs...) where {N,S,A<:AbstractAgent}
     add_agent!(A, model, properties...; kwargs...)
 end
 
-function add_agent!(A::Type{<:AbstractAgent}, model::ABM, properties...; kwargs...)
+@inline function add_agent!(A::Type{<:AbstractAgent}, model::ABM, properties::Vararg{Any, N}; kwargs...) where {N}
     add_agent!(random_position(model), A, model, properties...; kwargs...)
 end
 
 function add_agent!(
     pos::ValidPos,
     model::ABM{S,A},
-    properties...;
+    properties::Vararg{Any, N};
     kwargs...,
-) where {S,A<:AbstractAgent}
+) where {N,S,A<:AbstractAgent}
     add_agent!(pos, A, model, properties...; kwargs...)
 end
 
@@ -276,9 +276,9 @@ function add_agent!(
     pos::ValidPos,
     A::Type{<:AbstractAgent},
     model::ABM,
-    properties...;
+    properties::Vararg{Any, N};
     kwargs...,
-)
+) where {N}
     id = nextid(model)
     newagent = A(id, pos, properties...; kwargs...)
     add_agent_pos!(newagent, model)


### PR DESCRIPTION
Now I don't see any regression with these changes, running the benchmark in the related issue #820 

```julia
julia> @benchmark model_1()
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  125.087 μs …   2.810 ms  ┊ GC (min … max):  0.00% … 90.66%
 Time  (median):     134.490 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   158.740 μs ± 207.101 μs  ┊ GC (mean ± σ):  12.16% ±  8.70%

  ▁▆███▇▆▅▄▄▃▃▂▂▂▁▁▁▁▁▁▁  ▁▁                                    ▃
  ██████████████████████████▇█▇▆██▇▆▆▇▇▇▆▆▅▅▅▁▅▅▃▅▄▅▄▄▃▅▄▄▅▃▃▁▃ █
  125 μs        Histogram: log(frequency) by time        257 μs <

 Memory estimate: 434.19 KiB, allocs estimate: 4385.

julia> @benchmark model_2()
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  114.889 μs …   2.980 ms  ┊ GC (min … max):  0.00% … 88.82%
 Time  (median):     126.441 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   153.133 μs ± 237.755 μs  ┊ GC (mean ± σ):  14.52% ±  8.83%

   ▆███▇▅▄▄▃▂▂▂▁▁▁ ▁                                            ▂
  █████████████████████▆▆▇▇▆▇▆▆▆▆▅▅▆▄▆▅▄▅▄▃▅▅▁▁▃▄▄▁▅▁▃▁▁▁▄▁▃▄▃▃ █
  115 μs        Histogram: log(frequency) by time        293 μs <

 Memory estimate: 434.89 KiB, allocs estimate: 4394.
```

all of this was based on https://discourse.julialang.org/t/why-using-a-mutable-struct-type-argument-to-create-instances-creates-a-50x-slowdown/100764