### PR TITLE
More correct replicate! (and sample!)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "5.17.0"
+version = "5.17.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -47,6 +47,7 @@ OpenStreetMapSpace
 ```@docs
 add_agent!
 add_agent_pos!
+replicate!
 nextid
 random_position
 ```

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -85,10 +85,10 @@ function new_args(agent::A, model; kwargs...) where {A<:AbstractAgent}
     idx_id = findfirst(x -> x == :id, fields)
     fields_no_id = tuple(fields[1:idx_id-1]..., fields[idx_id+1:end]...)
     if isempty(kwargs)
-        new_args = map(x -> deepcopy(getfield(agent, x)), fields_no_id)
+        new_args = (deepcopy(getfield(agent, x)) for x in fields_no_id)
     else
         kwargs_nt = NamedTuple(kwargs)
-        new_args = map(x -> choose_arg(x, kwargs_nt, agent), fields_no_id)
+        new_args = (choose_arg(x, kwargs_nt, agent) for x in fields_no_id)
     end
 end
 

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -39,7 +39,6 @@ end
 function add_newids!(model, org_ids, newids)
     # `counter` counts the number of occurencies for each item, it comes from DataStructure.jl
     count_newids = counter(newids)
-    n = nextid(model)
     for id in org_ids
         noccurances = count_newids[id]
         agent = model[id]
@@ -47,10 +46,7 @@ function add_newids!(model, org_ids, newids)
             remove_agent!(agent, model)
         else
             for _ in 2:noccurances
-                newagent = deepcopy(agent)
-                newagent.id = n
-                add_agent_pos!(newagent, model)
-                n += 1
+                replicate!(agent, model)
             end
         end
     end
@@ -77,16 +73,23 @@ a = A(1, (2, 2), 0.5, 0.5)
 b = replicate!(a, model; w = 0.8)
 ```
 """
-function replicate!(agent, model; kwargs...)
-    newagent = deepcopy(agent)
-    for (key, value) in kwargs
-        setfield!(newagent, key, value)
-    end
-    newagent.id = nextid(model)
+function replicate!(agent::A, model; kwargs...) where {A<:AbstractAgent}
+    args = new_args(agent::A, model; kwargs...) 
+    newagent = A(nextid(model), args...)
     add_agent_pos!(newagent, model)
     return newagent
 end
 
-function Base.deepcopy(agent::A) where {A<:AbstractAgent}
-    return A((deepcopy(getfield(agent, name)) for name in fieldnames(A))...)
+function new_args(agent::A, model; kwargs...) where {A<:AbstractAgent}
+    fields = fieldnames(A)
+    idx_id = findfirst(x -> x == :id, fields)
+    fields_no_id = tuple(fields[1:idx_id-1]..., fields[idx_id+1:end]...)
+    if isempty(kwargs)
+        new_args = map(x -> deepcopy(getfield(agent, x)), fields_no_id)
+    else
+        kwargs_ntuple = NamedTuple(kwargs)
+        new_args = map(x -> hasproperty(kwargs_ntuple, x) ? 
+                       deepcopy(kwargs_ntuple[x]) : deepcopy(getfield(agent, x)), 
+                       fields_no_id)
+    end
 end

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -87,9 +87,11 @@ function new_args(agent::A, model; kwargs...) where {A<:AbstractAgent}
     if isempty(kwargs)
         new_args = map(x -> deepcopy(getfield(agent, x)), fields_no_id)
     else
-        kwargs_ntuple = NamedTuple(kwargs)
-        new_args = map(x -> hasproperty(kwargs_ntuple, x) ? 
-                       deepcopy(kwargs_ntuple[x]) : deepcopy(getfield(agent, x)), 
-                       fields_no_id)
+        kwargs_nt = NamedTuple(kwargs)
+        new_args = map(x -> choose_arg(x, kwargs_nt, agent), fields_no_id)
     end
+end
+
+function choose_arg(x, kwargs_nt, agent)
+    return deepcopy(getfield(hasproperty(kwargs_nt, x) ? kwargs_nt : agent, x))
 end

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -55,9 +55,9 @@ end
 """
     replicate!(agent, model; kwargs...) 
 
-Create a new agent at the same position of the given agent, copying the values
-of its fields. With the `kwargs` it is possible to override the values by specifying
-new ones for some fields. 
+Add a new agent to the `model` at the same position of the given agent, copying
+the values of its fields. With the `kwargs` it is possible to override the values
+by specifying new ones for some fields. 
 Return the new agent instance.
 
 ## Example


### PR DESCRIPTION
This is more correct since:

- in both the functions now the agent is created without changing the immutable `id` field, I also verified that now the `id` field is never updated throughout the library which means that we could declare it constant in the internal macros if we want to do so
- secondly it deepcopies also the argument given in kwargs, this could be useful to prevent bugs from the user side
- the replicate! function is exported :D 

I also verified that this doesn't change the performance of the functions, actually it improves the case where kwargs are given since it doesn't re-set the fields after the agent is created