### PR TITLE
Fix test throwing error

### DIFF
--- a/test/randomness_tests.jl
+++ b/test/randomness_tests.jl
@@ -50,6 +50,7 @@ end
     @test allunique(allweights)
 
     model3 = ABM(Agent2; rng = rng)
+    # Guarantee all starting weights are unique
     while true
         for i in 1:20
             add_agent!(model3, rand(abmrng(model3)) / rand(abmrng(model3)))

--- a/test/randomness_tests.jl
+++ b/test/randomness_tests.jl
@@ -25,7 +25,7 @@ end
     rng = StableRNG(42)
     model = ABM(Agent2; rng = rng)
     for i in 1:20
-        add_agent!(model, rand(abmrng(model2)))
+        add_agent!(model, rand(abmrng(model)))
     end
     allweights = [i.weight for i in allagents(model)]
     mean_weights = sum(allweights) / length(allweights)

--- a/test/randomness_tests.jl
+++ b/test/randomness_tests.jl
@@ -40,13 +40,13 @@ end
         for i in 1:20
             add_agent!(model2, rand(abmrng(model2)) / rand(abmrng(model2)))
         end
-        allweights = [i.weight for i in allagents(model3)]
+        allweights = [i.weight for i in allagents(model2)]
         allunique(allweights) && break
     end
     # Cannot draw 50 samples out of a pool of 20 without replacement
     @test_throws ErrorException sample!(model2, 50, :weight; replace = false)
     sample!(model2, 15, :weight; replace = false)
-    allweights = [i.weight for i in allagents(model3)]
+    allweights = [i.weight for i in allagents(model2)]
     @test allunique(allweights)
 
     model3 = ABM(Agent2; rng = rng)

--- a/test/randomness_tests.jl
+++ b/test/randomness_tests.jl
@@ -23,9 +23,9 @@ end
 
 @testset "sample!" begin
     rng = StableRNG(42)
-    model = ABM(Agent2)
+    model = ABM(Agent2; rng = rng)
     for i in 1:20
-        add_agent!(model, rand(abmrng(model)))
+        add_agent!(model, rand(abmrng(model2)))
     end
     allweights = [i.weight for i in allagents(model)]
     mean_weights = sum(allweights) / length(allweights)
@@ -35,25 +35,24 @@ end
     mean_weights_new = sum(allweights) / length(allweights)
     @test mean_weights_new > mean_weights
 
-    Random.seed!(6459)
-    #Guarantee all starting weights are unique
-    model3 = ABM(Agent2)
+    model2 = ABM(Agent2; rng = rng)
     while true
         for i in 1:20
-            add_agent!(model3, rand(model3.rng) / rand(model3.rng))
+            add_agent!(model2, rand(abmrng(model2)) / rand(abmrng(model2)))
         end
         allweights = [i.weight for i in allagents(model3)]
         allunique(allweights) && break
     end
     # Cannot draw 50 samples out of a pool of 20 without replacement
-    @test_throws ErrorException sample!(model3, 50, :weight; replace = false)
-    sample!(model3, 15, :weight; replace = false)
+    @test_throws ErrorException sample!(model2, 50, :weight; replace = false)
+    sample!(model2, 15, :weight; replace = false)
     allweights = [i.weight for i in allagents(model3)]
     @test allunique(allweights)
-    model3 = ABM(Agent2)
+
+    model3 = ABM(Agent2; rng = rng)
     while true
         for i in 1:20
-            add_agent!(model3, rand(model3.rng) / rand(model3.rng))
+            add_agent!(model3, rand(abmrng(model3)) / rand(abmrng(model3)))
         end
         allweights = [i.weight for i in allagents(model3)]
         allunique(allweights) && break


### PR DESCRIPTION
The test `mean_weights_new > mean_weights` sometimes throws errors since the model was not seeded e.g. https://github.com/JuliaDynamics/Agents.jl/actions/runs/5598262478/jobs/10237678720?pr=831 , now it should be fixed