### PR TITLE
Agents macro allows parametric types and subtyping

### DIFF
--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -228,9 +228,8 @@ macro agent(new_name, base_type, super_type, extra_fields)
             # However, this should never happen inside the main body of a macro
             # There are several reasons for that, see the cited discussion at the top
             expr = quote
-                # Also notice that we escape supertype and interpolate it twice
-                # because this is expected to already be defined in the calling module
-                @kwdef mutable struct $name <: $$(esc(super_type))
+                # Also notice that we quote supertype and interpolate it twice
+                @kwdef mutable struct $name <: $$(QuoteNode(super_type))
                     $(base_fields...)
                     $(additional_fields...)
                 end

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -196,17 +196,13 @@ macro agent(new_name, base_type, super_type, extra_fields)
     # This macro was generated with the guidance of @rdeits on Discourse:
     # https://discourse.julialang.org/t/
     # metaprogramming-obtain-actual-type-from-symbol-for-field-inheritance/84912
-    base_type_no_param = base_type isa Expr ? base_type.args[1] : Symbol()
+
     # We start with a quote. All macros return a quote to be evaluated
     quote
         let
             # Here we collect the field names and types from the base type
             # Because the base type already exists, we escape the symbols to obtain it
-            base_T = try
-                         $(esc(base_type))
-                     catch
-                         $(esc(base_type_no_param))
-                     end
+            base_T = $(esc(base_type))
             base_fieldnames = fieldnames(base_T)
             base_fieldtypes = fieldtypes(base_T)
             base_fieldconsts = isconst.(base_T, base_fieldnames)

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -196,13 +196,17 @@ macro agent(new_name, base_type, super_type, extra_fields)
     # This macro was generated with the guidance of @rdeits on Discourse:
     # https://discourse.julialang.org/t/
     # metaprogramming-obtain-actual-type-from-symbol-for-field-inheritance/84912
-
+    base_type_no_param = base_type isa Expr ? base_type.args[1] : Symbol()
     # We start with a quote. All macros return a quote to be evaluated
     quote
         let
             # Here we collect the field names and types from the base type
             # Because the base type already exists, we escape the symbols to obtain it
-            base_T = $(esc(base_type))
+            base_T = try
+                         $(esc(base_type))
+                     catch
+                         $(esc(base_type_no_param))
+                     end
             base_fieldnames = fieldnames(base_T)
             base_fieldtypes = fieldtypes(base_T)
             base_fieldconsts = isconst.(base_T, base_fieldnames)


### PR DESCRIPTION
this should solve #725 , can you @mastrof say to me if this is what you intended and that it works for your use case please?

Now this works:

```julia
using Agents
abstract type AbstractFoo{D} <: AbstractAgent where D end
@agent MyFoo2{D} ContinuousAgent{D} where D AbstractFoo{D} begin; end
```