### PR TITLE
Fix typos

### DIFF
--- a/docs/logo/example_zoo.jl
+++ b/docs/logo/example_zoo.jl
@@ -240,7 +240,7 @@ function bacteria_model_step!(model)
             add_agent!(a.p2, model, 0.0, a.orientation, 0.0, 0.1 * rand(model.rng) + 0.05)
             remove_agent!(a, model)
         else
-            ## The rest lengh of the internal spring grows with time. This causes
+            ## The rest length of the internal spring grows with time. This causes
             ## the nodes to physically separate.
             uv = unitvector(a.orientation)
             internalforce = model.hardness * (a.length - a.growthprog) .* uv

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -61,7 +61,7 @@ To use only a model step function, users can use the built-in [`dummystep`](@ref
 
 The stepping functions are created using the [API](@ref) functions, and the Examples hosted in this documentation showcase several different variants.
 
-After you have defined the stepping functions functions, you can evolve your model with `step!`:
+After you have defined the stepping functions, you can evolve your model with `step!`:
 ```@docs
 step!
 dummystep
@@ -125,7 +125,7 @@ If this is the case in your model, here's a helpful tip to keep things clean: us
 ```julia
 function assets(model)
     total_savings(model) = model.bank_balance + sum(model.assets)
-    function stategy(model)
+    function strategy(model)
         if model.year == 0
             return model.initial_strategy
         else

--- a/examples/agents_visualizations.jl
+++ b/examples/agents_visualizations.jl
@@ -180,7 +180,7 @@ abmobs
 
 #
 
-# create a new layout to add new plots to to the right of the abmplot
+# create a new layout to add new plots to the right of the abmplot
 plot_layout = fig[:,end+1] = GridLayout()
 
 # create a sublayout on its first row and column

--- a/examples/celllistmap.jl
+++ b/examples/celllistmap.jl
@@ -33,7 +33,7 @@
 using Agents
 
 # Below we define the `Particle` type, which represents the agents of the
-# simulation. The `Particle` type, for the `ContinousAgent{2}` space, will have additionally
+# simulation. The `Particle` type, for the `ContinuousAgent{2}` space, will have additionally
 # an `id` and `pos` (position) and `vel` (velocity) fields, which are automatically added
 # by the `@agent` macro.
 @agent Particle ContinuousAgent{2} begin

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -69,7 +69,7 @@ Create a fresh instance of a space with the same properties if you need to do th
 Here we the most important information on how to query an instance of `AgentBasedModel`:
 
 - `model[id]` gives the agent with given `id`.
-- `abmproperties(model)` gives the `properies` container stored in the model.
+- `abmproperties(model)` gives the `properties` container stored in the model.
 - `model.property`:  If the model properties is a dictionary with
   key type `Symbol`, or if it is a composite type (`struct`), then the syntax
   `model.property` will return the model property with key `:property`.

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -2,7 +2,7 @@ export Models
 
 """
 Sub-module of the module `Agents`, which contains pre-defined
-agent based models shown the Examples section of the documentation.
+agent based models shown in the Examples section of the documentation.
 
 Models are represented by functions that initialize an ABM, and return the ABM,
 and the agent and model stepping functions.

--- a/src/models/Models.jl
+++ b/src/models/Models.jl
@@ -2,7 +2,7 @@ export Models
 
 """
 Sub-module of the module `Agents`, which contains pre-defined
-agent based models shown the the Examples section of the documentation.
+agent based models shown the Examples section of the documentation.
 
 Models are represented by functions that initialize an ABM, and return the ABM,
 and the agent and model stepping functions.

--- a/src/simulations/paramscan.jl
+++ b/src/simulations/paramscan.jl
@@ -10,7 +10,7 @@ input parameter values used.
 
 `parameters` is a dictionary with key type `Symbol`. Each entry of the dictionary
 maps a parameter key to the parameter values that should be scanned over
-(or to a single paramter value that will remain constant throughout the scans).
+(or to a single parameter value that will remain constant throughout the scans).
 The approach regarding `parameters` is as follows:
 
 - If the value of a specific key is a `Vector`, all values of the vector are expended
@@ -20,7 +20,7 @@ The approach regarding `parameters` is as follows:
   expanded or scanned over.
 
 This is done so that parameter values that are inherently iterable (such as a `String`)
-are not wrongly expanded into their constitutents. (if the value of a parameter
+are not wrongly expanded into their constituents. (if the value of a parameter
 is itself a `Vector`, then you need to pass in a vector of vectors to scan the parameter)
 
 The second argument `initialize` is a function that creates an ABM and returns it.

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -477,8 +477,8 @@ function type_pairs!(
     available_types = unique(typeof(model[id]) for id in scheduler(model))
     for id in scheduler(model)
         for nid in nearby_f(model[id], model, r)
-            neigbor_type = typeof(model[nid])
-            if neigbor_type ∈ available_types && neigbor_type !== typeof(model[id])
+            neighbor_type = typeof(model[nid])
+            if neighbor_type ∈ available_types && neighbor_type !== typeof(model[id])
                 # Sort the pair to overcome any uniqueness issues
                 new_pair = isless(id, nid) ? (id, nid) : (nid, id)
                 new_pair ∉ pairs && push!(pairs, new_pair)

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -3,7 +3,7 @@
 Calculate and store the shortest path to move the agent from its current position to
 `dest` (a position e.g. `(1, 5)` or `(1.3, 5.2)`) using the provided `pathfinder`.
 
-Use this method in conjuction with [`move_along_route!`](@ref).
+Use this method in conjunction with [`move_along_route!`](@ref).
 """
 function Agents.plan_route!(
     agent::A,
@@ -20,7 +20,7 @@ end
 Calculate, store, and return the best path to move the agent from its current position to
 a chosen destination taken from `dests` using `pathfinder`.
 
-The `condition = :shortest` keyword retuns the shortest path which is shortest out of the
+The `condition = :shortest` keyword returns the shortest path which is shortest out of the
 possible destinations. Alternatively, the `:longest` path may also be requested.
 
 Return the position of the chosen destination. Return `nothing` if none of the supplied

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -64,7 +64,7 @@ fastest(model::ABM) = allids(model)
 
 """
     Schedulers.by_id
-A scheduler that activates all agents agents at each step according to their id.
+A scheduler that activates all agents at each step according to their id.
 """
 function by_id(model::ABM)
     agent_ids = sort(collect(allids(model)))
@@ -77,7 +77,7 @@ end
 
 """
     Schedulers.ByID()
-A non-allocating scheduler that activates all agents agents at each step according to their id.
+A non-allocating scheduler that activates all agents at each step according to their id.
 """
 ByID() = ByID(Int[])
 

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -376,7 +376,7 @@ end
         props = [:UNKNOWN]
         @test_throws ErrorException init_agent_dataframe(model, props)
 
-        # Aggregates should behave in a similiar fashion
+        # Aggregates should behave in a similar fashion
         pos1(a) = a.pos[1]
         props = [(:pos, length), (pos1, sum)]
         df = init_agent_dataframe(model, props)
@@ -409,7 +409,7 @@ end
         @test typeof(df.sum_weight_a3) <: Vector{Float64}
         @test df[1, :sum_weight_a3] ≈ 74.46
 
-        # Handle missmatches
+        # Handle mismatches
         # In this example, weight exists in both agents, but they have different types
         mutable struct Agent3Int <: AbstractAgent
             id::Int

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -135,7 +135,7 @@ using StableRNGs
         # All following are with r=1
         @testset "periodic=$(periodic)" for periodic in periodics
             @testset "Metric=$(metric)" for metric in metrics
-                # To undersatnd where the numbers here are coming from,
+                # To understand where the numbers here are coming from,
                 # check out the plot in the docs that shows the metrics
                 model = ABM(GridAgent{2}, SpaceType((5, 5); metric, periodic))
                 if metric ∈ (:euclidean, :mahnattan) # for r = 1 they give the same


### PR DESCRIPTION
this fixes some typos found with:

- https://github.com/crate-ci/typos
- a regex `(\w\w+) \1`