### PR TITLE
Allow using default values in agents macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# main
+
+- The `@agents` macro now supports fields with default values.
+
 # v5.17
 
 - New function `replicate!` allows to create a new instance of a given agent at the same position with the possibility to specify some

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -91,6 +91,18 @@ mutable struct Baker{T} <: AbstractAgent
     breadz_per_day::T
 end
 ```
+Notice that you can also use default values for some fields, in this case you 
+will need to specify the field names with the non-default values
+```julia
+@agent Person{T} GridAgent{2} begin
+    age::Int = 30
+    moneyz::T
+end
+# default age value
+Person(id = 1, pos = (1, 1), moneyz = 2000)
+# new age value
+Person(1, (1, 1), 40, 2000)
+```
 ### Example with optional hierarchy
 An alternative way to make the above structs, that also establishes
 a user-specific subtyping hierarchy would be to do:
@@ -192,7 +204,7 @@ macro agent(new_name, base_type, super_type, extra_fields)
             expr = quote
                 # Also notice that we escape supertype and interpolate it twice
                 # because this is expected to already be defined in the calling module
-                mutable struct $name <: $$(esc(super_type))
+                @kwdef mutable struct $name <: $$(esc(super_type))
                     $(base_fields...)
                     $(additional_fields...)
                 end

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -29,8 +29,8 @@ as well as any additional ones the user may provide via the `begin` block.
 See below for examples.
 
 Using `@agent` is the recommended way to create agent types for Agents.jl,
-however keep in mind that the macro (currently) doesn't work with `Base.@kwdef`
-or `const` declarations in individual fields (for Julia v1.8+).
+however keep in mind that the macro (currently) doesn't work with `const` 
+declarations in individual fields (for Julia v1.8+).
 
 Structs created with `@agent` by default subtype `AbstractAgent`.
 They cannot subtype each other, as all structs created from `@agent` are concrete types

--- a/test/model_creation_tests.jl
+++ b/test/model_creation_tests.jl
@@ -35,6 +35,13 @@ using Test, Agents, Random
     end
     @test Fisher <: AbstractHuman
     @test :fish_per_day ∈ fieldnames(Fisher)
+
+    agent_kwdef = Agent9(id = 1, f2 = 10)
+    values = (1, 40, 10, 3.0)
+    @test all(getfield(agent_kwdef, n) == v for (n, v) in zip(fieldnames(Agent9), values))
+    agent_kwdef = Agent9(1, 20, 10, 4.0)
+    values = (1, 20, 10, 4.0)
+    @test all(getfield(agent_kwdef, n) == v for (n, v) in zip(fieldnames(Agent9), values))
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,12 @@ end
 
 Agent8(id, pos; f1, f2) = Agent8(id, pos, f1, f2)
 
+@agent Agent9 NoSpaceAgent begin
+    f1::Int = 40
+    f2::Int
+    f3::Float64 = 3.0
+end
+
 @agent SchellingAgent GridAgent{2} begin
     mood::Bool
     group::Int


### PR DESCRIPTION
This tries to split in two parts #831 since the part with the consts variable is more hacky, but using default values is very easy and we can support it almost with no changes