### PR TITLE
Use SVector for ContinuousAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v6
+- Agent types in `ContinuousSpace` now require `SVector` for their `pos` and `vel` fields rather than `NTuple`. 
+
+## BREAKING
+- `NTuple` in `ContinuousSpace` is officially deprecated, but backward compatibility is *mostly* maintained. Known breakages include the comparison of agent position and/or velocity with user-defined tuples (which will silently fail).
+
 # main
 
 - The `@agent` macro now supports fields with default and const values (through the special `constants` field). Since now the macro supports these features, using `@agent` is the only supported way to create agent types for Agents.jl.

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [weakdeps]
@@ -30,9 +31,9 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 OSMMakie = "76b6901f-8821-46bb-9129-841bc9cfe677"
 
 [extensions]
+AgentsArrow = "Arrow"
 AgentsOSMVisualizations = "OSMMakie"
 AgentsVisualizations = "Makie"
-AgentsArrow = "Arrow"
 
 [compat]
 Arrow = "2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "5.17.1"
+version = "6.0.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [weakdeps]

--- a/benchmark/simple_grid/continuous_space_impact.jl
+++ b/benchmark/simple_grid/continuous_space_impact.jl
@@ -6,7 +6,7 @@ extent = (1.0, 1.0)
 spacing = 0.1
 r = 0.1
 space = ContinuousSpace(extent, spacing)
-@agent Agent ContinuousAgent{2} begin end
+@agent Agent ContinuousAgent{2,Float64} begin end
 model = ABM(Agent, space; rng = StableRNG(42))
 
 # fill with random agents

--- a/docs/logo/example_zoo.jl
+++ b/docs/logo/example_zoo.jl
@@ -66,7 +66,7 @@ plotkwargs..., unikwargs...,)
 models[1] = daisy_obs
 
 # Flocking
-@agent Bird ContinuousAgent{2} begin
+@agent Bird ContinuousAgent{2,Float64} begin
     speed::Float64
     cohere_factor::Float64
     separation::Float64
@@ -650,7 +650,7 @@ antworld_obs = abmplot!(axs[6], antworld;
 models[6] = antworld_obs
 
 # Fractal growth
-@agent FractalParticle ContinuousAgent{2} begin
+@agent FractalParticle ContinuousAgent{2,Float64} begin
     radius::Float64
     is_stuck::Bool
     spin_axis::Array{Float64,1}
@@ -773,7 +773,7 @@ fractal_obs = abmplot!(axs[8], model;
 models[8] = fractal_obs
 
 # Social distancing
-@agent PoorSoul ContinuousAgent{2} begin
+@agent PoorSoul ContinuousAgent{2,Float64} begin
     mass::Float64
     days_infected::Int  # number of days since is infected
     status::Symbol  # :S, :I or :R

--- a/docs/logo/example_zoo.jl
+++ b/docs/logo/example_zoo.jl
@@ -91,7 +91,7 @@ function flocking_model(;
 
     model = ABM(Bird, space2d; rng, scheduler = Schedulers.Randomly())
     for _ in 1:n_birds
-        vel = Tuple(rand(abmrng(model), 2) * 2 .- 1)
+        vel = rand(abmrng(model), SVector{2}) * 2 .- 1
         add_agent!(
             model,
             vel,
@@ -659,9 +659,9 @@ FractalParticle(
     id::Int,
     radius::Float64,
     spin_clockwise::Bool;
-    pos = (0.0, 0.0),
+    pos = SVector(0.0, 0.0),
     is_stuck = false,
-) = FractalParticle(id, pos, (0.0, 0.0), radius, is_stuck, [0.0, 0.0, spin_clockwise ? -1.0 : 1.0])
+) = FractalParticle(id, pos, SVector(0.0, 0.0), radius, is_stuck, [0.0, 0.0, spin_clockwise ? -1.0 : 1.0])
 
 rand_circle(rng) = (θ = rand(rng, 0.0:0.1:359.9); (cos(θ), sin(θ)))
 function particle_radius(min_radius::Float64, max_radius::Float64, rng)
@@ -733,7 +733,7 @@ function fractal_particle_step!(agent::FractalParticle, model)
     radial = abmspace(model).extent ./ 2.0 .- agent.pos
     radial = radial ./ norm(radial)
     ## tangential vector in the direction of orbit of the particle
-    tangent = Tuple(cross([radial..., 0.0], agent.spin_axis)[1:2])
+    tangent = SVector{2}(cross([radial..., 0.0], agent.spin_axis)[1:2])
     agent.vel =
         (
             radial .* model.attraction .+ tangent .* model.spin .+

--- a/examples/celllistmap.jl
+++ b/examples/celllistmap.jl
@@ -33,10 +33,10 @@
 using Agents
 
 # Below we define the `Particle` type, which represents the agents of the
-# simulation. The `Particle` type, for the `ContinuousAgent{2}` space, will have additionally
+# simulation. The `Particle` type, for the `ContinuousAgent{2,Float64}` space, will have additionally
 # an `id` and `pos` (position) and `vel` (velocity) fields, which are automatically added
 # by the `@agent` macro.
-@agent Particle ContinuousAgent{2} begin
+@agent Particle ContinuousAgent{2,Float64} begin
     r::Float64 # radius
     k::Float64 # repulsion force constant
     mass::Float64

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -21,7 +21,7 @@
 using Agents
 using Random, LinearAlgebra
 
-@agent Bird ContinuousAgent{2} begin
+@agent Bird ContinuousAgent{2,Float64} begin
     speed::Float64
     cohere_factor::Float64
     separation::Float64

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -61,7 +61,7 @@ function initialize_model(;
 
     model = ABM(Bird, space2d; rng, scheduler = Schedulers.Randomly())
     for _ in 1:n_birds
-        vel = Tuple(rand(abmrng(model), 2) * 2 .- 1)
+        vel = rand(abmrng(model), SVector{2}) * 2 .- 1
         add_agent!(
             model,
             vel,

--- a/examples/rabbit_fox_hawk.jl
+++ b/examples/rabbit_fox_hawk.jl
@@ -24,7 +24,7 @@ using Random
 import ImageMagick
 using FileIO: load
 
-@agent Animal ContinuousAgent{3} begin
+@agent Animal ContinuousAgent{3,Float64} begin
     type::Symbol # one of :rabbit, :fox or :hawk
     energy::Float64
 end

--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -68,7 +68,7 @@ function schoolyard(;
     )
     for student in 1:numStudents
         ## Students begin near the school building
-        position = abmspace(model).extent .* 0.5 .+ Tuple(rand(abmrng(model), 2)) .- 0.5
+        position = abmspace(model).extent .* 0.5 .+ rand(abmrng(model), SVector{2}) .- 0.5
         add_agent!(position, model, velocity)
 
         ## Add one friend and one foe to the social network
@@ -94,7 +94,7 @@ function agent_step!(student, model)
     teacher = (abmspace(model).extent .* 0.5 .- student.pos) .* model.teacher_attractor
 
     ## add a bit of randomness
-    noise = model.noise .* (Tuple(rand(abmrng(model), 2)) .- 0.5)
+    noise = model.noise .* (rand(abmrng(model), SVector{2}) .- 0.5)
 
     ## Adhere to the social network
     network = model.buddies.weights[student.id, :]

--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -26,9 +26,9 @@ using SimpleWeightedGraphs: SimpleWeightedDiGraph # will make social network
 using SparseArrays: findnz                        # for social network connections
 using Random: MersenneTwister                     # reproducibility
 
-# And create an alias to `ContinuousAgent{2}`,
+# And create an alias to `ContinuousAgent{2,Float64}`,
 # as our agents don't need additional properties.
-const Student = ContinuousAgent{2}
+const Student = ContinuousAgent{2,Float64}
 
 # ## Rules of the schoolyard
 

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -12,7 +12,8 @@ using DataStructures
 using Graphs
 using DataFrames
 using Random
-using StaticArraysCore
+using StaticArrays: SVector
+export SVector
 import ProgressMeter
 import Base.length # TODO: This should not be imported!!!
 import LinearAlgebra

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -12,6 +12,7 @@ using DataStructures
 using Graphs
 using DataFrames
 using Random
+using StaticArrays
 import ProgressMeter
 import Base.length # TODO: This should not be imported!!!
 import LinearAlgebra

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -62,33 +62,17 @@ using Scratch
 
 function __init__()
 display_update = true
-version_number = "5.18"
+version_number = "6"
 update_name = "update_v$(version_number)"
 update_message = """
 Update message: Agents v$(version_number)
 Welcome to this new update of Agents.jl!
 
-Noteworthy changes:
+Breaking changes:
 
-- Agents.jl moved to Julia 1.9+, and now exports visualization
-  and interactive applications automatically once Makie (or Makie backends
-  such as GLMakie) come into scope, using the new package extension system.
-  The only downside of this is that now to visualize ABMs on open street
-  maps, the package OSMMakie.jl must be explicitly loaded as well.
-  InteractiveDynamics.jl is now obsolete.
-- Several performance improvements all across the board.
-- The `@agent` macro is now THE way to create agent types for Agents.jl simulations since
-  now supports declaring default and constant fields. Directly creating structs by hand is 
-  no longer mentioned in the documentation at all. This will allow us in the future to utilize
-  additional fields that the user does not have to know about, which may bring new features or
-  performance gains by being part of the agent structures.
-- DEI-motivated name change for all names that remove agents:
-    - `genocide! -> remove_all!`
-    - `kill_agent! -> remove_agent!`
-    - `UnkillableABM -> UnremovableABM`
-- We have created an objective fully automated framework for comparing open source
-  agent based modelling software. It shows that Agents.jl is much faster
-  than competing alternatives (MASON, NetLogo, Mesa).
+- Agents in `ContinuousSpace` now require `SVector` for their `pos`
+  and `vel` fields instead of `NTuple`.
+  Using `NTuple`s in `ContinuousSpace` is now deprecated.
 
 See the online documentation for more!
 """

--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -12,7 +12,7 @@ using DataStructures
 using Graphs
 using DataFrames
 using Random
-using StaticArrays
+using StaticArraysCore
 import ProgressMeter
 import Base.length # TODO: This should not be imported!!!
 import LinearAlgebra

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -196,7 +196,11 @@ macro agent(new_name, base_type, super_type, extra_fields)
     # This macro was generated with the guidance of @rdeits on Discourse:
     # https://discourse.julialang.org/t/
     # metaprogramming-obtain-actual-type-from-symbol-for-field-inheritance/84912
-
+    if base_type isa Expr
+        if base_type.args[1] == :ContinuousAgent && length(base_type.args) == 2
+            base_type = Expr(base_type.head, base_type.args..., :Float64)
+        end
+    end
     # We start with a quote. All macros return a quote to be evaluated
     quote
         let

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -196,6 +196,8 @@ macro agent(new_name, base_type, super_type, extra_fields)
     # This macro was generated with the guidance of @rdeits on Discourse:
     # https://discourse.julialang.org/t/
     # metaprogramming-obtain-actual-type-from-symbol-for-field-inheritance/84912
+
+    # hack for backwards compatibility (PR #846)
     if base_type isa Expr
         if base_type.args[1] == :ContinuousAgent && length(base_type.args) == 2
             base_type = Expr(base_type.head, base_type.args..., :Float64)

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -21,7 +21,7 @@ SpaceType = Union{Nothing,AbstractSpace}
 ValidPos = Union{
     Int, # graph
     NTuple{N,Int}, # grid
-    NTuple{M,<:AbstractFloat}, # continuous
+    SVector{M,<:AbstractFloat}, # continuous
     Tuple{Int,Int,Float64} # osm
 } where {N,M}
 

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -21,7 +21,6 @@ SpaceType = Union{Nothing,AbstractSpace}
 ValidPos = Union{
     Int, # graph
     NTuple{N,Int}, # grid
-    NTuple{M,<:AbstractFloat}, # continuous
     SVector{M,<:AbstractFloat}, # continuous
     Tuple{Int,Int,Float64} # osm
 } where {N,M}

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -21,6 +21,7 @@ SpaceType = Union{Nothing,AbstractSpace}
 ValidPos = Union{
     Int, # graph
     NTuple{N,Int}, # grid
+    NTuple{M,<:AbstractFloat}, # continuous
     SVector{M,<:AbstractFloat}, # continuous
     Tuple{Int,Int,Float64} # osm
 } where {N,M}

--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -174,11 +174,17 @@ function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:
         elseif space_type <: GridSpace && !(pos_type <: NTuple{D,Integer} where {D})
             throw(ArgumentError("`pos` field in agent type must be of type `NTuple{Int}` when using GridSpace."))
         elseif space_type <: ContinuousSpace
-            if !(pos_type <: SVector{D,<:AbstractFloat} where {D} || (!isconcretetype(A) && pos_type <: SVector{D} where {D}))
+            if pos_type <: NTuple{D,<:AbstractFloat} where {D}
+                warn && @warn "Using `NTuple` for the `pos` and `vel` fields of agent types in ContinuousSpace is deprecated. Use `SVector` instead."
+            elseif !(pos_type <: SVector{D,<:AbstractFloat} where {D} || (!isconcretetype(A) && pos_type <: SVector{D} where {D}))
                 throw(ArgumentError("`pos` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
             if any(isequal(:vel), fieldnames(A)) &&
-               !(fieldtype(A, :vel) <: SVector{D,<:AbstractFloat} where {D} || (!isconcretetype(A) && fieldtype(A, :vel) <: SVector{D} where {D}))
+               !(
+                    fieldtype(A, :vel) <: NTuple{D,<:AbstractFloat} where {D} ||
+                    fieldtype(A, :vel) <: SVector{D,<:AbstractFloat} where {D} ||
+                    (!isconcretetype(A) && fieldtype(A, :vel) <: SVector{D} where {D})
+                )
                 throw(ArgumentError("`vel` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
             if eltype(space) != eltype(pos_type)

--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -176,7 +176,7 @@ function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:
         elseif space_type <: ContinuousSpace || space_type <: ContinuousSpace
             if pos_type <: NTuple{D,<:AbstractFloat} where {D}
                 if warn
-                    @warn "Using `NTuple` for the `pos` field of agent types in `ContinuousSpace` is deprecated. Please consider using `SVector` instead."
+                    @warn "Using `NTuple` for the `pos` field of agent types in `ContinuousSpace` is deprecated. Use `SVector` instead."
                 end
             elseif !(pos_type <: SVector{D,<:AbstractFloat} where {D})
                 throw(ArgumentError("`pos` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))

--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -174,7 +174,11 @@ function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:
         elseif space_type <: GridSpace && !(pos_type <: NTuple{D,Integer} where {D})
             throw(ArgumentError("`pos` field in agent type must be of type `NTuple{Int}` when using GridSpace."))
         elseif space_type <: ContinuousSpace || space_type <: ContinuousSpace
-            if !(pos_type <: SVector{D,<:AbstractFloat} where {D})
+            if pos_type <: NTuple{D,<:AbstractFloat} where {D}
+                if warn
+                    @warn "Using `NTuple` for the `pos` field of agent types in `ContinuousSpace` is deprecated. Please consider using `SVector` instead."
+                end
+            elseif !(pos_type <: SVector{D,<:AbstractFloat} where {D})
                 throw(ArgumentError("`pos` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
             if warn &&

--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -181,6 +181,9 @@ function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:
                !(fieldtype(A, :vel) <: SVector{D,<:AbstractFloat} where {D} || (!isconcretetype(A) && fieldtype(A, :vel) <: SVector{D} where {D}))
                 throw(ArgumentError("`vel` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
+            if eltype(space) != eltype(pos_type)
+                throw(ArgumentError("`pos` field in agent type must be of the same type of the `extent` field in ContinuousSpace."))
+            end
         end
     end
 end

--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -173,18 +173,13 @@ function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:
             throw(ArgumentError("`pos` field in agent type must be of type `Int` when using GraphSpace."))
         elseif space_type <: GridSpace && !(pos_type <: NTuple{D,Integer} where {D})
             throw(ArgumentError("`pos` field in agent type must be of type `NTuple{Int}` when using GridSpace."))
-        elseif space_type <: ContinuousSpace || space_type <: ContinuousSpace
-            if pos_type <: NTuple{D,<:AbstractFloat} where {D}
-                if warn
-                    @warn "Using `NTuple` for the `pos` field of agent types in `ContinuousSpace` is deprecated. Use `SVector` instead."
-                end
-            elseif !(pos_type <: SVector{D,<:AbstractFloat} where {D})
+        elseif space_type <: ContinuousSpace
+            if !(pos_type <: SVector{D,<:AbstractFloat} where {D} || (!isconcretetype(A) && pos_type <: SVector{D} where {D}))
                 throw(ArgumentError("`pos` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
-            if warn &&
-               any(isequal(:vel), fieldnames(A)) &&
-               !(fieldtype(A, :vel) <: SVector{D,<:AbstractFloat} where {D})
-                @warn "`vel` field in agent type should be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."
+            if any(isequal(:vel), fieldnames(A)) &&
+               !(fieldtype(A, :vel) <: SVector{D,<:AbstractFloat} where {D} || (!isconcretetype(A) && fieldtype(A, :vel) <: SVector{D} where {D}))
+                throw(ArgumentError("`vel` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
         end
     end
@@ -219,3 +214,4 @@ end
 
 schedulername(x::Union{Function,DataType}) = nameof(x)
 schedulername(x) = Symbol(typeof(x))
+

--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -174,13 +174,13 @@ function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:
         elseif space_type <: GridSpace && !(pos_type <: NTuple{D,Integer} where {D})
             throw(ArgumentError("`pos` field in agent type must be of type `NTuple{Int}` when using GridSpace."))
         elseif space_type <: ContinuousSpace || space_type <: ContinuousSpace
-            if !(pos_type <: NTuple{D,<:AbstractFloat} where {D})
-                throw(ArgumentError("`pos` field in agent type must be of type `NTuple{<:AbstractFloat}` when using ContinuousSpace."))
+            if !(pos_type <: SVector{D,<:AbstractFloat} where {D})
+                throw(ArgumentError("`pos` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
             if warn &&
                any(isequal(:vel), fieldnames(A)) &&
-               !(fieldtype(A, :vel) <: NTuple{D,<:AbstractFloat} where {D})
-                @warn "`vel` field in agent type should be of type `NTuple{<:AbstractFloat}` when using ContinuousSpace."
+               !(fieldtype(A, :vel) <: SVector{D,<:AbstractFloat} where {D})
+                @warn "`vel` field in agent type should be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."
             end
         end
     end

--- a/src/models/flocking.jl
+++ b/src/models/flocking.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra
 
-@agent Bird ContinuousAgent{2} begin
+@agent Bird ContinuousAgent{2,Float64} begin
     speed::Float64
     cohere_factor::Float64
     separation::Float64

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -109,6 +109,14 @@ end
 distance_from_cell_center(pos, model::ABM) =
     euclidean_distance(pos, cell_center(pos, model), model)
 
+
+# required for backward compatibility with NTuples in ContinuousSpace
+function add_agent!(A::Type{<:AbstractAgent}, model::ABM{S}, properties::Vararg{Any, N};
+    kwargs...) where {N,S<:ContinuousSpace}
+    T = (; zip(fieldnames(A), fieldtypes(A))...)[:pos]
+    add_agent!(T(random_position(model)), A, model, properties...; kwargs...)
+end
+
 function add_agent_to_space!(
     a::A, model::ABM{<:ContinuousSpace,A}, cell_index = pos2cell(a, model)) where {A<:AbstractAgent}
     push!(abmspace(model).grid.stored_ids[cell_index...], a.id)

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -324,6 +324,7 @@ https://juliadynamics.github.io/AgentsExampleZoo.jl/dev/examples/social_distanci
 function elastic_collision!(a, b, f = nothing)
     # Do elastic collision according to
     # https://en.wikipedia.org/wiki/Elastic_collision#Two-dimensional_collision_with_two_moving_objects
+    T = typeof(a.pos) # assumes that a and b have same field types
     v1, v2, x1, x2 = a.vel, b.vel, a.pos, b.pos
     length(v1) ≠ 2 && error("This function works only for two dimensions.")
     r1 = x1 .- x2 # B to A
@@ -335,14 +336,14 @@ function elastic_collision!(a, b, f = nothing)
     # mass weights
     m1 == m2 == Inf && return false
     if m1 == Inf
-        @assert v1 == zero(v1) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v1 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r1, v2) ≤ 0 && return false
-        v1 = zero(v1)
+        v1 = T(zero(eltype(v1)) for _ in v1)
         f1, f2 = 0.0, 2.0
     elseif m2 == Inf
-        @assert v2 == zero(v2) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v2 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r2, v1) ≤ 0 && return false
-        v2 = zero(v2)
+        v2 = ntuple(x -> zero(eltype(v1)), length(v1))
         f1, f2 = 2.0, 0.0
     else
         # Check if disks face or overtake each other, to avoid double collisions

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -22,19 +22,19 @@ end
 """
     ContinuousAgent{D} <: AbstractAgent
 The minimal agent struct for usage with `D`-dimensional [`ContinuousSpace`](@ref).
-It has the additional fields `pos::NTuple{D,Float64}, vel::NTuple{D,Float64}`.
+It has the additional fields `pos::SVector{D,Float64}, vel::SVector{D,Float64}`.
 See also [`@agent`](@ref).
 """
 @agent ContinuousAgent{D} NoSpaceAgent begin
-    pos::NTuple{D,Float64}
-    vel::NTuple{D,Float64}
+    pos::SVector{D,Float64}
+    vel::SVector{D,Float64}
 end
 
 """
     ContinuousSpace(extent::NTuple{D, <:Real}; kwargs...)
 Create a `D`-dimensional `ContinuousSpace` in range 0 to (but not including) `extent`.
-Your agent positions (field `pos`) must be of type `NTuple{D, <:Real}`,
-and it is strongly recommend that agents also have a field `vel::NTuple{D, <:Real}` to use
+Your agent positions (field `pos`) must be of type `SVector{D, <:Real}`,
+and it is strongly recommend that agents also have a field `vel::SVector{D, <:Real}` to use
 in conjunction with [`move_agent!`](@ref). Use [`ContinuousAgent`](@ref) for convenience.
 
 `ContinuousSpace` is a representation of agent dynamics on a continuous medium
@@ -77,7 +77,7 @@ If you want exact searches use the slower [`nearby_ids_exact`](@ref).
   You can of course change the agents' velocities
   during the agent interaction, the `update_vel!` functionality targets spatial force
   fields acting on the agents individually (e.g. some magnetic field).
-  If you use `update_vel!`, the agent type must have a field `vel::NTuple{D, <:Real}`.
+  If you use `update_vel!`, the agent type must have a field `vel::SVector{D, <:Real}`.
 """
 function ContinuousSpace(
     extent::NTuple{D,X};
@@ -94,15 +94,15 @@ function ContinuousSpace(
 end
 
 function random_position(model::ABM{<:ContinuousSpace})
-    map(dim -> rand(model.rng) * dim, spacesize(model))
+    map(dim -> rand(model.rng) * dim, SVector(spacesize(model)))
 end
 
 "given position in continuous space, return cell coordinates in grid space."
 pos2cell(a::AbstractAgent, model::ABM) = pos2cell(a.pos, model)
-pos2cell(pos::Tuple, model::ABM) = @. floor(Int, pos/model.space.spacing) + 1
+pos2cell(pos::SVector, model::ABM) = @. floor(Int, pos/model.space.spacing) + 1
 
 "given position in continuous space, return continuous space coordinates of cell center."
-function cell_center(pos::NTuple{D,<:AbstractFloat}, model) where {D}
+function cell_center(pos::SVector{D,<:AbstractFloat}, model) where {D}
     model.space.spacing .* (pos2cell(pos, model) .- 0.5)
 end
 
@@ -196,7 +196,7 @@ function nearby_ids(pos::ValidPos, model::ABM{<:ContinuousSpace{D,A,T}}, r = 1;
     grid_r = ceil(Int, (r + δ) / model.space.spacing)
     # Then return the ids within this distance, using the internal grid space
     # and iteration via `GridSpaceIdIterator`, see spaces/grid_multi.jl
-    focal_cell = pos2cell(pos, model)
+    focal_cell = Tuple(pos2cell(pos, model))
     return nearby_ids(focal_cell, model.space.grid, grid_r)
 end
 
@@ -325,12 +325,12 @@ function elastic_collision!(a, b, f = nothing)
     # mass weights
     m1 == m2 == Inf && return false
     if m1 == Inf
-        @assert v1 == (0, 0) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v1 == SVector(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r1, v2) ≤ 0 && return false
         v1 = ntuple(x -> zero(eltype(v1)), length(v1))
         f1, f2 = 0.0, 2.0
     elseif m2 == Inf
-        @assert v2 == (0, 0) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v2 == SVector(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r2, v1) ≤ 0 && return false
         v2 = ntuple(x -> zero(eltype(v1)), length(v1))
         f1, f2 = 2.0, 0.0
@@ -507,7 +507,7 @@ end
 #######################################################################################
 export get_spatial_property, get_spatial_index
 """
-    get_spatial_property(pos::NTuple{D, Float64}, property::AbstractArray, model::ABM)
+    get_spatial_property(pos, property::AbstractArray, model::ABM)
 Convert the continuous agent position into an appropriate `index` of `property`, which
 represents some discretization of a spatial field over a [`ContinuousSpace`](@ref).
 Then, return `property[index]`. To get the `index` directly, for e.g. mutating the
@@ -519,7 +519,7 @@ function get_spatial_property(pos, property::AbstractArray, model::ABM)
 end
 
 """
-    get_spatial_property(pos::NTuple{D, Float64}, property::Function, model::ABM)
+    get_spatial_property(pos, property::Function, model::ABM)
 Literally equivalent with `property(pos, model)`, provided just for syntax consistency.
 """
 get_spatial_property(pos, property, model::ABM) = property(pos, model)

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -324,7 +324,6 @@ https://juliadynamics.github.io/AgentsExampleZoo.jl/dev/examples/social_distanci
 function elastic_collision!(a, b, f = nothing)
     # Do elastic collision according to
     # https://en.wikipedia.org/wiki/Elastic_collision#Two-dimensional_collision_with_two_moving_objects
-    T = typeof(a.pos) # assumes that a and b have same field types
     v1, v2, x1, x2 = a.vel, b.vel, a.pos, b.pos
     length(v1) ≠ 2 && error("This function works only for two dimensions.")
     r1 = x1 .- x2 # B to A
@@ -336,14 +335,14 @@ function elastic_collision!(a, b, f = nothing)
     # mass weights
     m1 == m2 == Inf && return false
     if m1 == Inf
-        @assert v1 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v1 == zero(v1) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r1, v2) ≤ 0 && return false
-        v1 = T(zero(eltype(v1)) for _ in v1)
+        v1 = zero(v1)
         f1, f2 = 0.0, 2.0
     elseif m2 == Inf
-        @assert v2 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v2 == zero(v2) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r2, v1) ≤ 0 && return false
-        v2 = ntuple(x -> zero(eltype(v1)), length(v1))
+        v2 = zero(v2)
         f1, f2 = 2.0, 0.0
     else
         # Check if disks face or overtake each other, to avoid double collisions

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -540,5 +540,5 @@ function get_spatial_index(pos, property::AbstractArray{T,D}, model::ABM) where 
     usize = ssize[1:D]
     εs = usize ./ propertysize
     idxs = floor.(Int, upos ./ εs) .+ 1
-    return CartesianIndex(idxs)
+    return CartesianIndex(Tuple(idxs))
 end

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -115,7 +115,7 @@ distance_from_cell_center(pos, model::ABM) =
 # required for backward compatibility with NTuples in ContinuousSpace
 function add_agent!(A::Type{<:AbstractAgent}, model::ABM{S}, properties::Vararg{Any, N};
     kwargs...) where {N,S<:ContinuousSpace}
-    T = (; zip(fieldnames(A), fieldtypes(A))...)[:pos]
+    T = fieldtype(A, :pos)
     add_agent!(T(random_position(model)), A, model, properties...; kwargs...)
 end
 
@@ -338,7 +338,7 @@ function elastic_collision!(a, b, f = nothing)
     if m1 == Inf
         @assert v1 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r1, v2) ≤ 0 && return false
-        v1 = T(zero(eltype(v1)) for _ in eachindex(v1))
+        v1 = T(zero(eltype(v1)) for _ in v1)
         f1, f2 = 0.0, 2.0
     elseif m2 == Inf
         @assert v2 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -20,9 +20,10 @@ function Base.show(io::IO, space::ContinuousSpace{D,P}) where {D,P}
 end
 
 """
-    ContinuousAgent{D} <: AbstractAgent
+    ContinuousAgent{D,T} <: AbstractAgent
 The minimal agent struct for usage with `D`-dimensional [`ContinuousSpace`](@ref).
-It has the additional fields `pos::SVector{D,Float64}, vel::SVector{D,Float64}`.
+It has the additional fields `pos::SVector{D,T}, vel::SVector{D,T}` where `T`
+can be any `AbstractFloat` type.
 See also [`@agent`](@ref).
 """
 @agent ContinuousAgent{D,T} NoSpaceAgent begin

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -99,7 +99,7 @@ end
 
 "given position in continuous space, return cell coordinates in grid space."
 pos2cell(a::AbstractAgent, model::ABM) = pos2cell(a.pos, model)
-pos2cell(pos::SVector, model::ABM) = @. floor(Int, pos/model.space.spacing) + 1
+pos2cell(pos::ValidPos, model::ABM) = @. floor(Int, pos/model.space.spacing) + 1
 
 "given position in continuous space, return continuous space coordinates of cell center."
 function cell_center(pos::SVector{D,<:AbstractFloat}, model) where {D}

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -343,7 +343,7 @@ function elastic_collision!(a, b, f = nothing)
     elseif m2 == Inf
         @assert v2 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r2, v1) ≤ 0 && return false
-        v2 = ntuple(x -> zero(eltype(v1)), length(v1))
+        v2 = T(zero(eltype(v1)) for _ in v1)
         f1, f2 = 2.0, 0.0
     else
         # Check if disks face or overtake each other, to avoid double collisions

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -25,10 +25,11 @@ The minimal agent struct for usage with `D`-dimensional [`ContinuousSpace`](@ref
 It has the additional fields `pos::SVector{D,Float64}, vel::SVector{D,Float64}`.
 See also [`@agent`](@ref).
 """
-@agent ContinuousAgent{D} NoSpaceAgent begin
-    pos::SVector{D,Float64}
-    vel::SVector{D,Float64}
+@agent ContinuousAgent{D,T} NoSpaceAgent begin
+    pos::SVector{D,T}
+    vel::SVector{D,T}
 end
+ContinuousAgent{D}(args...; kwargs...) where D = ContinuousAgent{D,Float64}(args...; kwargs...)
 
 """
     ContinuousSpace(extent::NTuple{D, <:Real}; kwargs...)

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -100,23 +100,15 @@ end
 
 "given position in continuous space, return cell coordinates in grid space."
 pos2cell(a::AbstractAgent, model::ABM) = pos2cell(a.pos, model)
-pos2cell(pos::ValidPos, model::ABM) = Tuple(floor.(Int, pos./abmspace(model).spacing) .+ 1)
+pos2cell(pos::SVector, model::ABM) = Tuple(floor.(Int, pos./abmspace(model).spacing) .+ 1)
 
 "given position in continuous space, return continuous space coordinates of cell center."
-function cell_center(pos::ValidPos, model)
-    abmspace(model).spacing .* (pos2cell(pos, model) .- 0.5)
+function cell_center(pos::SVector, model)
+    SVector(abmspace(model).spacing .* (pos2cell(pos, model) .- 0.5))
 end
 
 distance_from_cell_center(pos, model::ABM) =
     euclidean_distance(pos, cell_center(pos, model), model)
-
-
-# required for backward compatibility with NTuples in ContinuousSpace
-function add_agent!(A::Type{<:AbstractAgent}, model::ABM{S}, properties::Vararg{Any, N};
-    kwargs...) where {N,S<:ContinuousSpace}
-    T = (; zip(fieldnames(A), fieldtypes(A))...)[:pos]
-    add_agent!(T(random_position(model)), A, model, properties...; kwargs...)
-end
 
 function add_agent_to_space!(
     a::A, model::ABM{<:ContinuousSpace,A}, cell_index = pos2cell(a, model)) where {A<:AbstractAgent}
@@ -323,7 +315,6 @@ https://juliadynamics.github.io/AgentsExampleZoo.jl/dev/examples/social_distanci
 function elastic_collision!(a, b, f = nothing)
     # Do elastic collision according to
     # https://en.wikipedia.org/wiki/Elastic_collision#Two-dimensional_collision_with_two_moving_objects
-    T = typeof(a.pos) # assumes that a and b have same field types
     v1, v2, x1, x2 = a.vel, b.vel, a.pos, b.pos
     length(v1) ≠ 2 && error("This function works only for two dimensions.")
     r1 = x1 .- x2 # B to A
@@ -335,14 +326,14 @@ function elastic_collision!(a, b, f = nothing)
     # mass weights
     m1 == m2 == Inf && return false
     if m1 == Inf
-        @assert v1 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v1 == SVector(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r1, v2) ≤ 0 && return false
-        v1 = T(zero(eltype(v1)) for _ in eachindex(v1))
+        v1 = zero(v1)
         f1, f2 = 0.0, 2.0
     elseif m2 == Inf
-        @assert v2 == T(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
+        @assert v2 == SVector(0, 0) "An agent with ∞ mass cannot have nonzero velocity"
         dot(r2, v1) ≤ 0 && return false
-        v2 = ntuple(x -> zero(eltype(v1)), length(v1))
+        v2 = zero(v1)
         f1, f2 = 2.0, 0.0
     else
         # Check if disks face or overtake each other, to avoid double collisions

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -234,9 +234,10 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = rotate(agent.vel, θ) .* relative_r
+    direction = T(rotate(SVector(agent.vel), θ) .* relative_r)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -250,8 +251,9 @@ function randomwalk!(
     if isnothing(polar)
         return uniform_randomwalk!(agent, model)
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
-    direction = rotate(SVector(agent.vel), θ)
+    direction = T(rotate(SVector(agent.vel), θ))
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -269,10 +271,11 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = rotate(agent.vel, θ, ϕ) .* relative_r
+    direction = T(rotate(SVector(agent.vel), θ, ϕ) .* relative_r)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -286,9 +289,10 @@ function randomwalk!(
     if isnothing(polar) && isnothing(azimuthal)
         return uniform_randomwalk!(agent, model)
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
-    direction = rotate(agent.vel, θ, ϕ)
+    direction = T(rotate(SVector(agent.vel), θ, ϕ))
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -353,13 +357,14 @@ function uniform_randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     rng = abmrng(model)
-    v = SVector{D}(randn(rng) for _ in 1:D)
+    v = T(randn(rng) for _ in 1:D)
     norm_v = sqrt(sum(abs2.(v)))
     if !iszero(norm_v)
         direction = v ./ norm_v .* r
     else
-        direction = SVector{D}(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
+        direction = T(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
     end
     agent.vel = direction
     walk!(agent, direction, model)

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -74,13 +74,24 @@ spaces this clamps the position to the space extent.
 """
 normalize_position(pos, model::ABM) = normalize_position(pos, abmspace(model))
 
-function normalize_position(pos::ValidPos, space::ContinuousSpace{D,true}) where {D}
-    return SVector(mod.(pos, spacesize(space)))
+function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,true}) where {D}
+    return mod.(pos, spacesize(space))
 end
 
-function normalize_position(pos::ValidPos, space::ContinuousSpace{D,false}) where {D}
-    return SVector(clamp.(pos, 0.0, prevfloat.(spacesize(space))))
+function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,false}) where {D}
+    return clamp.(pos, 0.0, prevfloat.(spacesize(space)))
 end
+
+#----
+# for backward compatibility 
+function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,true}) where {D}
+    return Tuple(mod.(pos, spacesize(space)))
+end
+
+function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,false}) where {D}
+    return Tuple(clamp.(pos, 0.0, prevfloat.(spacesize(space))))
+end
+#----
 
 function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,true}) where {D}
     return mod1.(pos, spacesize(space))

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -57,9 +57,9 @@ end
 
 function walk!(
     agent::AbstractAgent,
-    direction::SVector{D,<:AbstractFloat},
+    direction::ValidPos,
     model::ABM{<:ContinuousSpace}
-) where {D}
+)
     target = normalize_position(agent.pos .+ direction, model)
     move_agent!(agent, target, model)
     return agent
@@ -81,6 +81,17 @@ end
 function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,false}) where {D}
     return clamp.(pos, 0.0, prevfloat.(spacesize(space)))
 end
+
+#----
+# for backward compatibility 
+function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,true}) where {D}
+    return Tuple(mod.(pos, spacesize(space)))
+end
+
+function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,false}) where {D}
+    return Tuple(clamp.(pos, 0.0, prevfloat.(spacesize(space))))
+end
+#----
 
 function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,true}) where {D}
     return mod1.(pos, spacesize(space))
@@ -223,9 +234,10 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = rotate(agent.vel, θ) .* relative_r
+    direction = T(rotate(SVector(agent.vel), θ) .* relative_r)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -239,8 +251,9 @@ function randomwalk!(
     if isnothing(polar)
         return uniform_randomwalk!(agent, model)
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
-    direction = rotate(agent.vel, θ)
+    direction = T(rotate(SVector(agent.vel), θ))
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -258,10 +271,11 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = rotate(agent.vel, θ, ϕ) .* relative_r
+    direction = T(rotate(SVector(agent.vel), θ, ϕ) .* relative_r)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -275,9 +289,10 @@ function randomwalk!(
     if isnothing(polar) && isnothing(azimuthal)
         return uniform_randomwalk!(agent, model)
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
-    direction = rotate(agent.vel, θ, ϕ)
+    direction = T(rotate(SVector(agent.vel), θ, ϕ))
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -342,13 +357,14 @@ function uniform_randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     rng = abmrng(model)
-    v = randn(rng, SVector{D})
+    v = T(randn(rng) for _ in 1:D)
     norm_v = sqrt(sum(abs2.(v)))
     if !iszero(norm_v)
         direction = v ./ norm_v .* r
     else
-        direction = SVector{D}(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
+        direction = T(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
     end
     agent.vel = direction
     walk!(agent, direction, model)

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -57,9 +57,9 @@ end
 
 function walk!(
     agent::AbstractAgent,
-    direction::SVector{D,Float64},
+    direction::ValidPos,
     model::ABM{<:ContinuousSpace}
-) where {D}
+)
     target = normalize_position(agent.pos .+ direction, model)
     move_agent!(agent, target, model)
     return agent

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -234,9 +234,10 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = rotate(agent.vel, θ) .* relative_r
+    direction = T(rotate(SVector(agent.vel), θ) .* relative_r)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -250,8 +251,9 @@ function randomwalk!(
     if isnothing(polar)
         return uniform_randomwalk!(agent, model)
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
-    direction = rotate(agent.vel, θ)
+    direction = T(rotate(SVector(agent.vel), θ))
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -269,10 +271,11 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = rotate(agent.vel, θ, ϕ) .* relative_r
+    direction = T(rotate(SVector(agent.vel), θ, ϕ) .* relative_r)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -286,9 +289,10 @@ function randomwalk!(
     if isnothing(polar) && isnothing(azimuthal)
         return uniform_randomwalk!(agent, model)
     end
+    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
-    direction = rotate(agent.vel, θ, ϕ)
+    direction = T(rotate(SVector(agent.vel), θ, ϕ))
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -353,13 +357,14 @@ function uniform_randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
+    T = typeof(agent.pos)
     rng = abmrng(model)
-    v = randn(rng, SVector{D})
+    v = T(randn(rng) for _ in 1:D)
     norm_v = sqrt(sum(abs2.(v)))
     if !iszero(norm_v)
         direction = v ./ norm_v .* r
     else
-        direction = SVector{D}(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
+        direction = T(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
     end
     agent.vel = direction
     walk!(agent, direction, model)

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -57,9 +57,9 @@ end
 
 function walk!(
     agent::AbstractAgent,
-    direction::ValidPos,
+    direction::SVector{D,<:AbstractFloat},
     model::ABM{<:ContinuousSpace}
-)
+) where {D}
     target = normalize_position(agent.pos .+ direction, model)
     move_agent!(agent, target, model)
     return agent
@@ -81,17 +81,6 @@ end
 function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,false}) where {D}
     return clamp.(pos, 0.0, prevfloat.(spacesize(space)))
 end
-
-#----
-# for backward compatibility 
-function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,true}) where {D}
-    return Tuple(mod.(pos, spacesize(space)))
-end
-
-function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,false}) where {D}
-    return Tuple(clamp.(pos, 0.0, prevfloat.(spacesize(space))))
-end
-#----
 
 function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,true}) where {D}
     return mod1.(pos, spacesize(space))
@@ -234,10 +223,9 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = T(rotate(SVector(agent.vel), θ) .* relative_r)
+    direction = rotate(agent.vel, θ) .* relative_r
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -251,9 +239,8 @@ function randomwalk!(
     if isnothing(polar)
         return uniform_randomwalk!(agent, model)
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
-    direction = T(rotate(SVector(agent.vel), θ))
+    direction = rotate(agent.vel, θ)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -271,11 +258,10 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = T(rotate(SVector(agent.vel), θ, ϕ) .* relative_r)
+    direction = rotate(agent.vel, θ, ϕ) .* relative_r
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -289,10 +275,9 @@ function randomwalk!(
     if isnothing(polar) && isnothing(azimuthal)
         return uniform_randomwalk!(agent, model)
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
-    direction = T(rotate(SVector(agent.vel), θ, ϕ))
+    direction = rotate(agent.vel, θ, ϕ)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -357,14 +342,13 @@ function uniform_randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
-    T = typeof(agent.pos)
     rng = abmrng(model)
-    v = T(randn(rng) for _ in 1:D)
+    v = randn(rng, SVector{D})
     norm_v = sqrt(sum(abs2.(v)))
     if !iszero(norm_v)
         direction = v ./ norm_v .* r
     else
-        direction = T(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
+        direction = SVector{D}(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
     end
     agent.vel = direction
     walk!(agent, direction, model)

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -1,6 +1,6 @@
 using Distributions: Distributions, Uniform, ContinuousUnivariateDistribution
 using Rotations
-using StaticArrays: SVector, setindex
+using StaticArrays: setindex
 
 export walk!, randomwalk!, normalize_position
 export Arccos, Uniform

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -234,10 +234,9 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = T(rotate(SVector(agent.vel), θ) .* relative_r)
+    direction = rotate(agent.vel, θ) .* relative_r
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -251,9 +250,8 @@ function randomwalk!(
     if isnothing(polar)
         return uniform_randomwalk!(agent, model)
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), polar)
-    direction = T(rotate(SVector(agent.vel), θ))
+    direction = rotate(SVector(agent.vel), θ)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -271,11 +269,10 @@ function randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
     relative_r = r/LinearAlgebra.norm(agent.vel)
-    direction = T(rotate(SVector(agent.vel), θ, ϕ) .* relative_r)
+    direction = rotate(agent.vel, θ, ϕ) .* relative_r
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -289,10 +286,9 @@ function randomwalk!(
     if isnothing(polar) && isnothing(azimuthal)
         return uniform_randomwalk!(agent, model)
     end
-    T = typeof(agent.pos)
     θ = rand(abmrng(model), isnothing(polar) ? Uniform(-π,π) : polar)
     ϕ = rand(abmrng(model), isnothing(azimuthal) ? Arccos(-1,1) : azimuthal)
-    direction = T(rotate(SVector(agent.vel), θ, ϕ))
+    direction = rotate(agent.vel, θ, ϕ)
     agent.vel = direction
     walk!(agent, direction, model)
 end
@@ -357,14 +353,13 @@ function uniform_randomwalk!(
     if r ≤ 0
         throw(ArgumentError("The displacement must be larger than 0."))
     end
-    T = typeof(agent.pos)
     rng = abmrng(model)
-    v = T(randn(rng) for _ in 1:D)
+    v = SVector{D}(randn(rng) for _ in 1:D)
     norm_v = sqrt(sum(abs2.(v)))
     if !iszero(norm_v)
         direction = v ./ norm_v .* r
     else
-        direction = T(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
+        direction = SVector{D}(rand(rng, (-1, 1)) * r / sqrt(D) for _ in 1:D)
     end
     agent.vel = direction
     walk!(agent, direction, model)

--- a/src/submodules/io/jld2_integration.jl
+++ b/src/submodules/io/jld2_integration.jl
@@ -1,5 +1,6 @@
 using Random
 using JLD2
+using StaticArraysCore: SVector
 
 """
     AgentsIO.to_serializable(t)
@@ -64,7 +65,7 @@ struct SerializableContinuousSpace{D,P,T<:AbstractFloat}
     grid::SerializableGridSpace{D,P}
     dims::NTuple{D,Int}
     spacing::T
-    extent::NTuple{D,T}
+    extent::SVector{D,T}
 end
 
 struct SerializableGraphSpace{G}

--- a/src/submodules/io/jld2_integration.jl
+++ b/src/submodules/io/jld2_integration.jl
@@ -1,6 +1,5 @@
 using Random
 using JLD2
-using StaticArraysCore: SVector
 
 """
     AgentsIO.to_serializable(t)

--- a/src/submodules/pathfinding/Pathfinding.jl
+++ b/src/submodules/pathfinding/Pathfinding.jl
@@ -24,7 +24,6 @@ module Pathfinding
 using Agents
 using DataStructures
 using LinearAlgebra
-using StaticArrays
 
 abstract type GridPathfinder{D,P,M} end
 

--- a/src/submodules/pathfinding/Pathfinding.jl
+++ b/src/submodules/pathfinding/Pathfinding.jl
@@ -24,6 +24,7 @@ module Pathfinding
 using Agents
 using DataStructures
 using LinearAlgebra
+using StaticArrays
 
 abstract type GridPathfinder{D,P,M} end
 

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -97,7 +97,10 @@ function AStar(
 ) where {D,periodic}
     @assert walkmap isa BitArray{D} || cost_metric isa PenaltyMap "Pathfinding in ContinuousSpace requires either walkmap to be specified or cost_metric to be a PenaltyMap"
     isnothing(walkmap) && (walkmap = BitArray(trues(size(cost_metric.pmap))))
-    AStar(Agents.spacesize(space); periodic, diagonal_movement = true, admissibility, walkmap, cost_metric)
+    AStar(Tuple(Agents.spacesize(space));
+        periodic, diagonal_movement = true,
+        admissibility, walkmap, cost_metric
+    )
 end
 
 

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -124,7 +124,7 @@ function Agents.move_along_route!(
         end
         dir = dir ./ dist_to_target
         next_pos = from .+ dir .* (speed * dt)
-        next_pos = Agents.normalize_position(next_pos, model)
+        next_pos = Agents.normalize_position(T(next_pos), model)
         # overshooting means we reached the waypoint
         dist_to_next = euclidean_distance(T(from), T(next_pos), model)
         if dist_to_next > dist_to_target

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -16,8 +16,8 @@ in the discrete path to ensure continuous path is optimal.
 """
 function find_continuous_path(
     pathfinder::AStar{D},
-    from::SVector{D,Float64},
-    to::SVector{D,Float64},
+    from::Agents.ValidPos,
+    to::Agents.ValidPos,
 ) where {D}
     discrete_from = Tuple(to_discrete_position(from, pathfinder))
     discrete_to = Tuple(to_discrete_position(to, pathfinder))
@@ -56,7 +56,7 @@ end
 
 function Agents.plan_route!(
     agent::A,
-    dest::SVector{D,Float64},
+    dest::Agents.ValidPos,
     pathfinder::AStar{D,P,M,Float64},
 ) where {A<:AbstractAgent,D,P,M}
     path = find_continuous_path(pathfinder, agent.pos, dest)
@@ -107,8 +107,9 @@ function Agents.move_along_route!(
     isempty(agent.id, pathfinder) && return
     from = agent.pos
     next_pos = agent.pos
+    T = typeof(agent.pos)
     while true
-        next_waypoint = SVector(first(pathfinder.agent_paths[agent.id]))
+        next_waypoint = T(first(pathfinder.agent_paths[agent.id]))
         dir = get_direction(from, next_waypoint, model)
         dist_to_target = norm(dir)
         # edge case
@@ -123,9 +124,9 @@ function Agents.move_along_route!(
         end
         dir = dir ./ dist_to_target
         next_pos = from .+ dir .* (speed * dt)
-        next_pos = Agents.normalize_position(next_pos, model)
+        next_pos = Agents.normalize_position(T(next_pos), model)
         # overshooting means we reached the waypoint
-        dist_to_next = euclidean_distance(SVector(from), SVector(next_pos), model)
+        dist_to_next = euclidean_distance(T(from), T(next_pos), model)
         if dist_to_next > dist_to_target
             # change from and dt so it appears we're coming from the waypoint just skipped, instead
             # of directly where the agent was. E.g:
@@ -146,7 +147,7 @@ function Agents.move_along_route!(
             break
         end
     end
-    move_agent!(agent, SVector(next_pos), model)
+    move_agent!(agent, T(next_pos), model)
 end
 
 function random_walkable(model::ABM{<:ContinuousSpace{D}}, pathfinder::AStar{D}) where {D}
@@ -182,11 +183,12 @@ Return a random position within radius `r` of `pos` which is walkable, as specif
 Return `pos` if no such position exists.
 """
 function random_walkable(
-    pos::SVector{D,Float64},
+    pos::Agents.ValidPos,
     model::ABM{<:ContinuousSpace{D}},
     pathfinder::AStar{D},
     r = 1.0,
 ) where {D}
+    T = typeof(pos)
     discrete_r = to_discrete_position(r, pathfinder) .- 1
     discrete_pos = to_discrete_position(pos, pathfinder)
     options = collect(walkable_cells_in_radius(discrete_pos, discrete_r, pathfinder))
@@ -197,7 +199,7 @@ function random_walkable(
     )
     half_cell_size = abmspace(model).extent ./ size(pathfinder.walkmap) ./ 2.
     cts_rand = to_continuous_position(discrete_rand, pathfinder) .+
-        (rand(abmrng(model), SVector{D}) .- 0.5).* half_cell_size
+        (T(rand(abmrng(model)) for _ in 1:D) .- 0.5) .* half_cell_size
     dist = euclidean_distance(pos, cts_rand, model)
     dist > r && (cts_rand = mod1.(
         pos .+ get_direction(pos, cts_rand, model) ./ dist .* r,

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -16,8 +16,8 @@ in the discrete path to ensure continuous path is optimal.
 """
 function find_continuous_path(
     pathfinder::AStar{D},
-    from::SVector{D,Float64},
-    to::SVector{D,Float64},
+    from::Agents.ValidPos,
+    to::Agents.ValidPos,
 ) where {D}
     discrete_from = Tuple(to_discrete_position(from, pathfinder))
     discrete_to = Tuple(to_discrete_position(to, pathfinder))
@@ -56,7 +56,7 @@ end
 
 function Agents.plan_route!(
     agent::A,
-    dest::SVector{D,Float64},
+    dest::Agents.ValidPos,
     pathfinder::AStar{D,P,M,Float64},
 ) where {A<:AbstractAgent,D,P,M}
     path = find_continuous_path(pathfinder, agent.pos, dest)
@@ -107,8 +107,9 @@ function Agents.move_along_route!(
     isempty(agent.id, pathfinder) && return
     from = agent.pos
     next_pos = agent.pos
+    T = typeof(agent.pos)
     while true
-        next_waypoint = SVector(first(pathfinder.agent_paths[agent.id]))
+        next_waypoint = T(first(pathfinder.agent_paths[agent.id]))
         dir = get_direction(from, next_waypoint, model)
         dist_to_target = norm(dir)
         # edge case
@@ -125,7 +126,7 @@ function Agents.move_along_route!(
         next_pos = from .+ dir .* (speed * dt)
         next_pos = Agents.normalize_position(next_pos, model)
         # overshooting means we reached the waypoint
-        dist_to_next = euclidean_distance(SVector(from), SVector(next_pos), model)
+        dist_to_next = euclidean_distance(T(from), T(next_pos), model)
         if dist_to_next > dist_to_target
             # change from and dt so it appears we're coming from the waypoint just skipped, instead
             # of directly where the agent was. E.g:
@@ -146,7 +147,7 @@ function Agents.move_along_route!(
             break
         end
     end
-    move_agent!(agent, SVector(next_pos), model)
+    move_agent!(agent, T(next_pos), model)
 end
 
 function random_walkable(model::ABM{<:ContinuousSpace{D}}, pathfinder::AStar{D}) where {D}
@@ -182,11 +183,12 @@ Return a random position within radius `r` of `pos` which is walkable, as specif
 Return `pos` if no such position exists.
 """
 function random_walkable(
-    pos::SVector{D,Float64},
+    pos::Agents.ValidPos,
     model::ABM{<:ContinuousSpace{D}},
     pathfinder::AStar{D},
     r = 1.0,
 ) where {D}
+    T = typeof(pos)
     discrete_r = to_discrete_position(r, pathfinder) .- 1
     discrete_pos = to_discrete_position(pos, pathfinder)
     options = collect(walkable_cells_in_radius(discrete_pos, discrete_r, pathfinder))
@@ -197,7 +199,7 @@ function random_walkable(
     )
     half_cell_size = model.space.extent ./ size(pathfinder.walkmap) ./ 2.
     cts_rand = to_continuous_position(discrete_rand, pathfinder) .+
-        (rand(model.rng, SVector{D}) .- 0.5) .* half_cell_size
+        (T(rand(model.rng) for _ in 1:D) .- 0.5) .* half_cell_size
     dist = euclidean_distance(pos, cts_rand, model)
     dist > r && (cts_rand = mod1.(
         pos .+ get_direction(pos, cts_rand, model) ./ dist .* r,

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -16,17 +16,17 @@ in the discrete path to ensure continuous path is optimal.
 """
 function find_continuous_path(
     pathfinder::AStar{D},
-    from::NTuple{D,Float64},
-    to::NTuple{D,Float64},
+    from::SVector{D,Float64},
+    to::SVector{D,Float64},
 ) where {D}
-    discrete_from = to_discrete_position(from, pathfinder)
-    discrete_to = to_discrete_position(to, pathfinder)
+    discrete_from = Tuple(to_discrete_position(from, pathfinder))
+    discrete_to = Tuple(to_discrete_position(to, pathfinder))
     discrete_path = find_path(pathfinder, discrete_from, discrete_to)
     # find_path returns nothing if no path exists
     isnothing(discrete_path) && return
     # if discrete_path is empty, `from` and `to` are in the same grid cell,
     # so `to` is the only waypoint
-    isempty(discrete_path) && return Path{D,Float64}(to)
+    isempty(discrete_path) && return Path{D,Float64}(Tuple(to))
 
     cts_path = Path{D,Float64}()
     for pos in discrete_path
@@ -50,13 +50,13 @@ function find_continuous_path(
     end
     # If `to` is already at the center of a grid cell, there's no need
     # to push it to the path
-    last_to_end ≈ 0. || push!(cts_path, to)
+    last_to_end ≈ 0. || push!(cts_path, Tuple(to))
     return cts_path
 end
 
 function Agents.plan_route!(
     agent::A,
-    dest::NTuple{D,Float64},
+    dest::SVector{D,Float64},
     pathfinder::AStar{D,P,M,Float64},
 ) where {A<:AbstractAgent,D,P,M}
     path = find_continuous_path(pathfinder, agent.pos, dest)
@@ -108,7 +108,7 @@ function Agents.move_along_route!(
     from = agent.pos
     next_pos = agent.pos
     while true
-        next_waypoint = first(pathfinder.agent_paths[agent.id])
+        next_waypoint = SVector(first(pathfinder.agent_paths[agent.id]))
         dir = get_direction(from, next_waypoint, model)
         dist_to_target = norm(dir)
         # edge case
@@ -125,7 +125,7 @@ function Agents.move_along_route!(
         next_pos = from .+ dir .* (speed * dt)
         next_pos = Agents.normalize_position(next_pos, model)
         # overshooting means we reached the waypoint
-        dist_to_next = euclidean_distance(from, next_pos, model)
+        dist_to_next = euclidean_distance(SVector(from), SVector(next_pos), model)
         if dist_to_next > dist_to_target
             # change from and dt so it appears we're coming from the waypoint just skipped, instead
             # of directly where the agent was. E.g:
@@ -146,7 +146,7 @@ function Agents.move_along_route!(
             break
         end
     end
-    move_agent!(agent, next_pos, model)
+    move_agent!(agent, SVector(next_pos), model)
 end
 
 function random_walkable(model::ABM{<:ContinuousSpace{D}}, pathfinder::AStar{D}) where {D}
@@ -182,7 +182,7 @@ Return a random position within radius `r` of `pos` which is walkable, as specif
 Return `pos` if no such position exists.
 """
 function random_walkable(
-    pos,
+    pos::SVector{D,Float64},
     model::ABM{<:ContinuousSpace{D}},
     pathfinder::AStar{D},
     r = 1.0,
@@ -197,7 +197,7 @@ function random_walkable(
     )
     half_cell_size = model.space.extent ./ size(pathfinder.walkmap) ./ 2.
     cts_rand = to_continuous_position(discrete_rand, pathfinder) .+
-        Tuple(rand(model.rng, D) .- 0.5) .* half_cell_size
+        (rand(model.rng, SVector{D}) .- 0.5) .* half_cell_size
     dist = euclidean_distance(pos, cts_rand, model)
     dist > r && (cts_rand = mod1.(
         pos .+ get_direction(pos, cts_rand, model) ./ dist .* r,

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -1,5 +1,6 @@
 using Agents, Test
 using Agents.Pathfinding
+using StaticArrays
 
 @testset "AStar" begin
     moore = Pathfinding.moore_neighborhood(2)
@@ -98,45 +99,45 @@ using Agents.Pathfinding
         @testset "ContinuousSpace" begin
             pathfinder = AStar(cspace; walkmap = trues(10, 10))
             model = ABM(Agent6, cspace; properties = (pf = pathfinder,))
-            a = add_agent!((0., 0.), model, (0., 0.), 0.)
+            a = add_agent!(SVector(0., 0.), model, SVector(0., 0.), 0.)
             @test is_stationary(a, model.pf)
 
-            plan_route!(a, (4., 4.), model.pf)
+            plan_route!(a, SVector(4., 4.), model.pf)
             @test !is_stationary(a, model.pf)
             @test length(model.pf.agent_paths) == 1
             move_along_route!(a, model, model.pf, 0.35355)
-            @test all(isapprox.(a.pos, (4.75, 4.75); atol))
+            @test all(isapprox.(a.pos, SVector(4.75, 4.75); atol))
 
             # test waypoint skipping
-            move_agent!(a, (0.25, 0.25), model)
-            plan_route!(a, (0.75, 1.25), model.pf)
+            move_agent!(a, SVector(0.25, 0.25), model)
+            plan_route!(a, SVector(0.75, 1.25), model.pf)
             move_along_route!(a, model, model.pf, 0.807106)
-            @test all(isapprox.(a.pos, (0.75, 0.849999); atol)) || all(isapprox.(a.pos, (0.467156, 0.967156); atol))
+            @test all(isapprox.(a.pos, SVector(0.75, 0.849999); atol)) || all(isapprox.(a.pos, SVector(0.467156, 0.967156); atol))
             # make sure it doesn't overshoot the end
             move_along_route!(a, model, model.pf, 20.)
-            @test all(isapprox.(a.pos, (0.75, 1.25); atol))
+            @test all(isapprox.(a.pos, SVector(0.75, 1.25); atol))
 
             delete!(model.pf.agent_paths, 1)
             @test length(model.pf.agent_paths) == 0
 
             model.pf.walkmap[:, 3] .= 0
             @test all(get_spatial_property(random_walkable(model, model.pf), model.pf.walkmap, model) for _ in 1:10)
-            rpos = [random_walkable((2.5, 0.75), model, model.pf, 2.0) for _ in 1:50]
-            @test all(get_spatial_property(x, model.pf.walkmap, model) && euclidean_distance(x, (2.5, 0.75), model) <= 2.0 + atol for x in rpos)
+            rpos = [random_walkable(SVector(2.5, 0.75), model, model.pf, 2.0) for _ in 1:50]
+            @test all(get_spatial_property(x, model.pf.walkmap, model) && euclidean_distance(x, SVector(2.5, 0.75), model) <= 2.0 + atol for x in rpos)
 
             pcspace = ContinuousSpace((5., 5.); periodic = false)
             pathfinder = AStar(pcspace; walkmap = trues(10, 10))
             model = ABM(Agent6, pcspace; properties = (pf = pathfinder,))
-            a = add_agent!((0., 0.), model, (0., 0.), 0.)
-            @test all(plan_best_route!(a, [(2.5, 2.5), (4.99,0.), (0., 4.99)], model.pf) .≈ (2.5, 2.5))
+            a = add_agent!(SVector(0., 0.), model, SVector(0., 0.), 0.)
+            @test all(plan_best_route!(a, SVector.([(2.5, 2.5), (4.99,0.), (0., 4.99)]), model.pf) .≈ (2.5, 2.5))
             @test length(model.pf.agent_paths) == 1
             move_along_route!(a, model, model.pf, 1.0)
             @test all(isapprox.(a.pos, (0.7071, 0.7071); atol))
 
             model.pf.walkmap[:, 3] .= 0
-            move_agent!(a, (2.5, 2.5), model)
-            @test all(plan_best_route!(a, [(3., 0.3), (2.5, 2.5)], model.pf) .≈ (2.5, 2.5))
-            @test isnothing(plan_best_route!(a, [(3., 0.3), (1., 0.1)], model.pf))
+            move_agent!(a, SVector(2.5, 2.5), model)
+            @test all(plan_best_route!(a, SVector.([(3., 0.3), (2.5, 2.5)]), model.pf) .≈ (2.5, 2.5))
+            @test isnothing(plan_best_route!(a, SVector.([(3., 0.3), (1., 0.1)]), model.pf))
 
             remove_agent!(a, model, model.pf)
             @test length(model.pf.agent_paths) == 0
@@ -147,8 +148,8 @@ using Agents.Pathfinding
             @test penaltymap(pathfinder) == pmap
 
             @test all(get_spatial_property(random_walkable(model, model.pf), model.pf.walkmap, model) for _ in 1:10)
-            rpos = [random_walkable((2.5, 0.75), model, model.pf, 2.0) for _ in 1:50]
-            @test all(get_spatial_property(x, model.pf.walkmap, model) && euclidean_distance(x, (2.5, 0.75), model) <= 2.0 + atol for x in rpos)
+            rpos = [random_walkable(SVector(2.5, 0.75), model, model.pf, 2.0) for _ in 1:50]
+            @test all(get_spatial_property(x, model.pf.walkmap, model) && euclidean_distance(x, SVector(2.5, 0.75), model) <= 2.0 + atol for x in rpos)
         end
     end
 
@@ -260,13 +261,13 @@ using Agents.Pathfinding
 
         # Continuous
         model = ABM(Agent6, ContinuousSpace((10., 10.)))
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_m, (0.25, 0.25), (7.8, 9.5)))
-        testp = [(0.71429, 2.5), (0.71429, 4.16667), (0.71429, 5.83333), (0.71429, 7.5), (2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_np_m, SVector(0.25, 0.25), SVector(7.8, 9.5)))
+        testp = SVector.([(0.71429, 2.5), (0.71429, 4.16667), (0.71429, 5.83333), (0.71429, 7.5), (2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)])
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
 
-        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_m, (0.25, 0.25), (7.8, 9.5)))
-        testp = [(2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)]
+        p = collect(Pathfinding.find_continuous_path(pfinder_2d_p_m, SVector(0.25, 0.25), SVector(7.8, 9.5)))
+        testp = SVector.([(2.14286, 9.16667), (3.57143, 9.16667), (5.0, 9.16667), (6.42857, 9.16667), (7.85714, 9.16667), (7.8, 9.5)])
         @test length(p) == length(testp)
         @test all(all(isapprox.(p[i], testp[i]; atol)) for i in 1:length(p))
     end

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -1,6 +1,5 @@
 using Agents, Test
 using Agents.Pathfinding
-using StaticArrays
 
 @testset "AStar" begin
     moore = Pathfinding.moore_neighborhood(2)

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -99,9 +99,8 @@ using LinearAlgebra: norm, dot
         move_agent!(model[1], model, dt)
         @test model[1].pos == x .+ v.*dt
         model = ABM(TupleManualAgent, space; warn=false)
-        # generates SVector position, cannot convert to NTuple
-        @test_broken add_agent!(model, v)
-        add_agent!(x, model, v)
+        add_agent!(model, v)
+        @test model[1].pos isa NTuple && model[1].vel == v
         y = (0.5, 0.2)
         move_agent!(model[1], y, model)
         @test model[1].pos == y

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -5,7 +5,7 @@ using LinearAlgebra: norm, dot
 # TODO: We need to write tests for get_spatial_index and stuff!
 
 @testset "ContinuousSpace" begin
-    @agent SpeedyContinuousAgent ContinuousAgent{2} begin
+    @agent SpeedyContinuousAgent ContinuousAgent{2,Float64} begin
         speed::Float64
     end
 
@@ -230,7 +230,7 @@ using LinearAlgebra: norm, dot
         walk!(a, SVector(15.0, 1.0), model)
         @test a.pos == SVector(prevfloat(12.0), 2.0)
 
-        @agent ContinuousAgent3D ContinuousAgent{3} begin end
+        @agent ContinuousAgent3D ContinuousAgent{3,Float64} begin end
         model = ABM(ContinuousAgent3D, ContinuousSpace((12, 10, 5); spacing = 0.2))
         a = add_agent!(SVector(0.0, 0.0, 0.0), model, SVector(0.0, 0.0, 0.0))
         walk!(a, SVector(1.0, 1.0, 1.0), model)
@@ -243,7 +243,7 @@ using LinearAlgebra: norm, dot
 
 
         @testset "periodic" begin
-            model = ABM(ContinuousAgent{2}, ContinuousSpace((12, 10); periodic = true))
+            model = ABM(ContinuousAgent{2,Float64}, ContinuousSpace((12, 10); periodic = true))
             a = add_agent!(SVector(11.0, 9.0), model, SVector(3.0, 1.0))
             move_agent!(a, model, 1.0)
             @test a.pos[1] == 2
@@ -256,7 +256,7 @@ using LinearAlgebra: norm, dot
         speed = 0.002
         dt = 1.0
         diameter = 0.1
-        @agent MassContinuousAgent ContinuousAgent{2} begin
+        @agent MassContinuousAgent ContinuousAgent{2,Float64} begin
             mass::Float64
         end
 
@@ -334,7 +334,7 @@ using LinearAlgebra: norm, dot
         ≃(x,y) = isapprox(x,y,atol=1e-12) # \simeq
         @testset "2D" begin
             space = ContinuousSpace((10,10), periodic=true)
-            model = ABM(ContinuousAgent{2}, space)
+            model = ABM(ContinuousAgent{2,Float64}, space)
             x₀ = SVector(5.0, 5.0)
             v₀ = SVector(1.0, 0.0)
             add_agent!(x₀, model, v₀)
@@ -353,7 +353,7 @@ using LinearAlgebra: norm, dot
 
             # verify that reorientations obey the specified angles
             space = ContinuousSpace((10,10), periodic=true)
-            model = ABM(ContinuousAgent{2}, space)
+            model = ABM(ContinuousAgent{2,Float64}, space)
             x₀ = SVector(5.0, 5.0)
             v₀ = SVector(1.0, 0.0)
             add_agent!(x₀, model, v₀)
@@ -382,8 +382,8 @@ using LinearAlgebra: norm, dot
             # verify boundary conditions are respected
             space1 = ContinuousSpace((2,2), periodic=true)
             space2 = ContinuousSpace((2,2), periodic=false)
-            model1 = ABM(ContinuousAgent{2}, space1)
-            model2 = ABM(ContinuousAgent{2}, space2)
+            model1 = ABM(ContinuousAgent{2,Float64}, space1)
+            model2 = ABM(ContinuousAgent{2,Float64}, space2)
             x₀ = SVector(1.0, 1.0)
             v₀ = SVector(1.0, 0.0)
             add_agent!(x₀, model1, v₀)
@@ -399,7 +399,7 @@ using LinearAlgebra: norm, dot
 
         @testset "3D" begin
             space = ContinuousSpace((10,10,10), periodic=true)
-            model = ABM(ContinuousAgent{3}, space)
+            model = ABM(ContinuousAgent{3,Float64}, space)
             x₀ = SVector(5.0, 5.0, 5.0)
             v₀ = SVector(1.0, 0.0, 0.0)
             add_agent!(x₀, model, v₀)
@@ -418,7 +418,7 @@ using LinearAlgebra: norm, dot
 
             # verify that reorientations obey the specified angles
             space = ContinuousSpace((10,10,10), periodic=true)
-            model = ABM(ContinuousAgent{3}, space)
+            model = ABM(ContinuousAgent{3,Float64}, space)
             v₀ = SVector(1.0, 0.0, 0.0)
             add_agent!(model, v₀)
             r = 1.0
@@ -431,7 +431,7 @@ using LinearAlgebra: norm, dot
             @test dot(v₁, v₀) ≃ cos(θ)
 
             space = ContinuousSpace((10,10,10), periodic=true)
-            model = ABM(ContinuousAgent{3}, space)
+            model = ABM(ContinuousAgent{3,Float64}, space)
             v₀ = SVector(1.0, 0.0, 0.0)
             add_agent!(model, v₀)
             r = 1.0
@@ -448,7 +448,7 @@ using LinearAlgebra: norm, dot
 
             # test that velocity measure changes
             space = ContinuousSpace((10,10,10), periodic=true)
-            model = ABM(ContinuousAgent{3}, space)
+            model = ABM(ContinuousAgent{3,Float64}, space)
             v₀ = SVector(1.0, 0.0, 0.0)
             add_agent!(model, v₀)
             randomwalk!(model[1], model, 2)
@@ -457,7 +457,7 @@ using LinearAlgebra: norm, dot
 
         @testset "4D" begin
             space = ContinuousSpace((3,3,3,3), periodic=true)
-            model = ABM(ContinuousAgent{4}, space)
+            model = ABM(ContinuousAgent{4,Float64}, space)
             x₀ = SVector(2.0, 2.0, 2.0, 2.0)
             v₀ = SVector(0.2, 0.0, 0.0, 0.0)
             add_agent!(x₀, model, v₀)

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -476,17 +476,19 @@ using LinearAlgebra: norm, dot
 
     @testset "different continuous agent types" begin
         for T in [Float16, Float32]
-            space = ContinuousSpace((1,1))
+            space = ContinuousSpace((1,1)) # converted to SVector{2¸Float64}
+            @test_throws ArgumentError model = ABM(ContinuousAgent{2,T}, space)
+            space = ContinuousSpace(SVector{2,T}(1,1))
             model = ABM(ContinuousAgent{2,T}, space)
             x = spacesize(model) ./ 2
+            # vel is converted automatically
             vel = randn(SVector{2}) ./ 20
-            add_agent!(x, model; vel)
-            # values at creation are converted
+            add_agent!(x, model, vel)
             @test model[1].pos isa SVector{2,T} && model[1].pos == T.(x)
             @test model[1].vel isa SVector{2,T} && model[1].vel == T.(vel)
+
             dt = 1
-            x = model[1].pos
-            vel = model[1].vel
+            vel = T.(vel)
             move_agent!(model[1], model, dt)
             @test model[1].pos == x + vel .* dt
             y1 = SVector{2,T}(0.3, 0.7)

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -13,10 +13,10 @@ using LinearAlgebra: norm, dot
     @testset "space initialization" begin
         space1 = ContinuousSpace((1, 1))
         space2 = ContinuousSpace((1, 1, 1); spacing=0.25, periodic = false)
-        @test spacesize(space1) == (1.0, 1.0)
-        @test spacesize(space2) == (1.0, 1.0, 1.0)
+        @test spacesize(space1) == SVector(1.0, 1.0)
+        @test spacesize(space2) == SVector(1.0, 1.0, 1.0)
         @test_throws ArgumentError ContinuousSpace((-1,1)) # Cannot have negative extent
-        @test_throws MethodError ContinuousSpace([1,1]) # Must be a tuple
+        @test_throws MethodError ContinuousSpace([1,1]) # Must be a tuple or svector
         model = ABM(SpeedyContinuousAgent, space1)
         model2 = ABM(SpeedyContinuousAgent, space2)
     end
@@ -84,7 +84,7 @@ using LinearAlgebra: norm, dot
         space = ContinuousSpace((1,1))
         @test_logs (
             :warn,
-            "Using `NTuple` for the `pos` field of agent types in `ContinuousSpace` is deprecated. Please consider using `SVector` instead."
+            "Using `NTuple` for the `pos` field of agent types in `ContinuousSpace` is deprecated. Use `SVector` instead."
         ) (
             :warn,
             "`vel` field in agent type should be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -1,6 +1,5 @@
 using Agents, Test
 using StableRNGs
-using StaticArrays
 using LinearAlgebra: norm, dot
 
 # TODO: We need to write tests for get_spatial_index and stuff!

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -96,9 +96,8 @@ using LinearAlgebra: norm, dot
         add_agent!(x, model, v)
         @test model[1].pos == x
         @test model[1].vel == v
-        # normalize_position (in walk!) enforces SVector, cannot convert to NTuple
-        @test_broken move_agent!(model[1], model, dt)
-        #@test model[1].pos == x .+ v.*dt
+        move_agent!(model[1], model, dt)
+        @test model[1].pos == x .+ v.*dt
         model = ABM(TupleManualAgent, space)
         # generates SVector position, cannot convert to NTuple
         @test_broken add_agent!(model, v)
@@ -106,8 +105,8 @@ using LinearAlgebra: norm, dot
         y = (0.5, 0.2)
         move_agent!(model[1], y, model)
         @test model[1].pos == y
-        # normalize_position enforces SVector
-        @test_broken walk!(model[1], model[1].vel, model)
+        walk!(model[1], model[1].vel, model)
+        @test model[1].pos == y .+ model[1].vel
     end
 
     @testset "nearby ids" begin

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -50,6 +50,124 @@ using LinearAlgebra: norm, dot
         @test nagents(model) == 0
     end
 
+    @testset "support for tuples use with ContinuousAgent" begin
+        # agents with SVector types also work when passing tuples to functions
+        @agent SVecAgent ContinuousAgent{2,Float64} begin; end
+        space = ContinuousSpace((1,1))
+        model = ABM(SVecAgent, space)
+        x = (0.0, 0.0)
+        v = (0.1, 0.0)
+        dt = 1.0
+        add_agent!(x, model, v)
+        @test model[1].pos == SVector(x)
+        @test model[1].vel == SVector(v)
+        # different types of motion
+        move_agent!(model[1], model, dt)
+        @test model[1].pos == SVector(x .+ v.*dt)
+        y = (0.5, 0.2)
+        move_agent!(model[1], y, model)
+        @test model[1].pos == SVector(y)
+        walk!(model[1], 2 .* model[1].vel, model)
+        @test model[1].pos == SVector(y .+ 2 .* v)
+        # agent addition works also if pos is not specified
+        add_agent!(model, .-v)
+        @test model[2].pos isa SVector{2,Float64}
+        @test model[2].vel == SVector(.-v)
+        
+        # agents with hard-coded tuple types should work but throw warnings on creation
+        mutable struct TupleManualAgent <: AbstractAgent
+            id::Int
+            pos::NTuple{2,Float64}
+            vel::NTuple{2,Float64}
+        end
+        space = ContinuousSpace((1,1))
+        @test_logs (
+            :warn,
+            "Using `NTuple` for the `pos` and `vel` fields of agent types in ContinuousSpace is deprecated. Use `SVector` instead."
+        ) ABM(TupleManualAgent, space)
+        model = ABM(TupleManualAgent, space; warn=false)
+        x = (0.0, 0.0)
+        v = (0.1, 0.0)
+        dt = 1.0
+        add_agent!(x, model, v)
+        @test model[1].pos == x
+        @test model[1].vel == v
+        move_agent!(model[1], model, dt)
+        @test model[1].pos == x .+ v.*dt
+        model = ABM(TupleManualAgent, space; warn=false)
+        add_agent!(model, v)
+        @test model[1].pos isa NTuple{2,Float64}
+        y = (0.5, 0.2)
+        move_agent!(model[1], y, model)
+        @test model[1].pos == y
+        walk!(model[1], model[1].vel, model)
+        @test model[1].pos == y .+ model[1].vel
+        ## random walks
+        ≃(x,y) = isapprox(x, y; atol = 1e-12) # \simeq
+        space = ContinuousSpace((10,10), periodic=true)
+        model = ABM(TupleManualAgent, space; warn=false)
+        x₀ = (5.0, 5.0)
+        v₀ = (1.0, 0.0)
+        add_agent!(x₀, model, v₀)
+        r = 2.0
+        randomwalk!(model[1], model, r)
+        # distance between initial and new position should be r
+        @test norm(model[1].pos .- x₀) ≃ r
+        # velocity module remains equal to previous r
+        randomwalk!(model[1], model)
+        @test norm(model[1].vel) ≃ r
+        # verify that reorientations obey the specified angles
+        space = ContinuousSpace((10,10), periodic=true)
+        model = ABM(TupleManualAgent, space; warn=false)
+        x₀ = (5.0, 5.0)
+        v₀ = (1.0, 0.0)
+        add_agent!(x₀, model, v₀)
+        r = 1.0
+        polar = [π/2] # degenerate distribution, only π/2 reorientations
+        v₁ = (0.0, 1.0) # π/2
+        x₁ = x₀ .+ v₁
+        randomwalk!(model[1], model, r; polar)
+        @test all(model[1].vel .≃ v₁)
+        @test all(model[1].pos .≃ x₁)
+        # verify boundary conditions are respected
+        space1 = ContinuousSpace((2,2), periodic=true)
+        space2 = ContinuousSpace((2,2), periodic=false)
+        model1 = ABM(TupleManualAgent, space1; warn=false)
+        model2 = ABM(TupleManualAgent, space2; warn=false)
+        x₀ = (1.0, 1.0)
+        v₀ = (1.0, 0.0)
+        add_agent!(x₀, model1, v₀)
+        add_agent!(x₀, model2, v₀)
+        r = 1.1
+        polar = [0.0] # no reorientation, move straight
+        randomwalk!(model1[1], model1, r; polar)
+        randomwalk!(model2[1], model2, r; polar)
+        @test model1[1].pos[1] ≈ 0.1
+        @test model2[1].pos[1] ≈ 2.0
+        @test norm(model1[1].vel) == 1.1
+        ## pathfinding
+        using Agents.Pathfinding
+        gspace = GridSpace((5, 5))
+        cspace = ContinuousSpace((5., 5.))
+        atol = 0.0001 
+        pathfinder = AStar(cspace; walkmap = trues(10, 10))
+        model = ABM(TupleManualAgent, cspace; properties = (pf = pathfinder,), warn = false)
+        a = add_agent!((0., 0.), model, (0., 0.))
+        @test is_stationary(a, model.pf)
+        plan_route!(a, (4., 4.), model.pf)
+        @test !is_stationary(a, model.pf)
+        @test length(model.pf.agent_paths) == 1
+        move_along_route!(a, model, model.pf, 0.35355)
+        @test all(isapprox.(a.pos, (4.75, 4.75); atol))
+        # test waypoint skipping
+        move_agent!(a, (0.25, 0.25), model)
+        plan_route!(a, (0.75, 1.25), model.pf)
+        move_along_route!(a, model, model.pf, 0.807106)
+        @test all(isapprox.(a.pos, (0.75, 0.849999); atol)) || all(isapprox.(a.pos, (0.467156, 0.967156); atol))
+        # make sure it doesn't overshoot the end
+        move_along_route!(a, model, model.pf, 20.)
+        @test all(isapprox.(a.pos, (0.75, 1.25); atol))
+    end
     @testset "nearby ids" begin
         # At the end of this file there is a plotting test piece of code!
         # I've run it for many combinations and I am generally happy with the result.

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -106,24 +106,24 @@ using StableRNGs
     @testset "Distances" begin
     @testset "Euclidean distance" begin
         model = ABM(GridAgent{2}, SpaceType((12, 10); periodic = true))
-        a = add_agent!((1.0, 6.0), model)
-        b = add_agent!((11.0, 4.0), model)
+        a = add_agent!((1, 6), model)
+        b = add_agent!((11, 4), model)
         @test euclidean_distance(a, b, model) ≈ 2.82842712
 
         model = ABM(GridAgent{2}, SpaceType((12, 10); periodic = false))
-        a = add_agent!((1.0, 6.0), model)
-        b = add_agent!((11.0, 4.0), model)
+        a = add_agent!((1, 6), model)
+        b = add_agent!((11, 4), model)
         @test euclidean_distance(a, b, model) ≈ 10.198039
     end
     @testset "Manhattan Distance" begin
         model = ABM(GridAgent{2}, SpaceType((12, 10); metric = :manhattan, periodic = true))
-        a = add_agent!((1.0, 6.0), model)
-        b = add_agent!((11.0, 4.0), model)
+        a = add_agent!((1, 6), model)
+        b = add_agent!((11, 4), model)
         @test manhattan_distance(a, b, model) ≈ 4
 
         model = ABM(GridAgent{2}, SpaceType((12, 10); metric = :manhattan, periodic = false))
-        a = add_agent!((1.0, 6.0), model)
-        b = add_agent!((11.0, 4.0), model)
+        a = add_agent!((1, 6), model)
+        b = add_agent!((11, 4), model)
         @test manhattan_distance(a, b, model) ≈ 12
     end
     end

--- a/test/jld2_tests.jl
+++ b/test/jld2_tests.jl
@@ -1,3 +1,5 @@
+using StaticArrays
+
 # TODO: Add tests for GridSpaceSingle
 # TODO: None of these tests should access internal fields like .stored_ids!
 # instead they should use public API like `ids_in_position` etc.
@@ -250,8 +252,8 @@
                 properties = (pathfinder = pathfinder,),
                 rng = MersenneTwister(42)
             )
-            add_agent!((1.3, 1.5), model, (0.0, 0.0), 0.0)
-            plan_route!(model[1], (9.7, 4.8), model.pathfinder)
+            add_agent!(SVector(1.3, 1.5), model, SVector(0.0, 0.0), 0.0)
+            plan_route!(model[1], SVector(9.7, 4.8), model.pathfinder)
             step!(model, astep!, dummystep)
 
             AgentsIO.save_checkpoint("test.jld2", model)

--- a/test/jld2_tests.jl
+++ b/test/jld2_tests.jl
@@ -1,5 +1,3 @@
-using StaticArrays
-
 # TODO: Add tests for GridSpaceSingle
 # TODO: None of these tests should access internal fields like .stored_ids!
 # instead they should use public API like `ids_in_position` etc.

--- a/test/model_access.jl
+++ b/test/model_access.jl
@@ -79,7 +79,7 @@ end
     @test sprint(show, model)[1:25] == "StandardABM with 0 agents"
     @test sprint(show, Agents.abmspace(model)) == "GridSpace with size (5, 5), metric=chebyshev, periodic=true"
     model = ABM(Agent6, ContinuousSpace((1.0,1.0)))
-    @test sprint(show, Agents.abmspace(model)) == "periodic continuous space with (1.0, 1.0) extent and spacing=0.05"
+    @test sprint(show, Agents.abmspace(model)) == "periodic continuous space with [1.0, 1.0] extent and spacing=0.05"
     model = ABM(Agent5, GraphSpace(path_graph(5)))
     @test sprint(show, Agents.abmspace(model)) == "GraphSpace with 5 positions and 4 edges"
 end

--- a/test/model_creation_tests.jl
+++ b/test/model_creation_tests.jl
@@ -1,4 +1,4 @@
-using Test, Agents, Random
+using Test, Agents, Random, StaticArrays
 
 @testset "@agent macro" begin
     @test ContinuousAgent <: AbstractAgent
@@ -138,18 +138,18 @@ end
     # Shouldn't use DiscreteVelocity in a continuous space context since `vel` has an invalid type
     mutable struct DiscreteVelocity <: AbstractAgent
         id::Int
-        pos::NTuple{2,Float64}
-        vel::NTuple{2,Int}
+        pos::SVector{2,Float64}
+        vel::SVector{2,Int}
         diameter::Float64
     end
     @test_logs (
         :warn,
-        "`vel` field in agent type should be of type `NTuple{<:AbstractFloat}` when using ContinuousSpace.",
+        "`vel` field in agent type should be of type `SVector{<:AbstractFloat}` when using ContinuousSpace.",
     ) ABM(DiscreteVelocity, ContinuousSpace((1, 1)))
-    agent = DiscreteVelocity(1, (1, 1), (2, 3), 2.4)
+    agent = DiscreteVelocity(1, SVector(1, 1), SVector(2, 3), 2.4)
     @test_logs (
         :warn,
-        "`vel` field in agent type should be of type `NTuple{<:AbstractFloat}` when using ContinuousSpace.",
+        "`vel` field in agent type should be of type `SVector{<:AbstractFloat}` when using ContinuousSpace.",
     ) ABM(agent, ContinuousSpace((1, 1)))
     # Warning is suppressed if flag is set
     @test Agents.agenttype(ABM(agent, ContinuousSpace((1, 1)); warn = false)) <: AbstractAgent

--- a/test/model_creation_tests.jl
+++ b/test/model_creation_tests.jl
@@ -142,17 +142,9 @@ end
         vel::SVector{2,Int}
         diameter::Float64
     end
-    @test_logs (
-        :warn,
-        "`vel` field in agent type should be of type `SVector{<:AbstractFloat}` when using ContinuousSpace.",
-    ) ABM(DiscreteVelocity, ContinuousSpace((1, 1)))
+    @test_throws ArgumentError ABM(DiscreteVelocity, ContinuousSpace((1, 1)))
     agent = DiscreteVelocity(1, SVector(1, 1), SVector(2, 3), 2.4)
-    @test_logs (
-        :warn,
-        "`vel` field in agent type should be of type `SVector{<:AbstractFloat}` when using ContinuousSpace.",
-    ) ABM(agent, ContinuousSpace((1, 1)))
-    # Warning is suppressed if flag is set
-    @test Agents.agenttype(ABM(agent, ContinuousSpace((1, 1)); warn = false)) <: AbstractAgent
+    @test_throws ArgumentError ABM(agent, ContinuousSpace((1, 1)))
     # Shouldn't use ParametricAgent since it is not a concrete type
     mutable struct ParametricAgent{T<:Integer} <: AbstractAgent
         id::T
@@ -194,4 +186,5 @@ end
     ) ABM(Union{NoSpaceAgent,ValidAgent})
     @test_throws ArgumentError ABM(Union{NoSpaceAgent,BadAgent}; warn = false)
 end
+
 

--- a/test/model_creation_tests.jl
+++ b/test/model_creation_tests.jl
@@ -1,4 +1,4 @@
-using Test, Agents, Random, StaticArrays
+using Test, Agents, Random
 
 @testset "@agent macro" begin
     @test ContinuousAgent <: AbstractAgent

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test, Agents, Random, LinearAlgebra
 using CSV, Arrow
 using Agents.Graphs, Agents.DataFrames
 using StatsBase: mean
+using StaticArrays
 using StableRNGs
 
 using Distributed
@@ -11,6 +12,7 @@ addprocs(2)
     using CSV, Arrow
     using Agents.Graphs, Agents.DataFrames
     using StatsBase: mean
+    using StaticArrays
     using StableRNGs
 end
 
@@ -106,7 +108,7 @@ function flocking_model(
     space2d = ContinuousSpace(extent; spacing)
     model = ModelType(Bird, space2d, scheduler = Schedulers.Randomly(), rng=StableRNG(10))
     for _ in 1:n_birds
-        vel = Tuple(rand(model.rng, 2) * 2 .- 1)
+        vel = rand(model.rng, SVector{2}) .* 2 .- 1
         add_agent!(
             model,
             vel,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ function flocking_model(
     space2d = ContinuousSpace(extent; spacing)
     model = ModelType(Bird, space2d, scheduler = Schedulers.Randomly(), rng=StableRNG(10))
     for _ in 1:n_birds
-        vel = rand(rand(abmrng(model), SVector{2}) .* 2 .- 1
+        vel = rand(abmrng(model), SVector{2}) .* 2 .- 1
 
         add_agent!(
             model,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Test, Agents, Random, LinearAlgebra
 using CSV, Arrow
 using Agents.Graphs, Agents.DataFrames
 using StatsBase: mean
-using StaticArrays
 using StableRNGs
 
 using Distributed
@@ -12,7 +11,6 @@ addprocs(2)
     using CSV, Arrow
     using Agents.Graphs, Agents.DataFrames
     using StatsBase: mean
-    using StaticArrays
     using StableRNGs
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ end
     weight::Float64
 end
 
-@agent Agent6 ContinuousAgent{2} begin 
+@agent Agent6 ContinuousAgent{2,Float64} begin 
     weight::Float64
 end
 
@@ -43,7 +43,7 @@ end
     f2::Int
 end
 
-@agent Agent8 ContinuousAgent{2} begin 
+@agent Agent8 ContinuousAgent{2,Float64} begin 
     f1::Bool
     f2::Int
 end
@@ -55,7 +55,7 @@ Agent8(id, pos; f1, f2) = Agent8(id, pos, f1, f2)
     group::Int
 end
 
-@agent Bird ContinuousAgent{2} begin
+@agent Bird ContinuousAgent{2,Float64} begin
     speed::Float64
     cohere_factor::Float64
     separation::Float64


### PR DESCRIPTION
After I disgracefully deleted the branch I was using for #673, I restored and updated those changes. I could not reopen the original pr, sorry. Closes #672.

Still WIP, I'll try to improve this and then keep updating when needed

Main open points from #673:
- Pathfinder is messy due to multiple `SVector` <-> `NTuple` conversions
- Might be better to use `typeof` wherever possible rather than cast explicitly to `SVector`