### PR TITLE
Use API functions to access model fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ This is a huge release!
 - Self-contained features of Agents.jl will from now own exist in their own submodules. This will make the public API less cluttered and functionality more contained. Currently the new submodules are `Schedulers, Pathfinding, OSM`.
 - Pathfinding using the A* algorithm is now possible! Available for `GridSpace`.
 - Extend `dataname` (formerly `aggname`) to provide unique column names in collection dataframes when using anonymous functions
-- Fixed omission which did not enable updating properties of a model when `model.properties` is a `struct`.
+- Fixed omission which did not enable updating properties of a model when `abmproperties(model)` is a `struct`.
 - New function `ensemblerun!` for running ensemble model simulations.
 - Scheduler `Schedulers.by_property` (previously `property_activation`) now allows as input arbitrary functions besides symbols.
 
@@ -193,7 +193,7 @@ This is a huge release!
 
 # v4.1
 - A new example: Fractal Growth, explores `ContinuousSpace` and interactive plotting.
-- Models now supply a random number generator pool that is used in all random-related functions like `random_position`. Access it with `model.rng` and seed it with `seed!(model, seed)`.
+- Models now supply a random number generator pool that is used in all random-related functions like `random_position`. Access it with `abmrng(model)` and seed it with `seed!(model, seed)`.
 - Higher-order agent grouping utilities to facilitate complex interactions, see e.g. `iter_agent_groups`.
 - Several documentation improvements targeting newcomers.
 
@@ -277,8 +277,8 @@ therefore are not "truly breaking".
 * New continuous space functions `nearest_neighbor` and `elastic_collision!`.
 * New iterator `interacting_pairs`.
 * Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`.
-* If `model.properties` is a dictionary with key type Symbol, then the
-  convenience syntax `model.prop` returns `model.properties[:prop]`.
+* If `abmproperties(model)` is a dictionary with key type Symbol, then the
+  convenience syntax `model.prop` returns `abmproperties(model)[:prop]`.
 * Version of `add_agent!` now has keyword propagation as well (in case you make your types with `@kwdef` or Parameters.jl).
 * New function `nextid`
 * Cool new logo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ This is a huge release!
 - Self-contained features of Agents.jl will from now own exist in their own submodules. This will make the public API less cluttered and functionality more contained. Currently the new submodules are `Schedulers, Pathfinding, OSM`.
 - Pathfinding using the A* algorithm is now possible! Available for `GridSpace`.
 - Extend `dataname` (formerly `aggname`) to provide unique column names in collection dataframes when using anonymous functions
-- Fixed omission which did not enable updating properties of a model when `abmproperties(model)` is a `struct`.
+- Fixed omission which did not enable updating properties of a model when `model.properties` is a `struct`.
 - New function `ensemblerun!` for running ensemble model simulations.
 - Scheduler `Schedulers.by_property` (previously `property_activation`) now allows as input arbitrary functions besides symbols.
 
@@ -193,7 +193,7 @@ This is a huge release!
 
 # v4.1
 - A new example: Fractal Growth, explores `ContinuousSpace` and interactive plotting.
-- Models now supply a random number generator pool that is used in all random-related functions like `random_position`. Access it with `abmrng(model)` and seed it with `seed!(model, seed)`.
+- Models now supply a random number generator pool that is used in all random-related functions like `random_position`. Access it with `model.rng` and seed it with `seed!(model, seed)`.
 - Higher-order agent grouping utilities to facilitate complex interactions, see e.g. `iter_agent_groups`.
 - Several documentation improvements targeting newcomers.
 
@@ -277,8 +277,8 @@ therefore are not "truly breaking".
 * New continuous space functions `nearest_neighbor` and `elastic_collision!`.
 * New iterator `interacting_pairs`.
 * Agents can be accessed from the model directly. `model[id]` is equivalent with `model.agents[id]` and replaces `id2agent`.
-* If `abmproperties(model)` is a dictionary with key type Symbol, then the
-  convenience syntax `model.prop` returns `abmproperties(model)[:prop]`.
+* If `model.properties` is a dictionary with key type Symbol, then the
+  convenience syntax `model.prop` returns `model.properties[:prop]`.
 * Version of `add_agent!` now has keyword propagation as well (in case you make your types with `@kwdef` or Parameters.jl).
 * New function `nextid`
 * Cool new logo.
@@ -302,3 +302,4 @@ therefore are not "truly breaking".
 * It is now possible to `step!` until a boolean condition is met.
 # v2.0
 Changelog is kept with respect to version 2.0.
+

--- a/benchmark/simple_grid/abusive_unremovable.jl
+++ b/benchmark/simple_grid/abusive_unremovable.jl
@@ -22,12 +22,12 @@ function initialize_abusiveunremovable()
     for i in 1:2N
         grp = i <= N ? 1 : 2
         pos = (rand(1:grid_size[1]), rand(1:grid_size[2]))
-        while model.space[pos...] > 0
+        while abmspace(model)[pos...] > 0
             pos = (rand(1:grid_size[1]), rand(1:grid_size[2]))
         end
 
         push!(model.agents, AbusiveUnremovableAgent(pos, grp, false))
-        model.space[pos...] = length(model.agents)
+        abmspace(model)[pos...] = length(model.agents)
     end
 
     return model
@@ -40,14 +40,14 @@ function simulate_abusiveunremovable!(model)
         if same_count >= min_to_be_happy
             agent.happy = true
         else
-            grid_dims = size(model.space)
+            grid_dims = size(abmspace(model))
             new_pos = (rand(1:grid_dims[1]), rand(1:grid_dims[2]))
-            while model.space[new_pos...] > 0
+            while abmspace(model)[new_pos...] > 0
                 new_pos = (rand(1:grid_dims[1]), rand(1:grid_dims[2]))
             end
-            model.space[agent.pos...] = 0
+            abmspace(model)[agent.pos...] = 0
             agent.pos = new_pos
-            model.space[agent.pos...] = i
+            abmspace(model)[agent.pos...] = i
         end
     end
 end
@@ -56,8 +56,8 @@ function count_nearby_same_abusiveunremovable(agent, model)
     same_count = 0
     for offset in moore
         new_pos = agent.pos .+ offset
-        if checkbounds(Bool, model.space, new_pos...) && model.space[new_pos...] != 0
-            if model.agents[model.space[new_pos...]].group == agent.group
+        if checkbounds(Bool, abmspace(model), new_pos...) && abmspace(model)[new_pos...] != 0
+            if model.agents[abmspace(model)[new_pos...]].group == agent.group
                 same_count += 1
             end
         end

--- a/docs/logo/example_zoo.jl
+++ b/docs/logo/example_zoo.jl
@@ -91,7 +91,7 @@ function flocking_model(;
 
     model = ABM(Bird, space2d; rng, scheduler = Schedulers.Randomly())
     for _ in 1:n_birds
-        vel = Tuple(rand(model.rng, 2) * 2 .- 1)
+        vel = Tuple(rand(abmrng(model), 2) * 2 .- 1)
         add_agent!(
             model,
             vel,
@@ -165,7 +165,7 @@ function initialise_zombies(; seed = 1234)
 
     for id in 1:100
         start = random_position(model) # At an intersection
-        speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
+        speed = rand(abmrng(model)) * 5.0 + 2.0 # Random speed from 2-7kmph
         human = Zombie(id, start, false, speed)
         add_agent_pos!(human, model)
         OSM.plan_random_route!(human, model; limit = 50) # try 50 times to find a random route
@@ -173,14 +173,14 @@ function initialise_zombies(; seed = 1234)
     start = OSM.nearest_road((9.9351811, 51.5328328), model)
     finish = OSM.nearest_node((9.945125635913511, 51.530876112711745), model)
 
-    speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
+    speed = rand(abmrng(model)) * 5.0 + 2.0 # Random speed from 2-7kmph
     zombie = add_agent!(start, model, true, speed)
     plan_route!(zombie, finish, model)
     return model
 end
 function zombie_step!(agent, model)
     distance_left = move_along_route!(agent, model, agent.speed * model.dt)
-    if is_stationary(agent, model) && rand(model.rng) < 0.1
+    if is_stationary(agent, model) && rand(abmrng(model)) < 0.1
         OSM.plan_random_route!(agent, model; limit = 50)
         move_along_route!(agent, model, distance_left)
     end
@@ -236,8 +236,8 @@ function bacteria_model_step!(model)
         if a.growthprog ≥ 1
             ## When a cell has matured, it divides into two daughter cells on the
             ## positions of its nodes.
-            add_agent!(a.p1, model, 0.0, a.orientation, 0.0, 0.1 * rand(model.rng) + 0.05)
-            add_agent!(a.p2, model, 0.0, a.orientation, 0.0, 0.1 * rand(model.rng) + 0.05)
+            add_agent!(a.p1, model, 0.0, a.orientation, 0.0, 0.1 * rand(abmrng(model)) + 0.05)
+            add_agent!(a.p2, model, 0.0, a.orientation, 0.0, 0.1 * rand(abmrng(model)) + 0.05)
             remove_agent!(a, model)
         else
             ## The rest length of the internal spring grows with time. This causes
@@ -348,7 +348,7 @@ function initialize_runners(map_url; goal = (128, 409), seed = 88)
         properties = Dict(:goal => goal, :pathfinder => pathfinder)
     )
     for _ in 1:10
-        runner = add_agent!((rand(model.rng, 100:350), rand(model.rng, 50:200)), model)
+        runner = add_agent!((rand(abmrng(model), 100:350), rand(abmrng(model), 50:200)), model)
         plan_route!(runner, goal, model.pathfinder)
     end
     return model
@@ -523,7 +523,7 @@ function initialize_antworld(;number_ants::Int = 125, dimensions::Tuple = (70, 7
     )
 
     for n in 1:number_ants
-        agent = Ant(n, (x_center, y_center), false, rand(model.rng, range(1, 8)), 0, false)
+        agent = Ant(n, (x_center, y_center), false, rand(abmrng(model), range(1, 8)), 0, false)
         add_agent_pos!(agent, model)
     end
     return model
@@ -550,7 +550,7 @@ function detect_change_direction(agent::Ant, model_layer::Matrix)
     end
 end
 function wiggle(agent::Ant, model::AntWorld)
-    direction = rand(model.rng, [0, rand(model.rng, [-1, 1])])
+    direction = rand(abmrng(model), [0, rand(abmrng(model), [-1, 1])])
     agent.facing_direction = mod1(agent.facing_direction + direction, number_directions)
 end
 function apply_pheremone(agent::Ant, model::AntWorld; pheremone_val::Int = 60, spread_pheremone::Bool = false)
@@ -699,8 +699,8 @@ function initialize_fractal(;
     for i in 1:initial_particles
         particle = FractalParticle(
             i,
-            particle_radius(min_radius, max_radius, model.rng),
-            rand(model.rng) < clockwise_fraction,
+            particle_radius(min_radius, max_radius, abmrng(model)),
+            rand(abmrng(model)) < clockwise_fraction,
         )
         ## `add_agent!` automatically gives the particle a random position in the space
         add_agent!(particle, model)
@@ -708,7 +708,7 @@ function initialize_fractal(;
     ## create the seed particle
     particle = FractalParticle(
         initial_particles + 1,
-        particle_radius(min_radius, max_radius, model.rng),
+        particle_radius(min_radius, max_radius, abmrng(model)),
         true;
         pos = center,
         is_stuck = true,
@@ -737,7 +737,7 @@ function fractal_particle_step!(agent::FractalParticle, model)
     agent.vel =
         (
             radial .* model.attraction .+ tangent .* model.spin .+
-            rand_circle(model.rng) .* model.vibration
+            rand_circle(abmrng(model)) .* model.vibration
         ) ./ (agent.radius^2.0)
     move_agent!(agent, model, model.speed)
 end
@@ -748,9 +748,9 @@ function fractal_step!(model)
     while model.spawn_count > 0
         particle = FractalParticle(
             nextid(model),
-            particle_radius(model.min_radius, model.max_radius, model.rng),
-            rand(model.rng) < model.clockwise_fraction;
-            pos = (rand_circle(model.rng) .+ 1.0) .* model.space.extent .* 0.49,
+            particle_radius(model.min_radius, model.max_radius, abmrng(model)),
+            rand(abmrng(model)) < model.clockwise_fraction;
+            pos = (rand_circle(abmrng(model)) .+ 1.0) .* model.space.extent .* 0.49,
         )
         add_agent_pos!(particle, model)
         model.spawn_count -= 1
@@ -810,15 +810,15 @@ function socialdistancing_init(;
 
     ## Add initial individuals
     for ind in 1:N
-        pos = Tuple(rand(model.rng, 2))
+        pos = Tuple(rand(abmrng(model), 2))
         status = ind ≤ N - initial_infected ? :S : :I
         isisolated = ind ≤ isolated * N
         mass = isisolated ? Inf : 1.0
-        vel = isisolated ? (0.0, 0.0) : sincos(2π * rand(model.rng)) .* speed
+        vel = isisolated ? (0.0, 0.0) : sincos(2π * rand(abmrng(model))) .* speed
 
         ## very high transmission probability
         ## we are modelling close encounters after all
-        β = (βmax - βmin) * rand(model.rng) + βmin
+        β = (βmax - βmin) * rand(abmrng(model)) + βmin
         add_agent!(pos, model, vel, mass, 0, status, β)
     end
 
@@ -830,10 +830,10 @@ function transmit!(a1, a2, rp)
     count(a.status == :I for a in (a1, a2)) ≠ 1 && return
     infected, healthy = a1.status == :I ? (a1, a2) : (a2, a1)
 
-    rand(model.rng) > infected.β && return
+    rand(abmrng(model)) > infected.β && return
 
     if healthy.status == :R
-        rand(model.rng) > rp && return
+        rand(abmrng(model)) > rp && return
     end
     healthy.status = :I
 end
@@ -846,7 +846,7 @@ end
 update!(agent) = agent.status == :I && (agent.days_infected += 1)
 function recover_or_die!(agent, model)
     if agent.days_infected ≥ model.infection_period
-        if rand(model.rng) ≤ model.death_rate
+        if rand(abmrng(model)) ≤ model.death_rate
             remove_agent!(agent, model)
         else
             agent.status = :R

--- a/docs/logo/example_zoo.jl
+++ b/docs/logo/example_zoo.jl
@@ -730,7 +730,7 @@ function fractal_particle_step!(agent::FractalParticle, model)
         end
     end
     ## radial vector towards the center of the space
-    radial = model.space.extent ./ 2.0 .- agent.pos
+    radial = abmspace(model).extent ./ 2.0 .- agent.pos
     radial = radial ./ norm(radial)
     ## tangential vector in the direction of orbit of the particle
     tangent = Tuple(cross([radial..., 0.0], agent.spin_axis)[1:2])
@@ -750,7 +750,7 @@ function fractal_step!(model)
             nextid(model),
             particle_radius(model.min_radius, model.max_radius, abmrng(model)),
             rand(abmrng(model)) < model.clockwise_fraction;
-            pos = (rand_circle(abmrng(model)) .+ 1.0) .* model.space.extent .* 0.49,
+            pos = (rand_circle(abmrng(model)) .+ 1.0) .* abmspace(model).extent .* 0.49,
         )
         add_agent_pos!(particle, model)
         model.spawn_count -= 1

--- a/docs/logo/logo_model_def.jl
+++ b/docs/logo/logo_model_def.jl
@@ -37,7 +37,7 @@ end
 function sir_model_step!(model)
     r = model.interaction_radius
     for (a1, a2) in interacting_pairs(model, r, :all)
-        transmit!(a1, a2, model.reinfection_probability, model.rng)
+        transmit!(a1, a2, model.reinfection_probability, abmrng(model))
         elastic_collision!(a1, a2, :mass)
     end
 end
@@ -55,7 +55,7 @@ function recover_or_die!(agent, model)
     if agent.days_infected ≥ agent.recovery_period
         if agent.mass ≠ Inf
             kill_agent!(agent, model)
-        elseif rand(model.rng) ≤ model.death_rate
+        elseif rand(abmrng(model)) ≤ model.death_rate
             kill_agent!(agent, model)
         else
             agent.status = :R

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -20,6 +20,7 @@ allids
 abmproperties
 abmrng
 abmscheduler
+abmspace
 ```
 
 ## Available spaces

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -139,8 +139,8 @@ run!(model, agent_step!, model_step!, 10; mdata = assets)
 
 ## Seeding and Random numbers
 
-Each model created by [`AgentBasedModel`](@ref) provides a random number generator pool `model.rng` which by default coincides with the global RNG.
-For performance and reproducibility reasons, one should never use `rand()` without using a pool, thus throughout our examples we use `rand(model.rng)` or `rand(model.rng, 1:10, 100)`, etc.
+Each model created by [`AgentBasedModel`](@ref) provides a random number generator pool `abmrng(model)` which by default coincides with the global RNG.
+For performance and reproducibility reasons, one should never use `rand()` without using a pool, thus throughout our examples we use `rand(abmrng(model))` or `rand(abmrng(model), 1:10, 100)`, etc.
 
 Another benefit of this approach is deterministic models that can be run again and yield the same output.
 To do this, always pass a specifically seeded RNG to the model creation, e.g. `rng = Random.MersenneTwister(1234)`.

--- a/examples/agents_visualizations.jl
+++ b/examples/agents_visualizations.jl
@@ -260,12 +260,12 @@ end
 # `linesegments` to be tapered (i.e. one end is wider than the other).
 using Graphs: edges
 using GraphMakie: Shell
-edge_color(model) = fill((:grey, 0.25), ne(model.space.graph))
+edge_color(model) = fill((:grey, 0.25), ne(abmspace(model).graph))
 function edge_width(model)
-    w = zeros(ne(model.space.graph))
-    for e in edges(model.space.graph)
-        push!(w, 0.004 * length(model.space.stored_ids[e.src]))
-        push!(w, 0.004 * length(model.space.stored_ids[e.dst]))
+    w = zeros(ne(abmspace(model).graph))
+    for e in edges(abmspace(model).graph)
+        push!(w, 0.004 * length(abmspace(model).stored_ids[e.src]))
+        push!(w, 0.004 * length(abmspace(model).stored_ids[e.dst]))
     end
     return w
 end

--- a/examples/celllistmap.jl
+++ b/examples/celllistmap.jl
@@ -181,7 +181,7 @@ end
 # structure are updated.
 function agent_step!(agent, model::ABM)
     id = agent.id
-    dt = model.properties.dt
+    dt = abmproperties(model).dt
     ## Retrieve the forces on agent id
     f = model.system.forces[id]
     a = f / agent.mass

--- a/examples/diffeq.jl
+++ b/examples/diffeq.jl
@@ -43,7 +43,7 @@ end
 
 function agent_step!(agent, model)
     ## Make sure we sample from the fish distribution
-    agent.yearly_catch = rand(model.rng, Poisson(agent.competence))
+    agent.yearly_catch = rand(abmrng(model), Poisson(agent.competence))
 end
 
 function dstock(model)
@@ -88,7 +88,7 @@ function initialise(;
         add_agent!(
             model,
             ## Competence level is a lognormal distribution between 1 and 5
-            floor(rand(model.rng, truncated(LogNormal(), 1, 6))),
+            floor(rand(abmrng(model), truncated(LogNormal(), 1, 6))),
             ## Yearly catch can start at 0
             0.0,
         )
@@ -129,7 +129,7 @@ f
 
 function agent_step!(agent, model)
     if model.tick % 365 == 0
-        agent.yearly_catch = rand(model.rng, Poisson(agent.competence))
+        agent.yearly_catch = rand(abmrng(model), Poisson(agent.competence))
     end
 end
 
@@ -163,7 +163,7 @@ function initialise(;
         ),
     )
     for _ in 1:nagents
-        add_agent!(model, floor(rand(model.rng, truncated(LogNormal(), 1, 6))), 0.0)
+        add_agent!(model, floor(rand(abmrng(model), truncated(LogNormal(), 1, 6))), 0.0)
     end
     model
 end
@@ -217,7 +217,7 @@ Random.seed!(6549) #hide
 import OrdinaryDiffEq
 
 function agent_diffeq_step!(agent, model)
-    agent.yearly_catch = rand(model.rng, Poisson(agent.competence))
+    agent.yearly_catch = rand(abmrng(model), Poisson(agent.competence))
 end
 
 function model_diffeq_step!(model)
@@ -263,7 +263,7 @@ function initialise_diffeq(;
         ),
     )
     for _ in 1:nagents
-        add_agent!(model, floor(rand(model.rng, truncated(LogNormal(), 1, 6))), 0.0)
+        add_agent!(model, floor(rand(abmrng(model), truncated(LogNormal(), 1, 6))), 0.0)
     end
     model
 end
@@ -357,14 +357,14 @@ f
 # to handle the agent based aspects of our problem.
 
 function agent_cb_step!(agent, model)
-    agent.yearly_catch = rand(model.rng, Poisson(agent.competence))
+    agent.yearly_catch = rand(abmrng(model), Poisson(agent.competence))
 end
 
 function initialise_cb(; min_threshold = 60.0, nagents = 50)
     model = ABM(Fisher; properties = Dict(:min_threshold => min_threshold))
 
     for _ in 1:nagents
-        add_agent!(model, floor(rand(model.rng, truncated(LogNormal(), 1, 6))), 0.0)
+        add_agent!(model, floor(rand(abmrng(model), truncated(LogNormal(), 1, 6))), 0.0)
     end
     model
 end

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -61,7 +61,7 @@ function initialize_model(;
 
     model = ABM(Bird, space2d; rng, scheduler = Schedulers.Randomly())
     for _ in 1:n_birds
-        vel = Tuple(rand(model.rng, 2) * 2 .- 1)
+        vel = Tuple(rand(abmrng(model), 2) * 2 .- 1)
         add_agent!(
             model,
             vel,

--- a/examples/measurements.jl
+++ b/examples/measurements.jl
@@ -56,7 +56,7 @@ function update_surface_temperature!(pos::Dims{2}, model::DaisyWorld)
 end
 
 function diffuse_temperature!(pos::Dims{2}, model::DaisyWorld)
-    ratio = get(model.properties, :ratio, 0.5)
+    ratio = get(abmproperties(model), :ratio, 0.5)
     ids = nearby_ids(pos, model)
     meantemp = sum(model[i].temperature for i in ids if model[i] isa Land) / 8
     land = model[ids_in_position(pos, model)[1]]
@@ -69,7 +69,7 @@ function propagate!(pos::Dims{2}, model::DaisyWorld)
         daisy = model[ids[2]]
         temperature = model[ids[1]].temperature
         seed_threshold = (0.1457 * temperature - 0.0032 * temperature^2) - 0.6443
-        if rand(model.rng) < seed_threshold
+        if rand(abmrng(model)) < seed_threshold
             filter_place_daisy(pos) = length(ids_in_position(pos, model)) == 1
             seeding_place = random_nearby_position(pos, model, 1, filter_place_daisy)
             if !isnothing(seeding_place)
@@ -149,14 +149,14 @@ function daisyworld(;
     white_positions =
         StatsBase.sample(grid, Int(init_white * num_positions); replace = false)
     for wp in white_positions
-        wd = Daisy(nextid(model), wp, :white, rand(model.rng, 0:max_age), albedo_white)
+        wd = Daisy(nextid(model), wp, :white, rand(abmrng(model), 0:max_age), albedo_white)
         add_agent_pos!(wd, model)
     end
     allowed = setdiff(grid, white_positions)
     black_positions =
         StatsBase.sample(allowed, Int(init_black * num_positions); replace = false)
     for bp in black_positions
-        wd = Daisy(nextid(model), bp, :black, rand(model.rng, 0:max_age), albedo_black)
+        wd = Daisy(nextid(model), bp, :black, rand(abmrng(model), 0:max_age), albedo_black)
         add_agent_pos!(wd, model)
     end
 

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -93,17 +93,17 @@ function initialize_model(;
     )
     ## Add agents
     for _ in 1:n_sheep
-        energy = rand(model.rng, 1:(Δenergy_sheep*2)) - 1
+        energy = rand(abmrng(model), 1:(Δenergy_sheep*2)) - 1
         add_agent!(Sheep, model, energy, sheep_reproduce, Δenergy_sheep)
     end
     for _ in 1:n_wolves
-        energy = rand(model.rng, 1:(Δenergy_wolf*2)) - 1
+        energy = rand(abmrng(model), 1:(Δenergy_wolf*2)) - 1
         add_agent!(Wolf, model, energy, wolf_reproduce, Δenergy_wolf)
     end
     ## Add grass with random initial growth
     for p in positions(model)
-        fully_grown = rand(model.rng, Bool)
-        countdown = fully_grown ? regrowth_time : rand(model.rng, 1:regrowth_time) - 1
+        fully_grown = rand(abmrng(model), Bool)
+        countdown = fully_grown ? regrowth_time : rand(abmrng(model), 1:regrowth_time) - 1
         model.countdown[p...] = countdown
         model.fully_grown[p...] = fully_grown
     end
@@ -129,7 +129,7 @@ function sheepwolf_step!(sheep::Sheep, model)
         return
     end
     eat!(sheep, model)
-    if rand(model.rng) ≤ sheep.reproduction_prob
+    if rand(abmrng(model)) ≤ sheep.reproduction_prob
         reproduce!(sheep, model)
     end
 end
@@ -144,7 +144,7 @@ function sheepwolf_step!(wolf::Wolf, model)
     ## If there is any sheep on this grid cell, it's dinner time!
     dinner = first_sheep_in_position(wolf.pos, model)
     !isnothing(dinner) && eat!(wolf, dinner, model)
-    if rand(model.rng) ≤ wolf.reproduction_prob
+    if rand(abmrng(model)) ≤ wolf.reproduction_prob
         reproduce!(wolf, model)
     end
 end

--- a/examples/rabbit_fox_hawk.jl
+++ b/examples/rabbit_fox_hawk.jl
@@ -147,7 +147,7 @@ function initialize_model(
                 nextid(model), ## Using `nextid` prevents us from having to manually keep track
                                ## of animal IDs
                 random_walkable(model, model.landfinder),
-                rand(model.rng, Δe_grass:2Δe_grass),
+                rand(abmrng(model), Δe_grass:2Δe_grass),
             ),
             model,
         )
@@ -157,7 +157,7 @@ function initialize_model(
             Fox(
                 nextid(model),
                 random_walkable(model, model.landfinder),
-                rand(model.rng, Δe_rabbit:2Δe_rabbit),
+                rand(abmrng(model), Δe_rabbit:2Δe_rabbit),
             ),
             model,
         )
@@ -167,7 +167,7 @@ function initialize_model(
             Hawk(
                 nextid(model),
                 random_walkable(model, model.airfinder),
-                rand(model.rng, Δe_rabbit:2Δe_rabbit),
+                rand(abmrng(model), Δe_rabbit:2Δe_rabbit),
             ),
             model,
         )
@@ -254,7 +254,7 @@ function rabbit_step!(rabbit, model)
 
     ## Reproduce with a random probability, scaling according to the time passed each
     ## step
-    rand(model.rng) <= model.rabbit_repr * model.dt && reproduce!(rabbit, model)
+    rand(abmrng(model)) <= model.rabbit_repr * model.dt && reproduce!(rabbit, model)
 
     ## If the rabbit isn't already moving somewhere, move to a random spot
     if is_stationary(rabbit, model.landfinder)
@@ -275,7 +275,7 @@ function fox_step!(fox, model)
     ## Look for nearby rabbits that can be eaten
     food = [x for x in nearby_agents(fox, model) if x.type == :rabbit]
     if !isempty(food)
-        remove_agent!(rand(model.rng, food), model, model.landfinder)
+        remove_agent!(rand(abmrng(model), food), model, model.landfinder)
         fox.energy += model.Δe_rabbit
     end
 
@@ -290,7 +290,7 @@ function fox_step!(fox, model)
     end
 
     ## Random chance to reproduce every step
-    rand(model.rng) <= model.fox_repr * model.dt && reproduce!(fox, model)
+    rand(abmrng(model)) <= model.fox_repr * model.dt && reproduce!(fox, model)
 
     ## If the fox isn't already moving somewhere
     if is_stationary(fox, model.landfinder)
@@ -305,7 +305,7 @@ function fox_step!(fox, model)
             )
         else
             ## Move toward a random rabbit
-            plan_route!(fox, rand(model.rng, map(x -> x.pos, prey)), model.landfinder)
+            plan_route!(fox, rand(abmrng(model), map(x -> x.pos, prey)), model.landfinder)
         end
     end
 
@@ -320,7 +320,7 @@ function hawk_step!(hawk, model)
     food = [x for x in nearby_agents(hawk, model) if x.type == :rabbit]
     if !isempty(food)
         ## Eat (remove) the rabbit
-        remove_agent!(rand(model.rng, food), model, model.airfinder)
+        remove_agent!(rand(abmrng(model), food), model, model.airfinder)
         hawk.energy += model.Δe_rabbit
         ## Fly back up
         plan_route!(hawk, hawk.pos .+ (0., 0., 7.), model.airfinder)
@@ -334,7 +334,7 @@ function hawk_step!(hawk, model)
         return
     end
 
-    rand(model.rng) <= model.hawk_repr * model.dt && reproduce!(hawk, model)
+    rand(abmrng(model)) <= model.hawk_repr * model.dt && reproduce!(hawk, model)
 
     if is_stationary(hawk, model.airfinder)
         prey = [x for x in nearby_agents(hawk, model, model.hawk_vision) if x.type == :rabbit]
@@ -345,7 +345,7 @@ function hawk_step!(hawk, model)
                 model.airfinder,
             )
         else
-            plan_route!(hawk, rand(model.rng, map(x -> x.pos, prey)), model.airfinder)
+            plan_route!(hawk, rand(abmrng(model), map(x -> x.pos, prey)), model.airfinder)
         end
     end
 
@@ -371,7 +371,7 @@ function model_step!(model)
     )
     ## Grass regrows with a random probability, scaling with the amount of time passing
     ## each step of the model
-    growable .= rand(model.rng, length(growable)) .< model.regrowth_chance * model.dt
+    growable .= rand(abmrng(model), length(growable)) .< model.regrowth_chance * model.dt
 end
 
 # ## Visualization

--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -68,7 +68,7 @@ function schoolyard(;
     )
     for student in 1:numStudents
         ## Students begin near the school building
-        position = model.space.extent .* 0.5 .+ Tuple(rand(abmrng(model), 2)) .- 0.5
+        position = abmspace(model).extent .* 0.5 .+ Tuple(rand(abmrng(model), 2)) .- 0.5
         add_agent!(position, model, velocity)
 
         ## Add one friend and one foe to the social network
@@ -91,7 +91,7 @@ scale(L, force) = (L / distance(force)) .* force
 
 function agent_step!(student, model)
     ## place a teacher in the center of the yard, so we don’t go too far away
-    teacher = (model.space.extent .* 0.5 .- student.pos) .* model.teacher_attractor
+    teacher = (abmspace(model).extent .* 0.5 .- student.pos) .* model.teacher_attractor
 
     ## add a bit of randomness
     noise = model.noise .* (Tuple(rand(abmrng(model), 2)) .- 0.5)

--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -68,14 +68,14 @@ function schoolyard(;
     )
     for student in 1:numStudents
         ## Students begin near the school building
-        position = model.space.extent .* 0.5 .+ Tuple(rand(model.rng, 2)) .- 0.5
+        position = model.space.extent .* 0.5 .+ Tuple(rand(abmrng(model), 2)) .- 0.5
         add_agent!(position, model, velocity)
 
         ## Add one friend and one foe to the social network
-        friend = rand(model.rng, filter(s -> s != student, 1:numStudents))
-        add_edge!(model.buddies, student, friend, rand(model.rng))
-        foe = rand(model.rng, filter(s -> s != student, 1:numStudents))
-        add_edge!(model.buddies, student, foe, -rand(model.rng))
+        friend = rand(abmrng(model), filter(s -> s != student, 1:numStudents))
+        add_edge!(model.buddies, student, friend, rand(abmrng(model)))
+        foe = rand(abmrng(model), filter(s -> s != student, 1:numStudents))
+        add_edge!(model.buddies, student, foe, -rand(abmrng(model)))
     end
     model
 end
@@ -94,7 +94,7 @@ function agent_step!(student, model)
     teacher = (model.space.extent .* 0.5 .- student.pos) .* model.teacher_attractor
 
     ## add a bit of randomness
-    noise = model.noise .* (Tuple(rand(model.rng, 2)) .- 0.5)
+    noise = model.noise .* (Tuple(rand(abmrng(model), 2)) .- 0.5)
 
     ## Adhere to the social network
     network = model.buddies.weights[student.id, :]

--- a/examples/sir.jl
+++ b/examples/sir.jl
@@ -183,7 +183,7 @@ end
 
 function migrate!(agent, model)
     pid = agent.pos
-    m = sample(model.rng, 1:(model.C), Weights(model.migration_rates[pid, :]))
+    m = sample(abmrng(model), 1:(model.C), Weights(model.migration_rates[pid, :]))
     if m ≠ pid
         move_agent!(agent, m, model)
     end
@@ -197,13 +197,13 @@ function transmit!(agent, model)
         model.β_det[agent.pos]
     end
 
-    n = rate * abs(randn(model.rng))
+    n = rate * abs(randn(abmrng(model)))
     n <= 0 && return
 
     for contactID in ids_in_position(agent, model)
         contact = model[contactID]
         if contact.status == :S ||
-           (contact.status == :R && rand(model.rng) ≤ model.reinfection_probability)
+           (contact.status == :R && rand(abmrng(model)) ≤ model.reinfection_probability)
             contact.status = :I
             n -= 1
             n <= 0 && return
@@ -215,7 +215,7 @@ update!(agent, model) = agent.status == :I && (agent.days_infected += 1)
 
 function recover_or_die!(agent, model)
     if agent.days_infected ≥ model.infection_period
-        if rand(model.rng) ≤ model.death_rate
+        if rand(abmrng(model)) ≤ model.death_rate
             remove_agent!(agent, model)
         else
             agent.status = :R

--- a/examples/zombies.jl
+++ b/examples/zombies.jl
@@ -50,7 +50,7 @@ function initialise_zombies(; seed = 1234)
 
     for id in 1:100
         start = random_position(model) # At an intersection
-        speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
+        speed = rand(abmrng(model)) * 5.0 + 2.0 # Random speed from 2-7kmph
         human = Zombie(id, start, false, speed)
         add_agent_pos!(human, model)
         OSM.plan_random_route!(human, model; limit = 50) # try 50 times to find a random route
@@ -59,7 +59,7 @@ function initialise_zombies(; seed = 1234)
     start = OSM.nearest_road((9.9351811, 51.5328328), model)
     finish = OSM.nearest_node((9.945125635913511, 51.530876112711745), model)
 
-    speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
+    speed = rand(abmrng(model)) * 5.0 + 2.0 # Random speed from 2-7kmph
     zombie = add_agent!(start, model, true, speed)
     plan_route!(zombie, finish, model)
     ## This function call creates & adds an agent, see `add_agent!`
@@ -76,7 +76,7 @@ function zombie_step!(agent, model)
     ## destination early
     distance_left = move_along_route!(agent, model, agent.speed * model.dt)
 
-    if is_stationary(agent, model) && rand(model.rng) < 0.1
+    if is_stationary(agent, model) && rand(abmrng(model)) < 0.1
         ## When stationary, give the agent a 10% chance of going somewhere else
         OSM.plan_random_route!(agent, model; limit = 50)
         ## Start on new route, moving the remaining distance

--- a/ext/AgentsOSMVisualizations/AgentsOSMVisualizations.jl
+++ b/ext/AgentsOSMVisualizations/AgentsOSMVisualizations.jl
@@ -10,7 +10,7 @@ default_colors["secondary"] = colorant"#a18f78"
 default_colors["tertiary"] = colorant"#b3b381"
 
 function Agents.agents_osmplot!(ax::Axis, model::ABM; kwargs...)
-    osm_plot = OSMMakie.osmplot!(ax, model.space.map;
+    osm_plot = OSMMakie.osmplot!(ax, abmspace(model).map;
         graphplotkwargs = (; arrow_show = false), kwargs...
     )
     osm_plot.plots[1].plots[1].plots[1].inspectable[] = false

--- a/ext/AgentsVisualizations/src/abmplot.jl
+++ b/ext/AgentsVisualizations/src/abmplot.jl
@@ -122,12 +122,12 @@ const SUPPORTED_SPACES = Union{
 
 function Makie.plot!(abmplot::_ABMPlot)
     model = abmplot.abmobs[].model[]
-    if !(model.space isa SUPPORTED_SPACES)
-        error("Space type $(typeof(model.space)) is not supported for plotting.")
+    if !(abmspace(model) isa SUPPORTED_SPACES)
+        error("Space type $(typeof(abmspace(model))) is not supported for plotting.")
     end
     ax = abmplot.ax[]
     abmplot.adjust_aspect[] && (ax.aspect = DataAspect())
-    if !(model.space isa Agents.GraphSpace)
+    if !(abmspace(model) isa Agents.GraphSpace)
         set_axis_limits!(ax, model)
     end
     fig = ax.parent
@@ -139,7 +139,7 @@ function Makie.plot!(abmplot::_ABMPlot)
             abmplot.offset, abmplot.heatarray, abmplot._used_poly)
 
     # OpenStreetMapSpace preplot
-    if model.space isa Agents.OpenStreetMapSpace
+    if abmspace(model) isa Agents.OpenStreetMapSpace
         Agents.agents_osmplot!(abmplot.ax[], model; abmplot.osmkwargs...)
     end
 
@@ -183,7 +183,7 @@ function Makie.plot!(abmplot::_ABMPlot)
         edge_color = @lift(abmplot_edge_color($(abmplot.abmobs[].model), $ec))
         ew = get(abmplot.graphplotkwargs, :edge_width, Observable(1))
         edge_width = @lift(abmplot_edge_width($(abmplot.abmobs[].model), $ew))
-        graphplot!(abmplot, model.space.graph;
+        graphplot!(abmplot, abmspace(model).graph;
             node_color = color, node_marker = marker, node_size = markersize,
             abmplot.graphplotkwargs..., # must come first to not overwrite lifted kwargs
             edge_color, edge_width)
@@ -209,7 +209,7 @@ end
 
 "Plot space and/or set axis limits."
 function set_axis_limits!(ax, model)
-    if model.space isa Agents.OpenStreetMapSpace
+    if abmspace(model) isa Agents.OpenStreetMapSpace
         o = [Inf, Inf]
         e = [-Inf, -Inf]
         for i ∈ Agents.positions(model)
@@ -217,11 +217,11 @@ function set_axis_limits!(ax, model)
             o[1] = min(x, o[1]); o[2] = min(y, o[2])
             e[1] = max(x, e[1]); e[2] = max(y, e[2])
         end
-    elseif model.space isa Agents.ContinuousSpace
-        e = model.space.extent
+    elseif abmspace(model) isa Agents.ContinuousSpace
+        e = abmspace(model).extent
         o = zero.(e)
-    elseif model.space isa Agents.AbstractGridSpace
-        e = size(model.space) .+ 0.5
+    elseif abmspace(model) isa Agents.AbstractGridSpace
+        e = size(abmspace(model)) .+ 0.5
         o = zero.(e) .+ 0.5
     end
     xlims!(ax, o[1], e[1])

--- a/ext/AgentsVisualizations/src/daisyworld_def.jl
+++ b/ext/AgentsVisualizations/src/daisyworld_def.jl
@@ -34,7 +34,7 @@ function propagate!(pos, model::DaisyWorld)
     daisy = model[id_in_position(pos, model)]
     temperature = model.temperature[pos...]
     seed_threshold = (0.1457 * temperature - 0.0032 * temperature^2) - 0.6443
-    if rand(model.rng) < seed_threshold
+    if rand(abmrng(model)) < seed_threshold
         empty_near_pos = random_nearby_position(pos, model, 1, npos -> isempty(npos, model))
         if !isnothing(empty_near_pos)
             add_agent!(empty_near_pos, model, daisy.breed, 0, daisy.albedo)
@@ -100,14 +100,14 @@ function daisyworld(;
     white_positions =
         StatsBase.sample(grid, Int(init_white * num_positions); replace = false)
     for wp in white_positions
-        wd = Daisy(nextid(model), wp, :white, rand(model.rng, 0:max_age), albedo_white)
+        wd = Daisy(nextid(model), wp, :white, rand(abmrng(model), 0:max_age), albedo_white)
         add_agent_pos!(wd, model)
     end
     allowed = setdiff(grid, white_positions)
     black_positions =
         StatsBase.sample(allowed, Int(init_black * num_positions); replace = false)
     for bp in black_positions
-        wd = Daisy(nextid(model), bp, :black, rand(model.rng, 0:max_age), albedo_black)
+        wd = Daisy(nextid(model), bp, :black, rand(abmrng(model), 0:max_age), albedo_black)
         add_agent_pos!(wd, model)
     end
 

--- a/ext/AgentsVisualizations/src/inspection.jl
+++ b/ext/AgentsVisualizations/src/inspection.jl
@@ -114,7 +114,7 @@ ids_to_inspect(model::ABM{<:ContinuousSpace}, agent_pos) =
 ids_to_inspect(model::ABM{<:OpenStreetMapSpace}, agent_pos) =
     nearby_ids(agent_pos, model, 0.0)
 ids_to_inspect(model::ABM{<:GraphSpace}, agent_pos) =
-    model.space.stored_ids[agent_pos]
+    abmspace(model).stored_ids[agent_pos]
 ids_to_inspect(model::ABM, agent_pos) = []
 
 function Agents.agent2string(agent::A) where {A<:AbstractAgent}

--- a/ext/AgentsVisualizations/src/lifting.jl
+++ b/ext/AgentsVisualizations/src/lifting.jl
@@ -20,7 +20,7 @@ end
 
 abmplot_ids(model::ABM{<:SUPPORTED_SPACES}) = allids(model)
 # for GraphSpace the collected ids are the indices of the graph nodes (= agent positions)
-abmplot_ids(model::ABM{<:GraphSpace}) = eachindex(model.space.stored_ids)
+abmplot_ids(model::ABM{<:GraphSpace}) = eachindex(abmspace(model).stored_ids)
 
 
 #####
@@ -28,7 +28,7 @@ abmplot_ids(model::ABM{<:GraphSpace}) = eachindex(model.space.stored_ids)
 #####
 
 function abmplot_pos(model::ABM{<:SUPPORTED_SPACES}, offset, ids)
-    postype = agents_space_dimensionality(model.space) == 3 ? Point3f : Point2f
+    postype = agents_space_dimensionality(abmspace(model)) == 3 ? Point3f : Point2f
     if isnothing(offset)
         return [postype(model[i].pos) for i in ids]
     else
@@ -62,7 +62,7 @@ abmplot_colors(model::ABM{<:SUPPORTED_SPACES}, ac::Function, ids) =
     to_color.([ac(model[i]) for i in ids])
 # in GraphSpace we iterate over a list of agents (not agent ids) at a graph node position
 abmplot_colors(model::ABM{<:GraphSpace}, ac::Function, ids) =
-    to_color.(ac(model[id] for id in model.space.stored_ids[idx]) for idx in ids)
+    to_color.(ac(model[id] for id in abmspace(model).stored_ids[idx]) for idx in ids)
 
 #####
 ## markers
@@ -91,7 +91,7 @@ end
 # TODO: Add support for polygon markers for GraphSpace if possible with GraphMakie
 abmplot_marker(model::ABM{<:GraphSpace}, used_poly, am, pos, ids) = am
 abmplot_marker(model::ABM{<:GraphSpace}, used_poly, am::Function, pos, ids) =
-    [am(model[id] for id in model.space.stored_ids[idx]) for idx in ids]
+    [am(model[id] for id in abmspace(model).stored_ids[idx]) for idx in ids]
 
 user_used_polygons(am, marker) = false
 user_used_polygons(am::Makie.Polygon, marker) = true
@@ -108,7 +108,7 @@ abmplot_markersizes(model::ABM{<:SUPPORTED_SPACES}, as::Function, ids) =
 
 abmplot_markersizes(model::ABM{<:GraphSpace}, as, ids) = as
 abmplot_markersizes(model::ABM{<:GraphSpace}, as::Function, ids) =
-    [as(model[id] for id in model.space.stored_ids[idx]) for idx in ids]
+    [as(model[id] for id in abmspace(model).stored_ids[idx]) for idx in ids]
 
 
 #####

--- a/src/core/higher_order_iteration.jl
+++ b/src/core/higher_order_iteration.jl
@@ -11,7 +11,7 @@ e.g. `(agent1, agent7, agent8)`. `order` must be larger than `1` but has no uppe
 Index order is provided by the model scheduler by default,
 but can be altered with the `scheduler` keyword.
 """
-iter_agent_groups(order::Int, model::ABM; scheduler = model.scheduler) =
+iter_agent_groups(order::Int, model::ABM; scheduler = abmscheduler(model)) =
     Iterators.product((map(i -> model[i], scheduler(model)) for _ in 1:order)...)
 
 """

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -3,7 +3,7 @@
 # All methods, whose defaults won't apply, must be extended
 # during the definition of a new ABM type.
 export AgentBasedModel, ABM
-export abmrng, abmscheduler, abmproperties
+export abmrng, abmscheduler, abmspace, abmproperties
 export random_agent, nagents, allagents, allids, nextid, seed!
 
 ###########################################################################################
@@ -116,6 +116,12 @@ abmproperties(model::ABM) = getfield(model, :properties)
 Return the default scheduler stored in `model`.
 """
 abmscheduler(model::ABM) = getfield(model, :scheduler)
+
+"""
+    abmspace(model::ABM)
+Return the space instance stored in the `model`.
+"""
+abmspace(model::ABM) = getfield(model, :space)
 
 """
     allids(model)
@@ -263,12 +269,6 @@ add_agent_to_model!(agent, model) = notimplemented(model)
 Remove the agent from the model's internal container.
 """
 remove_agent_from_model!(agent, model) = notimplemented(model)
-
-"""
-    abmspace(model::ABM)
-Return the space instance stored in the `model`.
-"""
-abmspace(model::ABM) = getfield(model, :space)
 
 function Base.setindex!(m::ABM, args...; kwargs...)
     error("`setindex!` or `model[id] = agent` are invalid. Use `add_agent!(model, agent)` "*

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -38,12 +38,12 @@ This functionality is deprecated. Use [`randomwalk!`](@ref) instead.
 """
 function walk!(agent, ::typeof(rand), model::ABM{<:AbstractGridSpace{D}}; kwargs...) where {D}
     @warn "Producing random walks through `walk!` is deprecated. Use `randomwalk!` instead."
-    walk!(agent, Tuple(rand(model.rng, -1:1, D)), model; kwargs...)
+    walk!(agent, Tuple(rand(abmrng(model), -1:1, D)), model; kwargs...)
 end
 
 function walk!(agent, ::typeof(rand), model::ABM{<:ContinuousSpace{D}}) where {D}
     @warn "Producing random walks through `walk!` is deprecated. Use `randomwalk!` instead."
-    walk!(agent, Tuple(2.0 * rand(model.rng) - 1.0 for _ in 1:D), model)
+    walk!(agent, Tuple(2.0 * rand(abmrng(model)) - 1.0 for _ in 1:D), model)
 end
 
 # Fixed mass

--- a/src/models/flocking.jl
+++ b/src/models/flocking.jl
@@ -39,7 +39,7 @@ function flocking(;
     space2d = ContinuousSpace(extent; spacing)
     model = UnremovableABM(Bird, space2d, scheduler = Schedulers.Randomly())
     for _ in 1:n_birds
-        vel = Tuple(rand(model.rng, 2) * 2 .- 1)
+        vel = Tuple(rand(abmrng(model), 2) * 2 .- 1)
         add_agent!(
             model,
             vel,

--- a/src/models/sir.jl
+++ b/src/models/sir.jl
@@ -104,7 +104,7 @@ end
 
 function sir_migrate!(agent, model)
     pid = agent.pos
-    m = sample(model.rng, 1:(model.C), Weights(model.migration_rates[pid, :]))
+    m = sample(abmrng(model), 1:(model.C), Weights(model.migration_rates[pid, :]))
     if m ≠ pid
         move_agent!(agent, m, model)
     end
@@ -118,13 +118,13 @@ function sir_transmit!(agent, model)
         model.β_det[agent.pos]
     end
 
-    n = rate * abs(randn(model.rng))
+    n = rate * abs(randn(abmrng(model)))
     n <= 0 && return
 
     for contactID in ids_in_position(agent, model)
         contact = model[contactID]
         if contact.status == :S ||
-           (contact.status == :R && rand(model.rng) ≤ model.reinfection_probability)
+           (contact.status == :R && rand(abmrng(model)) ≤ model.reinfection_probability)
             contact.status = :I
             n -= 1
             n <= 0 && return
@@ -136,7 +136,7 @@ sir_update!(agent, model) = agent.status == :I && (agent.days_infected += 1)
 
 function sir_recover_or_die!(agent, model)
     if agent.days_infected ≥ model.infection_period
-        if rand(model.rng) ≤ model.death_rate
+        if rand(abmrng(model)) ≤ model.death_rate
             remove_agent!(agent, model)
         else
             agent.status = :R

--- a/src/models/zombies.jl
+++ b/src/models/zombies.jl
@@ -21,7 +21,7 @@ function zombies(; seed = 1234)
 
     for id in 1:100
         start = random_position(model) # At an intersection
-        speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
+        speed = rand(abmrng(model)) * 5.0 + 2.0 # Random speed from 2-7kmph
         human = Zombie(id, start, false, speed)
         add_agent_pos!(human, model)
         OSM.plan_random_route!(human, model; limit = 50) # try 50 times to find a random route
@@ -30,7 +30,7 @@ function zombies(; seed = 1234)
     start = OSM.nearest_road((51.5328328, 9.9351811), model)
     finish = OSM.nearest_node((51.530876112711745, 9.945125635913511), model)
 
-    speed = rand(model.rng) * 5.0 + 2.0 # Random speed from 2-7kmph
+    speed = rand(abmrng(model)) * 5.0 + 2.0 # Random speed from 2-7kmph
     zombie = add_agent!(start, model, true, speed)
     plan_route!(zombie, finish, model)
     ## This function call creates & adds an agent, see `add_agent!`
@@ -41,7 +41,7 @@ function zombie_agent_step!(agent, model)
     ## Each agent will progress slightly along their route
     distance_left = move_along_route!(agent, model, agent.speed * model.dt)
 
-    if is_stationary(agent, model) && rand(model.rng) < 0.1
+    if is_stationary(agent, model) && rand(abmrng(model)) < 0.1
         ## When stationary, give the agent a 10% chance of going somewhere else
         OSM.plan_random_route!(agent, model; limit = 50)
         ## Start on new route

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -629,7 +629,7 @@ function init_model_dataframe(model::ABM, properties::Vector)
     types[1] = Int[]
     for (i, k) in enumerate(properties)
         types[i+1] = if typeof(k) <: Symbol
-            current_props = model.properties
+            current_props = abmproperties(model)
             # How the properties are accessed depends on the type
             if typeof(current_props) <: Dict || typeof(current_props) <: Tuple
                 typeof(current_props[k])[]

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -426,7 +426,7 @@ function multi_agent_types!(
 end
 
 function collect_agent_data!(df, model, properties::Vector, step::Int = 0; kwargs...)
-    alla = sort!(collect(values(model.agents)), by = a -> a.id)
+    alla = sort!(collect(allagents(model)), by = a -> a.id)
     dd = DataFrame()
     dd[!, :step] = fill(step, length(alla))
     dd[!, :id] = map(a -> a.id, alla)

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -28,9 +28,9 @@ function sample!(
     org_ids = collect(allids(model))
     if weight !== nothing
         weights = Weights([get_data(a, weight, identity) for a in values(model.agents)])
-        newids = sample(model.rng, org_ids, weights, n, replace = replace)
+        newids = sample(abmrng(model), org_ids, weights, n, replace = replace)
     else
-        newids = sample(model.rng, org_ids, n, replace = replace)
+        newids = sample(abmrng(model), org_ids, n, replace = replace)
     end
     add_newids!(model, org_ids, newids)
 end

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -27,7 +27,7 @@ function sample!(
     nagents(model) == 0 && return nothing
     org_ids = collect(allids(model))
     if weight !== nothing
-        weights = Weights([get_data(a, weight, identity) for a in values(model.agents)])
+        weights = Weights([get_data(a, weight, identity) for a in allagents(model)])
         newids = sample(abmrng(model), org_ids, weights, n, replace = replace)
     else
         newids = sample(abmrng(model), org_ids, n, replace = replace)

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -7,7 +7,7 @@ export step!, dummystep
     step!(model::ABM, agent_step!, model_step!, n::Int = 1, agents_first::Bool = true)
 
 Update agents `n` steps according to the stepping function `agent_step!`.
-Agents will be activated as specified by the `model.scheduler`.
+Agents will be activated as specified by the `abmscheduler(model)`.
 `model_step!` is triggered _after_ every scheduled agent has acted, unless
 the argument `agents_first` is `false` (which then first calls `model_step!` and then
 activates the agents).

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -406,7 +406,7 @@ function interacting_pairs(model::ABM{<:ContinuousSpace}, r::Real, method;
     elseif method == :types
         type_pairs!(pairs, model, r, scheduler, nearby_f)
     end
-    return PairIterator(pairs, model.agents)
+    return PairIterator(pairs, agent_container(model))
 end
 
 function all_pairs!(

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -94,7 +94,7 @@ function ContinuousSpace(
 end
 
 function random_position(model::ABM{<:ContinuousSpace})
-    map(dim -> rand(model.rng) * dim, spacesize(model))
+    map(dim -> rand(abmrng(model)) * dim, spacesize(model))
 end
 
 "given position in continuous space, return cell coordinates in grid space."
@@ -349,7 +349,7 @@ end
 # interacting pairs
 #######################################################################################
 """
-    interacting_pairs(model, r, method; scheduler = model.scheduler) → piter
+    interacting_pairs(model, r, method; scheduler = abmscheduler(model)) → piter
 Return an iterator that yields **unique pairs** of agents `(a, b)` that are close
 neighbors to each other, within some interaction radius `r`.
 
@@ -377,7 +377,7 @@ The argument `method` provides three pairing scenarios
   types, i.e.: `scheduler(model) = (a.id for a in allagents(model) if !(a isa Grass))`.
 
 The following keywords can be used:
-- `scheduler = model.scheduler`, which schedulers the agents during iteration for finding
+- `scheduler = abmscheduler(model)`, which schedulers the agents during iteration for finding
   pairs. Especially in the `:nearest` case, this is important, as different sequencing
   for the agents may give different results (if `b` is the nearest agent for `a`, but
   `a` is not the nearest agent for `b`, whether you get the pair `(a, b)` or not depends
@@ -395,7 +395,7 @@ Example usage in [https://juliadynamics.github.io/AgentsExampleZoo.jl/dev/exampl
 
 """
 function interacting_pairs(model::ABM{<:ContinuousSpace}, r::Real, method;
-        scheduler = model.scheduler, nearby_f = nearby_ids_exact,
+        scheduler = abmscheduler(model), nearby_f = nearby_ids_exact,
     )
     @assert method ∈ (:nearest, :all, :types)
     pairs = Tuple{Int,Int}[]

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -15,7 +15,7 @@ export positions, npositions, ids_in_position, agents_in_position,
        random_id_in_position, random_agent_in_position
 
 
-positions(model::ABM) = positions(model.space)
+positions(model::ABM) = positions(abmspace(model))
 """
     positions(model::ABM{<:DiscreteSpace}) → ns
 Return an iterator over all positions of a model with a discrete space.
@@ -45,7 +45,7 @@ end
 
 Return the number of positions of a model with a discrete space.
 """
-npositions(model::ABM) = npositions(model.space)
+npositions(model::ABM) = npositions(abmspace(model))
 
 """
     ids_in_position(position, model::ABM{<:DiscreteSpace})

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -31,7 +31,7 @@ function positions(model::ABM{<:DiscreteSpace}, by::Symbol)
     n = collect(positions(model))
     itr = vec(n)
     if by == :random
-        shuffle!(model.rng, itr)
+        shuffle!(abmrng(model), itr)
     elseif by == :population
         sort!(itr, by = i -> length(ids_in_position(i, model)), rev = true)
     else
@@ -114,7 +114,7 @@ function random_empty(model::ABM{<:DiscreteSpace}, cutoff = 0.998)
     else
         empty = empty_positions(model)
         isempty(empty) && return nothing
-        return rand(model.rng, collect(empty))
+        return rand(abmrng(model), collect(empty))
     end
 end
 

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -86,7 +86,7 @@ end
 # The following is for the discrete space API:
 npositions(space::GraphSpace) = nv(space.graph)
 positions(space::GraphSpace) = 1:npositions(space)
-ids_in_position(n::Integer, model::ABM{<:GraphSpace}) = model.space.stored_ids[n]
+ids_in_position(n::Integer, model::ABM{<:GraphSpace}) = abmspace(model).stored_ids[n]
 # NOTICE: The return type of `ids_in_position` must support `length` and `isempty`!
 
 #######################################################################################
@@ -94,7 +94,7 @@ ids_in_position(n::Integer, model::ABM{<:GraphSpace}) = model.space.stored_ids[n
 #######################################################################################
 function nearby_ids(pos::Int, model::ABM{<:GraphSpace}, r = 1; kwargs...)
     np = nearby_positions(pos, model, r; kwargs...)
-    vcat(model.space.stored_ids[pos], model.space.stored_ids[np]...)
+    vcat(abmspace(model).stored_ids[pos], abmspace(model).stored_ids[np]...)
 end
 
 # This function is here purely because of performance reasons
@@ -110,13 +110,13 @@ function nearby_positions(
 )
     @assert neighbor_type ∈ (:default, :all, :in, :out)
     if neighbor_type == :default
-        Graphs.neighbors(model.space.graph, position)
+        Graphs.neighbors(abmspace(model).graph, position)
     elseif neighbor_type == :in
-        Graphs.inneighbors(model.space.graph, position)
+        Graphs.inneighbors(abmspace(model).graph, position)
     elseif neighbor_type == :out
-        Graphs.outneighbors(model.space.graph, position)
+        Graphs.outneighbors(abmspace(model).graph, position)
     else
-        Graphs.all_neighbors(model.space.graph, position)
+        Graphs.all_neighbors(abmspace(model).graph, position)
     end
 end
 
@@ -138,9 +138,9 @@ that of the one to be removed, while every other node remains as is. This means 
          remove_agent!(model[id], model)
      end
     V = nv(model)
-    success = Graphs.rem_vertex!(model.space.graph, n)
+    success = Graphs.rem_vertex!(abmspace(model).graph, n)
     n > V && error("Node number exceeds amount of nodes in graph!")
-    s = model.space.stored_ids
+    s = abmspace(model).stored_ids
     s[V], s[n] = s[n], s[V]
     pop!(s)
 end
@@ -151,8 +151,8 @@ end
  You can connect this new node with existing ones using [`add_edge!`](@ref).
  """
  function add_node!(model::ABM{<:GraphSpace})
-     add_vertex!(model.space.graph)
-     push!(model.space.stored_ids, Int[])
+     add_vertex!(abmspace(model).graph)
+     push!(abmspace(model).stored_ids, Int[])
      return nv(model)
  end
 
@@ -170,9 +170,9 @@ function Graphs.rem_vertex!(model::ABM{<:GraphSpace}, n::Int)
         remove_agent!(model[id], model)
     end
     V = nv(model)
-    success = Graphs.rem_vertex!(model.space.graph, n)
+    success = Graphs.rem_vertex!(abmspace(model).graph, n)
     n > V && error("Node number exceeds amount of nodes in graph!")
-    s = model.space.stored_ids
+    s = abmspace(model).stored_ids
     s[V], s[n] = s[n], s[V]
     pop!(s)
 end
@@ -183,8 +183,8 @@ Add a new node (i.e. possible position) to the model's graph and return it.
 You can connect this new node with existing ones using [`add_edge!`](@ref).
 """
 function Graphs.add_vertex!(model::ABM{<:GraphSpace})
-    add_vertex!(model.space.graph)
-    push!(model.space.stored_ids, Int[])
+    add_vertex!(abmspace(model).graph)
+    push!(abmspace(model).stored_ids, Int[])
     return nv(model)
 end
 
@@ -195,11 +195,11 @@ Returns a boolean, true if the operation was successful.
 
 `args` and `kwargs` are directly passed to the `add_edge!` dispatch that acts the underlying graph type.
 """
-Graphs.add_edge!(model::ABM{<:GraphSpace}, args::Vararg{Any, N}; kwargs...) where {N} = add_edge!(model.space.graph, args...; kwargs...)
+Graphs.add_edge!(model::ABM{<:GraphSpace}, args::Vararg{Any, N}; kwargs...) where {N} = add_edge!(abmspace(model).graph, args...; kwargs...)
 
 """
     rem_edge!(model::ABM{<:GraphSpace}, n, m)
 Remove an edge (relationship between two positions) from the graph.
 Returns a boolean, true if the operation was successful. 
 """
-Graphs.rem_edge!(model::ABM{<:GraphSpace}, n, m) = rem_edge!(model.space.graph, n, m)
+Graphs.rem_edge!(model::ABM{<:GraphSpace}, n, m) = rem_edge!(abmspace(model).graph, n, m)

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -63,7 +63,7 @@ end
 #######################################################################################
 # Agents.jl space API
 #######################################################################################
-random_position(model::ABM{<:GraphSpace}) = rand(model.rng, 1:nv(model))
+random_position(model::ABM{<:GraphSpace}) = rand(abmrng(model), 1:nv(model))
 
 function remove_agent_from_space!(
     agent::A,

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -45,7 +45,7 @@ The function does two things:
 1. If a vector of indices exists in the model, it returns that.
 2. If not, it creates this vector, stores it in the model and then returns that.
 """
-offsets_within_radius(model::ABM, r::Real) = offsets_within_radius(model.space, r::Real)
+offsets_within_radius(model::ABM, r::Real) = offsets_within_radius(abmspace(model), r::Real)
 function offsets_within_radius(
     space::AbstractGridSpace{D}, r::Real)::Vector{NTuple{D, Int}} where {D}
     r₀ = floor(Int, r)
@@ -64,7 +64,7 @@ The function does two things:
 1. If a vector of indices exists in the model, it returns that.
 2. If not, it creates this vector, stores it in the model and then returns that.
 """
-offsets_at_radius(model::ABM, r::Real) = offsets_at_radius(model.space, r::Real)
+offsets_at_radius(model::ABM, r::Real) = offsets_at_radius(abmspace(model), r::Real)
 function offsets_at_radius(
     space::AbstractGridSpace{D}, r::Real
 )::Vector{NTuple{D, Int}} where {D}
@@ -102,11 +102,11 @@ function calculate_offsets(space::AbstractGridSpace{D}, r::Int) where {D}
 end
 
 function random_position(model::ABM{<:AbstractGridSpace})
-    Tuple(rand(abmrng(model), CartesianIndices(model.space.stored_ids)))
+    Tuple(rand(abmrng(model), CartesianIndices(abmspace(model).stored_ids)))
 end
 
 offsets_within_radius_no_0(model::ABM, r::Real) =
-    offsets_within_radius_no_0(model.space, r::Real)
+    offsets_within_radius_no_0(abmspace(model), r::Real)
 function offsets_within_radius_no_0(
     space::AbstractGridSpace{D}, r::Real)::Vector{NTuple{D, Int}} where {D}
     r₀ = floor(Int, r)
@@ -126,7 +126,7 @@ end
 # we want to be able to re-use it in `ContinuousSpace`, so we allow it to either
 # find positions with the 0 or without.
 function nearby_positions(pos::ValidPos, model::ABM{<:AbstractGridSpace}, args::Vararg{Any, N}) where {N}
-    return nearby_positions(pos, model.space, args...)
+    return nearby_positions(pos, abmspace(model), args...)
 end
 function nearby_positions(
         pos::ValidPos, space::AbstractGridSpace{D,false}, r = 1,
@@ -159,8 +159,8 @@ function nearby_positions(
 end
 
 function random_nearby_position(pos::ValidPos, model::ABM{<:AbstractGridSpace{D,false}}, r=1; kwargs...) where {D}
-    nindices = offsets_within_radius_no_0(model.space, r)
-    stored_ids = model.space.stored_ids
+    nindices = offsets_within_radius_no_0(abmspace(model), r)
+    stored_ids = abmspace(model).stored_ids
     rng = abmrng(model)
     while true
         chosen_offset = rand(rng, nindices)
@@ -170,8 +170,8 @@ function random_nearby_position(pos::ValidPos, model::ABM{<:AbstractGridSpace{D,
 end
 
 function random_nearby_position(pos::ValidPos, model::ABM{<:AbstractGridSpace{D,true}}, r=1; kwargs...) where {D}
-    nindices = offsets_within_radius_no_0(model.space, r)
-    stored_ids = model.space.stored_ids
+    nindices = offsets_within_radius_no_0(abmspace(model), r)
+    stored_ids = abmspace(model).stored_ids
     chosen_offset = rand(abmrng(model), nindices)
     chosen_pos = pos .+ chosen_offset
     checkbounds(Bool, stored_ids, chosen_pos...) && return chosen_pos

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -102,7 +102,7 @@ function calculate_offsets(space::AbstractGridSpace{D}, r::Int) where {D}
 end
 
 function random_position(model::ABM{<:AbstractGridSpace})
-    Tuple(rand(model.rng, CartesianIndices(model.space.stored_ids)))
+    Tuple(rand(abmrng(model), CartesianIndices(model.space.stored_ids)))
 end
 
 offsets_within_radius_no_0(model::ABM, r::Real) =

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -84,12 +84,12 @@ end
 # %% Implementation of space API
 #######################################################################################
 function add_agent_to_space!(a::A, model::ABM{<:GridSpace,A}) where {A<:AbstractAgent}
-    push!(model.space.stored_ids[a.pos...], a.id)
+    push!(abmspace(model).stored_ids[a.pos...], a.id)
     return a
 end
 
 function remove_agent_from_space!(a::A, model::ABM{<:GridSpace,A}) where {A<:AbstractAgent}
-    prev = model.space.stored_ids[a.pos...]
+    prev = abmspace(model).stored_ids[a.pos...]
     ai = findfirst(i -> i == a.id, prev)
     deleteat!(prev, ai)
     return a
@@ -105,7 +105,7 @@ end
 # Instead, here we create a dedicated iterator for going over IDs.
 
 # We allow this to be used with space directly because it is reused in `ContinuousSpace`.
-nearby_ids(pos::NTuple, model::ABM{<:GridSpace}, r::Real = 1) = nearby_ids(pos, model.space, r)
+nearby_ids(pos::NTuple, model::ABM{<:GridSpace}, r::Real = 1) = nearby_ids(pos, abmspace(model), r)
 function nearby_ids(pos::NTuple{D, Int}, space::GridSpace{D,P}, r::Real = 1) where {D,P}
     nindices = offsets_within_radius(space, r)
     stored_ids = space.stored_ids
@@ -228,16 +228,16 @@ function nearby_ids(
     model::ABM{<:GridSpace},
     r::Vector{Tuple{Int64, UnitRange{Int64}}},
 )
-    @assert model.space.metric == :chebyshev
+    @assert abmspace(model).metric == :chebyshev
     dims = first.(r)
     vidx = []
-    for d in 1:ndims(model.space.stored_ids)
+    for d in 1:ndims(abmspace(model).stored_ids)
         idx = findall(dim -> dim == d, dims)
         dim_range = isempty(idx) ? Colon() :
-            bound_range(pos[d] .+ last(r[only(idx)]), d, model.space)
+            bound_range(pos[d] .+ last(r[only(idx)]), d, abmspace(model))
         push!(vidx, dim_range)
     end
-    s = view(model.space.stored_ids, vidx...)
+    s = view(abmspace(model).stored_ids, vidx...)
     Iterators.flatten(s)
 end
 
@@ -249,7 +249,7 @@ end
 #######################################################################################
 # %% Further discrete space functions
 #######################################################################################
-ids_in_position(pos::ValidPos, model::ABM{<:GridSpace}) = ids_in_position(pos, model.space)
+ids_in_position(pos::ValidPos, model::ABM{<:GridSpace}) = ids_in_position(pos, abmspace(model))
 function ids_in_position(pos::ValidPos, space::GridSpace)
     return space.stored_ids[pos...]
 end

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -39,22 +39,22 @@ end
 function add_agent_to_space!(a::A, model::ABM{<:GridSpaceSingle,A}) where {A<:AbstractAgent}
     pos = a.pos
     !isempty(pos, model) && error("Cannot add agent $(a) to occupied position $(pos)")
-    model.space.stored_ids[pos...] = a.id
+    abmspace(model).stored_ids[pos...] = a.id
     return a
 end
 
 function remove_agent_from_space!(a::A, model::ABM{<:GridSpaceSingle,A}) where {A<:AbstractAgent}
-    model.space.stored_ids[a.pos...] = 0
+    abmspace(model).stored_ids[a.pos...] = 0
     return a
 end
 # `random_position` comes from `AbstractGridSpace` in spaces/grid_general.jl
 # move_agent! does not need be implemented.
 # The generic version at core/space_interaction_API.jl covers it.
 # `random_empty` comes from spaces/discrete.jl as long as we extend:
-Base.isempty(pos, model::ABM{<:GridSpaceSingle}) = model.space.stored_ids[pos...] == 0
+Base.isempty(pos, model::ABM{<:GridSpaceSingle}) = abmspace(model).stored_ids[pos...] == 0
 # And we also need to extend the iterator of empty positions
 function empty_positions(model::ABM{<:GridSpaceSingle})
-    Iterators.filter(i -> model.space.stored_ids[i...] == 0, positions(model))
+    Iterators.filter(i -> abmspace(model).stored_ids[i...] == 0, positions(model))
 end
 
 """
@@ -66,7 +66,7 @@ This is similar to [`ids_in_position`](@ref), but specialized for `GridSpaceSing
 See also [`isempty`](@ref).
 """
 function id_in_position(pos, model::ABM{<:GridSpaceSingle})
-    return model.space.stored_ids[pos...]
+    return abmspace(model).stored_ids[pos...]
 end
 
 
@@ -84,7 +84,7 @@ function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,true}}, 
         get_offset_indices = offsets_within_radius # internal, see last function
     ) where {D}
     nindices = get_offset_indices(model, r)
-    stored_ids = model.space.stored_ids
+    stored_ids = abmspace(model).stored_ids
     space_size = size(stored_ids)
     position_iterator = (pos .+ β for β in nindices)
     # check if we are far from the wall to skip bounds checks
@@ -103,7 +103,7 @@ function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,false}},
         get_offset_indices = offsets_within_radius # internal, see last function
     ) where {D}
     nindices = get_offset_indices(model, r)
-    stored_ids = model.space.stored_ids
+    stored_ids = abmspace(model).stored_ids
     space_size = size(stored_ids)
     position_iterator = (pos .+ β for β in nindices)
     # check if we are far from the wall to skip bounds checks

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -181,10 +181,10 @@ returns a location somewhere on a road heading in a random direction.
 function random_road_position(model::ABM{<:OpenStreetMapSpace})
     # pick a random source and destination, and then a random distance on that edge
     s = Int(rand(abmrng(model), 1:Agents.nv(model)))
-    if isempty(all_neighbors(model.space.map.graph, s))
+    if isempty(all_neighbors(abmspace(model).map.graph, s))
         return (s, s, 0.0)
     end
-    d = Int(rand(abmrng(model), all_neighbors(model.space.map.graph, s)))
+    d = Int(rand(abmrng(model), all_neighbors(abmspace(model).map.graph, s)))
     dist = rand(abmrng(model)) * road_length(s, d, model)
     return (s, d, dist)
 end
@@ -241,7 +241,7 @@ function Agents.plan_route!(
         kwargs...
     ) where {A<:AbstractAgent}
 
-    delete!(model.space.routes, agent.id) # clear old route
+    delete!(abmspace(model).routes, agent.id) # clear old route
     same_position(agent.pos, dest, model) && return true
 
     if same_road(agent.pos, dest)
@@ -252,7 +252,7 @@ function Agents.plan_route!(
             move_agent!(agent, get_reverse_direction(agent.pos, model), model)
             dest = get_reverse_direction(dest, model)
         end
-        model.space.routes[agent.id] = OpenStreetMapPath(
+        abmspace(model).routes[agent.id] = OpenStreetMapPath(
             Int[],
             agent.pos,
             dest,
@@ -270,7 +270,7 @@ function Agents.plan_route!(
         if agent.pos[1] == agent.pos[2] # start at node
             end_node == dest[2] && (dest = get_reverse_direction(dest, model))
             move_agent!(agent, (dest[1], dest[2], 0.0), model)
-            model.space.routes[agent.id] = OpenStreetMapPath(
+            abmspace(model).routes[agent.id] = OpenStreetMapPath(
                 Int[],
                 agent.pos,
                 dest,
@@ -282,7 +282,7 @@ function Agents.plan_route!(
         if dest[1] == dest[2] # end at node
             start_node == agent.pos[1] && move_agent!(agent, get_reverse_direction(agent.pos, model), model)
             dest = (agent.pos[1], agent.pos[2], road_length(agent.pos, model))
-            model.space.routes[agent.id] = OpenStreetMapPath(
+            abmspace(model).routes[agent.id] = OpenStreetMapPath(
                 Int[],
                 agent.pos,
                 dest,
@@ -296,7 +296,7 @@ function Agents.plan_route!(
             move_agent!(agent, get_reverse_direction(agent.pos, model), model)
         end_node == dest[2] &&
             (dest = get_reverse_direction(dest, model))
-        model.space.routes[agent.id] = OpenStreetMapPath(
+        abmspace(model).routes[agent.id] = OpenStreetMapPath(
             Int[start_node],
             agent.pos,
             dest,
@@ -307,16 +307,16 @@ function Agents.plan_route!(
     end
 
     route = shortest_path(
-        model.space.map,
-        model.space.map.index_to_node[start_node],
-        model.space.map.index_to_node[end_node];
+        abmspace(model).map,
+        abmspace(model).map.index_to_node[start_node],
+        abmspace(model).map.index_to_node[end_node];
         kwargs...
     )
 
     isnothing(route) && return false
 
     for i in 1:length(route)
-        route[i] = Int(model.space.map.node_to_index[route[i]])
+        route[i] = Int(abmspace(model).map.node_to_index[route[i]])
     end
 
     reverse!(route)
@@ -336,16 +336,16 @@ function Agents.plan_route!(
     return_route = Int[]
     if return_trip
         return_route = shortest_path(
-            model.space.map,
-            model.space.map.index_to_node[end_node],
-            model.space.map.index_to_node[start_node];
+            abmspace(model).map,
+            abmspace(model).map.index_to_node[end_node],
+            abmspace(model).map.index_to_node[start_node];
             kwargs...
         )
 
         isnothing(return_route) && return false
 
         for i in 1:length(return_route)
-            return_route[i] = Int(model.space.map.node_to_index[return_route[i]])
+            return_route[i] = Int(abmspace(model).map.node_to_index[return_route[i]])
         end
 
         reverse!(return_route)
@@ -358,7 +358,7 @@ function Agents.plan_route!(
         end
     end
 
-    model.space.routes[agent.id] = OpenStreetMapPath(
+    abmspace(model).routes[agent.id] = OpenStreetMapPath(
         route,
         agent.pos,
         dest,
@@ -422,16 +422,16 @@ function distance(
 
     # get route
     route = shortest_path(
-        model.space.map,
-        model.space.map.index_to_node[st_node],
-        model.space.map.index_to_node[en_node];
+        abmspace(model).map,
+        abmspace(model).map.index_to_node[st_node],
+        abmspace(model).map.index_to_node[en_node];
         kwargs...
     )
     # return infinite distance if a connection doesn't exist
     isnothing(route) && return Inf
 
     # distance along route
-    dist = sum(weights_from_path(model.space.map, route))
+    dist = sum(weights_from_path(abmspace(model).map, route))
 
     # cases where starting or ending position is partway along a road
     # route may or may not pass through that road, so all cases need to be handled
@@ -496,7 +496,7 @@ end
 Return `(longitude, latitude)` of current road or intersection position.
 """
 lonlat(pos::Int, model::ABM{<:OpenStreetMapSpace}) =
-    Tuple(reverse(model.space.map.node_coordinates[pos]))
+    Tuple(reverse(abmspace(model).map.node_coordinates[pos]))
 
 function lonlat(pos::Tuple{Int,Int,Float64}, model::ABM{<:OpenStreetMapSpace})
     # extra checks to ensure consistency between both versions of `lonlat`
@@ -518,7 +518,7 @@ lonlat(agent::A, model::ABM{<:OpenStreetMapSpace,A}) where {A<:AbstractAgent} =
     lonlat(agent.pos, model)
 
 latlon(pos::Int, model::ABM{<:OpenStreetMapSpace}) =
-    Tuple(model.space.map.node_coordinates[pos])
+    Tuple(abmspace(model).map.node_coordinates[pos])
 latlon(pos::Tuple{Int,Int,Float64}, model::ABM{<:OpenStreetMapSpace}) =
     reverse(lonlat(pos, model))
 latlon(agent::A, model::ABM{<:OpenStreetMapSpace,A}) where {A<:AbstractAgent} =
@@ -532,9 +532,9 @@ Quicker, but less precise than [`OSM.nearest_road`](@ref).
 """
 function nearest_node(ll::Tuple{Float64,Float64}, model::ABM{<:OpenStreetMapSpace})
     ll = reverse(ll)
-    nearest_node_id = LightOSM.nearest_node(model.space.map,
+    nearest_node_id = LightOSM.nearest_node(abmspace(model).map,
         [GeoLocation(ll..., 0.0)])[1][1][1]
-    vert = Int(model.space.map.node_to_index[nearest_node_id])
+    vert = Int(abmspace(model).map.node_to_index[nearest_node_id])
     return (vert, vert, 0.0)
 end
 
@@ -547,15 +547,15 @@ precise than [`OSM.nearest_node`](@ref).
 function nearest_road(ll::Tuple{Float64,Float64}, model::ABM{<:OpenStreetMapSpace})
     geoloc = GeoLocation(ll[2], ll[1], 0.0)
     
-    _, _, closest_point = LightOSM.nearest_way(model.space.map, geoloc)
+    _, _, closest_point = LightOSM.nearest_way(abmspace(model).map, geoloc)
     # NOTE: This should never happen, see:
     # https://github.com/DeloitteDigitalAPAC/LightOSM.jl/blob/42b0acf63563c041d656f2954038d16c05dde79a/src/nearest_way.jl#L32
     # As long as there are no isolated nodes (not on a way) this will always find
     # a result
     isnothing(closest_point) && return nothing
     
-    start_index = Int(model.space.map.node_to_index[closest_point.n1])
-    end_index = Int(model.space.map.node_to_index[closest_point.n2])
+    start_index = Int(abmspace(model).map.node_to_index[closest_point.n1])
+    end_index = Int(abmspace(model).map.node_to_index[closest_point.n2])
     road_len = road_length((start_index, end_index, 0.0), model)
     position = closest_point.pos * road_len
     return (start_index, end_index, position)
@@ -575,15 +575,15 @@ road_length(pos::Tuple{Int,Int,Float64}, model::ABM{<:OpenStreetMapSpace}) =
     road_length(pos[1], pos[2], model)
 function road_length(p1::Int, p2::Int, model::ABM{<:OpenStreetMapSpace})
     p1 == p2 && return 0.0
-    len = model.space.map.weights[p1, p2]
+    len = abmspace(model).map.weights[p1, p2]
     if len == 0.0 || len == Inf
-        len = model.space.map.weights[p2, p1]
+        len = abmspace(model).map.weights[p2, p1]
     end
     return len
 end
 
 function Agents.is_stationary(agent::A, model::ABM{<:OpenStreetMapSpace, A}) where {A}
-    return !haskey(model.space.routes, agent.id)
+    return !haskey(abmspace(model).routes, agent.id)
 end
 
 """
@@ -596,7 +596,7 @@ function route_length(agent::A, model::ABM{<:OpenStreetMapSpace, A}) where {A}
     is_stationary(agent, model) && return 0.0
     prev_node, next_node = agent.pos
     length = road_length(prev_node, next_node, model)
-    for node in reverse(model.space.routes[agent.id].route)
+    for node in reverse(abmspace(model).routes[agent.id].route)
         prev_node = next_node
         next_node = node
         length += road_length(prev_node, next_node, model)
@@ -613,7 +613,7 @@ end
 Return `GeoLocation` corresponding to node `pos`.
 """
 get_geoloc(pos::Int, model::ABM{<:OpenStreetMapSpace}) =
-    GeoLocation(model.space.map.node_coordinates[pos]..., 0.0)
+    GeoLocation(abmspace(model).map.node_coordinates[pos]..., 0.0)
 
 """
     OSM.get_reverse_direction(pos::Tuple{Int,Int,Float64}, model::ABM{<:OpenStreetMapSpace})
@@ -722,7 +722,7 @@ function Agents.add_agent_to_space!(
         agent::A,
         model::ABM{<:OpenStreetMapSpace,A},
     ) where {A<:AbstractAgent}
-    push!(model.space.s[agent.pos[1]], agent.id)
+    push!(abmspace(model).s[agent.pos[1]], agent.id)
     return agent
 end
 
@@ -730,7 +730,7 @@ function Agents.remove_agent_from_space!(
         agent::A,
         model::ABM{<:OpenStreetMapSpace,A},
     ) where {A<:AbstractAgent}
-    prev = model.space.s[agent.pos[1]]
+    prev = abmspace(model).s[agent.pos[1]]
     ai = findfirst(i -> i == agent.id, prev)
     deleteat!(prev, ai)
     return agent
@@ -775,7 +775,7 @@ function Agents.move_along_route!(
     # It might be easier to formulate this as a recursive structure, so recursive calls are annotated where necessary
     # instead of the loop this currently runs in. These annotations are marked with `##` just to make it clear.
 
-    osmpath = model.space.routes[agent.id]
+    osmpath = abmspace(model).routes[agent.id]
     while distance > 0.0
         # check if reached end
         if same_position(agent.pos, osmpath.dest, model)
@@ -787,7 +787,7 @@ function Agents.move_along_route!(
                 elseif osmpath.return_route[end] == agent.pos[1]
                     move_agent!(agent, get_reverse_direction(agent.pos, model), model)
                 end
-                osmpath = model.space.routes[agent.id] = OpenStreetMapPath(
+                osmpath = abmspace(model).routes[agent.id] = OpenStreetMapPath(
                     osmpath.return_route,
                     agent.pos,
                     osmpath.start,
@@ -797,7 +797,7 @@ function Agents.move_along_route!(
                 continue
             end
 
-            delete!(model.space.routes, agent.id)
+            delete!(abmspace(model).routes, agent.id)
             break
         end
 
@@ -954,7 +954,7 @@ function Agents.nearby_ids(
 end
 
 forward_ids_on_road(pos_1::Int, pos_2::Int, model::ABM{<:OpenStreetMapSpace}) =
-    Iterators.filter(i -> model[i].pos[2] == pos_2, model.space.s[pos_1])
+    Iterators.filter(i -> model[i].pos[2] == pos_2, abmspace(model).s[pos_1])
 
 reverse_ids_on_road(pos_1::Int, pos_2::Int, model::ABM{<:OpenStreetMapSpace}) =
     forward_ids_on_road(pos_2, pos_1, model)
@@ -993,7 +993,7 @@ function Agents.nearby_positions(
     else
         Graphs.all_neighbors
     end
-    Int.(neighborfn(model.space.map.graph, position))
+    Int.(neighborfn(abmspace(model).map.graph, position))
 end
 
 # Deprecations

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -180,12 +180,12 @@ returns a location somewhere on a road heading in a random direction.
 """
 function random_road_position(model::ABM{<:OpenStreetMapSpace})
     # pick a random source and destination, and then a random distance on that edge
-    s = Int(rand(model.rng, 1:Agents.nv(model)))
+    s = Int(rand(abmrng(model), 1:Agents.nv(model)))
     if isempty(all_neighbors(model.space.map.graph, s))
         return (s, s, 0.0)
     end
-    d = Int(rand(model.rng, all_neighbors(model.space.map.graph, s)))
-    dist = rand(model.rng) * road_length(s, d, model)
+    d = Int(rand(abmrng(model), all_neighbors(model.space.map.graph, s)))
+    dist = rand(abmrng(model)) * road_length(s, d, model)
     return (s, d, dist)
 end
 
@@ -714,7 +714,7 @@ end
 # Agents.jl space API
 #######################################################################################
 function Agents.random_position(model::ABM{<:OpenStreetMapSpace})
-    vert = Int(rand(model.rng, 1:Agents.nv(model)))
+    vert = Int(rand(abmrng(model), 1:Agents.nv(model)))
     return (vert, vert, 0.0)
 end
 

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -22,9 +22,9 @@ sense: currently `AbstractGridSpace` and `ContinuousSpace`.
 Example usage in the [Flocking model](@ref).
 """
 euclidean_distance(a::A, b::B, model::ABM,
-) where {A <: AbstractAgent,B <: AbstractAgent} = euclidean_distance(a.pos, b.pos, model.space)
+) where {A <: AbstractAgent,B <: AbstractAgent} = euclidean_distance(a.pos, b.pos, abmspace(model))
 
-euclidean_distance(p1, p2, model::ABM) = euclidean_distance(p1, p2, model.space)
+euclidean_distance(p1, p2, model::ABM) = euclidean_distance(p1, p2, abmspace(model))
 
 function euclidean_distance(
     p1::ValidPos,
@@ -51,9 +51,9 @@ respecting periodic boundary conditions (if in use). Works with any space where 
 sense: currently `AbstractGridSpace` and `ContinuousSpace`.
 """
 manhattan_distance(a::A, b::B, model::ABM
-) where {A <: AbstractAgent,B <: AbstractAgent} = manhattan_distance(a.pos, b.pos, model.space)
+) where {A <: AbstractAgent,B <: AbstractAgent} = manhattan_distance(a.pos, b.pos, abmspace(model))
 
-manhattan_distance(p1, p2, model::ABM) = manhattan_distance(p1, p2, model.space)
+manhattan_distance(p1, p2, model::ABM) = manhattan_distance(p1, p2, abmspace(model))
 
 function manhattan_distance(
     p1::ValidPos,
@@ -77,7 +77,7 @@ end
 Return the direction vector from the position `from` to position `to` taking into account
 periodicity of the space.
 """
-get_direction(from, to, model::ABM) = get_direction(from, to, model.space)
+get_direction(from, to, model::ABM) = get_direction(from, to, abmspace(model))
 
 function get_direction(
     from::ValidPos,

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -151,12 +151,12 @@ end
 
 function random_walkable(model::ABM{<:ContinuousSpace{D}}, pathfinder::AStar{D}) where {D}
     discrete_pos = Tuple(rand(
-        model.rng,
+        abmrng(model),
         filter(x -> pathfinder.walkmap[x], CartesianIndices(pathfinder.walkmap))
     ))
     half_cell_size = model.space.extent ./ size(pathfinder.walkmap) ./ 2.
     return to_continuous_position(discrete_pos, pathfinder) .+
-        Tuple(rand(model.rng, D) .- 0.5) .* half_cell_size
+        Tuple(rand(abmrng(model), D) .- 0.5) .* half_cell_size
 end
 
 walkable_cells_in_radius(pos, r, pathfinder::AStar{D,false}) where {D} =
@@ -192,12 +192,12 @@ function random_walkable(
     options = collect(walkable_cells_in_radius(discrete_pos, discrete_r, pathfinder))
     isempty(options) && return pos
     discrete_rand = rand(
-        model.rng,
+        abmrng(model),
         options
     )
     half_cell_size = model.space.extent ./ size(pathfinder.walkmap) ./ 2.
     cts_rand = to_continuous_position(discrete_rand, pathfinder) .+
-        Tuple(rand(model.rng, D) .- 0.5) .* half_cell_size
+        Tuple(rand(abmrng(model), D) .- 0.5) .* half_cell_size
     dist = euclidean_distance(pos, cts_rand, model)
     dist > r && (cts_rand = mod1.(
         pos .+ get_direction(pos, cts_rand, model) ./ dist .* r,

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -154,7 +154,7 @@ function random_walkable(model::ABM{<:ContinuousSpace{D}}, pathfinder::AStar{D})
         abmrng(model),
         filter(x -> pathfinder.walkmap[x], CartesianIndices(pathfinder.walkmap))
     ))
-    half_cell_size = model.space.extent ./ size(pathfinder.walkmap) ./ 2.
+    half_cell_size = abmspace(model).extent ./ size(pathfinder.walkmap) ./ 2.
     return to_continuous_position(discrete_pos, pathfinder) .+
         Tuple(rand(abmrng(model), D) .- 0.5) .* half_cell_size
 end
@@ -195,13 +195,13 @@ function random_walkable(
         abmrng(model),
         options
     )
-    half_cell_size = model.space.extent ./ size(pathfinder.walkmap) ./ 2.
+    half_cell_size = abmspace(model).extent ./ size(pathfinder.walkmap) ./ 2.
     cts_rand = to_continuous_position(discrete_rand, pathfinder) .+
         Tuple(rand(abmrng(model), D) .- 0.5) .* half_cell_size
     dist = euclidean_distance(pos, cts_rand, model)
     dist > r && (cts_rand = mod1.(
         pos .+ get_direction(pos, cts_rand, model) ./ dist .* r,
-        model.space.extent
+        abmspace(model).extent
     ))
     return cts_rand
 end

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -85,6 +85,6 @@ Return a random position in the given `model` that is walkable as specified by t
 """
 function random_walkable(model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}) where {D}
     return Tuple(rand(abmrng(model),
-        filter(x -> pathfinder.walkmap[x], CartesianIndices(model.space.stored_ids))
+        filter(x -> pathfinder.walkmap[x], CartesianIndices(abmspace(model).stored_ids))
     ))
 end

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -84,7 +84,7 @@ Return a random position in the given `model` that is walkable as specified by t
 `pathfinder`.
 """
 function random_walkable(model::ABM{<:GridSpace{D}}, pathfinder::AStar{D}) where {D}
-    return Tuple(rand(model.rng,
+    return Tuple(rand(abmrng(model),
         filter(x -> pathfinder.walkmap[x], CartesianIndices(model.space.stored_ids))
     ))
 end

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -94,7 +94,7 @@ A scheduler that activates all agents once per step in a random order.
 Different random ordering is used at each different step.
 """
 function randomly(model::ABM)
-    order = shuffle!(model.rng, collect(allids(model)))
+    order = shuffle!(abmrng(model), collect(allids(model)))
 end
 
 struct Randomly
@@ -109,7 +109,7 @@ Different random ordering is used at each different step.
 Randomly() = Randomly(Int[])
 function (sched::Randomly)(model::ABM)
     get_ids!(sched.ids, model)
-    shuffle!(model.rng, sched.ids)
+    shuffle!(abmrng(model), sched.ids)
 end
 
 """
@@ -119,7 +119,7 @@ A scheduler that at each step activates only `p` percentage of randomly chosen a
 function partially(p::Real)
     function partial(model::ABM)
         ids = collect(allids(model))
-        return randsubseq(model.rng, ids, p)
+        return randsubseq(abmrng(model), ids, p)
     end
     return partial
 end
@@ -139,7 +139,7 @@ Partially(p::R) where {R<:Real} = Partially{R}(p, Int[], Int[])
 
 function (sched::Partially)(model::ABM)
     get_ids!(sched.all_ids, model)
-    randsubseq!(model.rng, sched.schedule, sched.all_ids, sched.p)
+    randsubseq!(abmrng(model), sched.schedule, sched.all_ids, sched.p)
 end
 
 """
@@ -204,10 +204,10 @@ function by_type(shuffle_types::Bool, shuffle_agents::Bool)
             idx = findfirst(t -> t == typeof(agent), types)
             push!(sets[idx], agent.id)
         end
-        shuffle_types && shuffle!(model.rng, sets)
+        shuffle_types && shuffle!(abmrng(model), sets)
         if shuffle_agents
             for set in sets
-                shuffle!(model.rng, set)
+                shuffle!(abmrng(model), set)
             end
         end
         vcat(sets...)
@@ -233,7 +233,7 @@ function by_type(order::Tuple{Type,Vararg{Type}}, shuffle_agents::Bool)
         end
         if shuffle_agents
             for set in sets
-                shuffle!(model.rng, set)
+                shuffle!(abmrng(model), set)
             end
         end
         vcat(sets...)
@@ -290,11 +290,11 @@ function (sched::ByType)(model::ABM)
         push!(sched.ids[sched.type_inds[typeof(agent)]], agent.id)
     end
 
-    sched.shuffle_types && shuffle!(model.rng, sched.ids)
+    sched.shuffle_types && shuffle!(abmrng(model), sched.ids)
 
     if sched.shuffle_agents
         for i in 1:length(sched.ids)
-            shuffle!(model.rng, sched.ids[i])
+            shuffle!(abmrng(model), sched.ids[i])
         end
     end
 

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -39,7 +39,7 @@ end
     agent = add_agent!(model, 5.3)
     init_pos = agent.pos
     # Checking specific indexing
-    move_agent!(agent, rand(model.rng, [i for i in 1:6 if i != init_pos]), model)
+    move_agent!(agent, rand(abmrng(model), [i for i in 1:6 if i != init_pos]), model)
     new_pos = agent.pos
     @test new_pos != init_pos
     # Checking a random move
@@ -226,7 +226,7 @@ end
     for bool in (true, false)
         model = ABM(Agent2; properties = Dict(:count => 0))
         for i in 1:100
-            add_agent!(model, rand(model.rng))
+            add_agent!(model, rand(abmrng(model)))
         end
         step!(model, agent_step!, model_step!, 1, bool)
         if bool

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -726,7 +726,7 @@ end
         fill_space!(abm, _ -> rand(abm.rng, 1:1000))
         abm
     end
-    as!(agent, model) = (agent.p = rand(model.rng, 1:1000))
+    as!(agent, model) = (agent.p = rand(abmrng(model), 1:1000))
     seeds = [1234, 563, 211]
     adata = [(:p, sum)]
     adf, _ = ensemblerun!(fake_model, as!, dummystep, 2; adata, seeds)

--- a/test/continuous_space_tests.jl
+++ b/test/continuous_space_tests.jl
@@ -224,7 +224,7 @@ using LinearAlgebra: norm, dot
     @testset "walk" begin
         # ContinuousSpace
         model = ABM(SpeedyContinuousAgent, ContinuousSpace((12, 10); periodic = false))
-        a = add_agent!((0.0, 0.0), model, (0.0, 0.0), rand(model.rng))
+        a = add_agent!((0.0, 0.0), model, (0.0, 0.0), rand(abmrng(model)))
         walk!(a, (1.0, 1.0), model)
         @test a.pos == (1.0, 1.0)
         walk!(a, (15.0, 1.0), model)
@@ -268,7 +268,7 @@ using LinearAlgebra: norm, dot
             for i in 1:10, j in 1:10
                     pos = (i/10, j/10)
                 if i > 5
-                    vel = sincos(2π*rand(model.rng)) .* speed
+                    vel = sincos(2π*rand(abmrng(model))) .* speed
                     mass = 1.33
                 else
                     # these agents have infinite mass and 0 velocity. They are fixed.
@@ -286,7 +286,7 @@ using LinearAlgebra: norm, dot
             for (a1, a2) in ipairs
                 e = elastic_collision!(a1, a2, :mass)
                 if e
-                    model.properties[:c] += 1
+                    abmproperties(model)[:c] += 1
                 end
             end
         end

--- a/test/csv_tests.jl
+++ b/test/csv_tests.jl
@@ -9,7 +9,7 @@
     function hk(; numagents = 100, ϵ = 0.2)
         model = ABM(HKAgent, scheduler = Schedulers.fastest, properties = Dict(:ϵ => ϵ))
         for i in 1:numagents
-            o = rand(model.rng)
+            o = rand(abmrng(model))
             add_agent!(model, o, o, -1)
         end
         return model

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -335,7 +335,7 @@ using StableRNGs
         model = ABM(GridAgent{2}, space)
         add_agent!(model)
         r = 1.0
-        @test_throws ArgumentError randomwalk!(model.agents[1], model, r)
+        @test_throws ArgumentError randomwalk!(model[1], model, r)
 
         # chebyshev metric
         space = SpaceType((100,100), metric=:chebyshev)
@@ -343,14 +343,14 @@ using StableRNGs
         x₀ = (50,50)
         add_agent!(x₀, model)
         r = 1.5
-        randomwalk!(model.agents[1], model, r)
-        x₁ = model.agents[1].pos
+        randomwalk!(model[1], model, r)
+        x₁ = model[1].pos
         # chebyshev distance after the random step should be 1
         @test maximum(abs.(x₁ .- x₀)) == 1
         # for r < 1 the agent should not move
         r = 0.5
-        randomwalk!(model.agents[1], model, r)
-        @test model.agents[1].pos == x₁
+        randomwalk!(model[1], model, r)
+        @test model[1].pos == x₁
 
         # manhattan metric
         space = SpaceType((100,100), metric=:manhattan)
@@ -358,14 +358,14 @@ using StableRNGs
         x₀ = (50,50)
         add_agent!(x₀, model)
         r = 1.5
-        randomwalk!(model.agents[1], model, r)
-        x₁ = model.agents[1].pos
+        randomwalk!(model[1], model, r)
+        x₁ = model[1].pos
         # manhattan distance after the random step should be 1
         @test manhattan_distance(x₁, x₀, model) == 1
         # for r < 1 the agent should not move
         r = 0.5
-        randomwalk!(model.agents[1], model, r)
-        @test model.agents[1].pos == x₁
+        randomwalk!(model[1], model, r)
+        @test model[1].pos == x₁
 
         space = SpaceType((100,100), metric=:manhattan)
         model = ABM(GridAgent{2}, space)
@@ -376,28 +376,28 @@ using StableRNGs
         for β in offsets; add_agent!(pos.+β, model); end
         if SpaceType == GridSpaceSingle
             # agent 1 should not move since there are no available offsets
-            randomwalk!(model.agents[1], model, 1)
-            @test model.agents[1].pos == pos
+            randomwalk!(model[1], model, 1)
+            @test model[1].pos == pos
             # the keyword ifempty should have no effect in a GridSpaceSingle
-            randomwalk!(model.agents[1], model, 1; ifempty=false)
-            @test model.agents[1].pos == pos
-            randomwalk!(model.agents[1], model, 1; ifempty=true)
-            @test model.agents[1].pos == pos
+            randomwalk!(model[1], model, 1; ifempty=false)
+            @test model[1].pos == pos
+            randomwalk!(model[1], model, 1; ifempty=true)
+            @test model[1].pos == pos
         elseif SpaceType == GridSpace
             # if ifempty=true (default), agent 1 should not move since there are
             # no available offsets
-            randomwalk!(model.agents[1], model, 1)
-            @test model.agents[1].pos == pos
+            randomwalk!(model[1], model, 1)
+            @test model[1].pos == pos
             # if ifempty=false, agent 1 will move and occupy
             # the same position as one of the other agents
-            randomwalk!(model.agents[1], model, 1; ifempty=false)
-            @test model.agents[1].pos ≠ pos
+            randomwalk!(model[1], model, 1; ifempty=false)
+            @test model[1].pos ≠ pos
             # 5 agents but only 4 unique positions
-            unique_pos = unique([a.second.pos for a in model.agents])
-            @test (length(model.agents)==5) && length(unique_pos)==4
-            move_agent!(model.agents[1], pos, model)
+            unique_pos = unique([a.pos for a in allagents(model)])
+            @test (nagents(model)==5) && length(unique_pos)==4
+            move_agent!(model[1], pos, model)
         end
-        agent_1, agent_2 = model.agents[1], model.agents[2]
+        agent_1, agent_2 = model[1], model[2]
         # agent 1 can't move to surronding cells since none is empty
         randomwalk!(agent_1, model, 1; force_motion=true)
         @test agent_1.pos == (50,50)

--- a/test/jld2_tests.jl
+++ b/test/jld2_tests.jl
@@ -68,8 +68,8 @@
         # model data
         test_model_data(model, other)
         # space data
-        @test typeof(model.space) == typeof(other.space)    # to check periodicity
-        test_space(model.space, other.space)
+        @test typeof(abmspace(model)) == typeof(other.space)    # to check periodicity
+        test_space(abmspace(model), other.space)
         # pathfinder data
         test_astar(model.pathfinder, other.pathfinder)
     end
@@ -116,8 +116,8 @@
             # model data
             test_model_data(model, other)
             # space data
-            @test typeof(model.space) == typeof(other.space)    # to check periodicity
-            test_space(model.space, other.space)
+            @test typeof(abmspace(model)) == typeof(other.space)    # to check periodicity
+            test_space(abmspace(model), other.space)
 
             rm("test.jld2")
         end
@@ -139,8 +139,8 @@
             # model data
             test_model_data(model, other)
             # space data
-            @test typeof(model.space) == typeof(other.space)    # to check periodicity
-            test_space(model.space, other.space)
+            @test typeof(abmspace(model)) == typeof(other.space)    # to check periodicity
+            test_space(abmspace(model), other.space)
 
             rm("test.jld2")
         end
@@ -181,10 +181,10 @@
         # model data
         test_model_data(model, other)
         # space data
-        @test model.space.graph == other.space.graph
-        @test length(model.space.stored_ids) == length(other.space.stored_ids)
-        @test all(length(model.space.stored_ids[pos]) == length(other.space.stored_ids[pos]) for pos in eachindex(model.space.stored_ids))
-        @test all(all(x in other.space.stored_ids[pos] for x in model.space.stored_ids[pos]) for pos in eachindex(model.space.stored_ids))
+        @test abmspace(model).graph == other.space.graph
+        @test length(abmspace(model).stored_ids) == length(other.space.stored_ids)
+        @test all(length(abmspace(model).stored_ids[pos]) == length(other.space.stored_ids[pos]) for pos in eachindex(abmspace(model).stored_ids))
+        @test all(all(x in other.space.stored_ids[pos] for x in abmspace(model).stored_ids[pos]) for pos in eachindex(abmspace(model).stored_ids))
 
         rm("test.jld2")
     end
@@ -285,7 +285,7 @@
         # model data
         test_model_data(model, other)
         # space data
-        test_space(model.space, other.space)
+        test_space(abmspace(model), other.space)
 
         rm("test.jld2")
     end
@@ -320,12 +320,12 @@
         @test all(model[i].infected == other[i].infected for i in allids(model))
         # model data
         test_model_data(model, other)
-        @test sort(collect(keys(model.space.routes))) == sort(collect(keys(other.space.routes)))
-        @test all(model.space.routes[i].route == other.space.routes[i].route for i in keys(model.space.routes))
-        @test all(model.space.routes[i].start == other.space.routes[i].start for i in keys(model.space.routes))
-        @test all(model.space.routes[i].dest == other.space.routes[i].dest for i in keys(model.space.routes))
-        @test all(model.space.routes[i].return_route == other.space.routes[i].return_route for i in keys(model.space.routes))
-        @test all(model.space.routes[i].has_to_return == other.space.routes[i].has_to_return for i in keys(model.space.routes))
+        @test sort(collect(keys(abmspace(model).routes))) == sort(collect(keys(other.space.routes)))
+        @test all(abmspace(model).routes[i].route == other.space.routes[i].route for i in keys(abmspace(model).routes))
+        @test all(abmspace(model).routes[i].start == other.space.routes[i].start for i in keys(abmspace(model).routes))
+        @test all(abmspace(model).routes[i].dest == other.space.routes[i].dest for i in keys(abmspace(model).routes))
+        @test all(abmspace(model).routes[i].return_route == other.space.routes[i].return_route for i in keys(abmspace(model).routes))
+        @test all(abmspace(model).routes[i].has_to_return == other.space.routes[i].has_to_return for i in keys(abmspace(model).routes))
 
         rm("test.jld2")
     end

--- a/test/jld2_tests.jl
+++ b/test/jld2_tests.jl
@@ -4,8 +4,8 @@
 @testset "JLD2" begin
 
     function test_model_data(model, other)
-        @test (model.scheduler isa Function && model.scheduler == other.scheduler) || (!isa(model.scheduler, Function) && typeof(model.scheduler) == typeof(other.scheduler))
-        @test model.rng == other.rng
+        @test (abmscheduler(model) isa Function && abmscheduler(model) == other.scheduler) || (!isa(abmscheduler(model), Function) && typeof(abmscheduler(model)) == typeof(other.scheduler))
+        @test abmrng(model) == other.rng
         @test model.maxid.x == other.maxid.x
     end
 
@@ -77,7 +77,7 @@
     @testset "No space" begin
         model = ABM(Agent2, nothing; properties = Dict(:abc => 123), rng = MersenneTwister(42))
         for i in 1:100
-            add_agent!(model, rand(model.rng))
+            add_agent!(model, rand(abmrng(model)))
         end
         AgentsIO.save_checkpoint("test.jld2", model)
         other = AgentsIO.load_checkpoint("test.jld2")
@@ -161,7 +161,7 @@
         )
 
         for i in 1:30
-            add_agent_pos!(Agent7(i, i % 10 + 1, rand(model.rng) < 0.5, rand(model.rng, Int)), model)
+            add_agent_pos!(Agent7(i, i % 10 + 1, rand(abmrng(model)) < 0.5, rand(abmrng(model), Int)), model)
         end
 
         AgentsIO.save_checkpoint("test.jld2", model)

--- a/test/model_access.jl
+++ b/test/model_access.jl
@@ -68,7 +68,7 @@ end
     model = ABM(Agent3, GridSpace((5,5)))
     @test Agents.agenttype(model) == Agent3
     @test Agents.spacetype(model) <: GridSpace
-    @test size(model.space) == (5,5)
+    @test size(abmspace(model)) == (5,5)
     @test all(isempty(p, model) for p in positions(model))
 end
 

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -51,7 +51,7 @@ end
     @testset "Route planning" begin
         add_agent!(start_road, model)
         plan_route!(model[1], finish_road, model)
-        @test length(model.space.routes[1].route) == 85
+        @test length(abmspace(model).routes[1].route) == 85
 
         add_agent!(finish_intersection, model)
 
@@ -72,26 +72,26 @@ end
     @testset "Moving along routes" begin
         move_agent!(model[1], (start_road[2], start_road[2], 0.0), model)
         plan_route!(model[1], finish_road[1], model)
-        @test length(model.space.routes[1].route) == 95
+        @test length(abmspace(model).routes[1].route) == 95
 
         move_agent!(model[1], start_road, model)
         plan_route!(model[1], finish_road[1], model)
-        @test length(model.space.routes[1].route) == 86
+        @test length(abmspace(model).routes[1].route) == 86
 
         move_agent!(model[1], (start_road[2], start_road[2], 0.0), model)
         plan_route!(model[1], finish_road, model)
-        @test length(model.space.routes[1].route) == 94
+        @test length(abmspace(model).routes[1].route) == 94
 
         move_agent!(model[2], start_road, model)
         plan_route!(model[2], finish_road[1], model)
-        @test model.space.routes[1].route != model.space.routes[2].route
+        @test abmspace(model).routes[1].route != abmspace(model).routes[2].route
 
         plan_route!(model[2], finish_road, model)
-        @test length(model.space.routes[2].route) == 85
+        @test length(abmspace(model).routes[2].route) == 85
 
         @test !is_stationary(model[1], model)
         move_along_route!(model[1], model, 0.01)
-        @test length(model.space.routes[1].route) == 62
+        @test length(abmspace(model).routes[1].route) == 62
         move_along_route!(model[1], model, 1500)
         @test is_stationary(model[1], model)
     end
@@ -124,7 +124,7 @@ end
 
     @testset "Distances, road/route lengths" begin
         pos_1 = start_intersection[1]
-        nbor = Int(outneighbors(model.space.map.graph, pos_1[1])[1])
+        nbor = Int(outneighbors(abmspace(model).map.graph, pos_1[1])[1])
         rl = OSM.road_length(pos_1, nbor, model)
         @test OSM.distance(pos_1, nbor, model) ≈ rl
         @test OSM.distance(pos_1, pos_1, model) == 0.
@@ -133,10 +133,10 @@ end
         move_agent!(model[1], (pos_1, pos_1, 0.0), model)
         plan_route!(model[1], finish_intersection, model)
         len = sum(OSM.LightOSM.weights_from_path(
-            model.space.map,
-            reverse([model.space.map.index_to_node[i] for i in model.space.routes[1].route]),
+            abmspace(model).map,
+            reverse([abmspace(model).map.index_to_node[i] for i in abmspace(model).routes[1].route]),
         ))
-        len += OSM.road_length(pos_1, model.space.routes[1].route[end], model)
+        len += OSM.road_length(pos_1, abmspace(model).routes[1].route[end], model)
         @test OSM.distance(pos_1, finish_intersection, model) ≈ len
         @test OSM.route_length(model[1], model) ≈ len
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,7 +106,7 @@ function flocking_model(
     space2d = ContinuousSpace(extent; spacing)
     model = ModelType(Bird, space2d, scheduler = Schedulers.Randomly(), rng=StableRNG(10))
     for _ in 1:n_birds
-        vel = Tuple(rand(model.rng, 2) * 2 .- 1)
+        vel = Tuple(rand(abmrng(model), 2) * 2 .- 1)
         add_agent!(
             model,
             vel,

--- a/test/scheduler_tests.jl
+++ b/test/scheduler_tests.jl
@@ -9,7 +9,7 @@
         add_agent!(model)
     end
     @test sort!(collect(keys(model.agents))) == 1:N
-    @test model.scheduler(model) == 1:N
+    @test abmscheduler(model)(model) == 1:N
 
     # fastest
     Random.seed!(12)
@@ -17,7 +17,7 @@
     for i in 1:N
         add_agent!(model)
     end
-    @test sort!(collect(model.scheduler(model))) == 1:N
+    @test sort!(collect(abmscheduler(model)(model))) == 1:N
 
     # random
     model = ABM(Agent0; scheduler = Schedulers.randomly, rng = StableRNG(12))
@@ -25,7 +25,7 @@
         add_agent!(model)
     end
     fastest_order = collect(keys(model.agents))[1:3]
-    @test model.scheduler(model)[1:3] != fastest_order
+    @test abmscheduler(model)(model)[1:3] != fastest_order
 
     # partial
     model = ABM(Agent0; scheduler = Schedulers.partially(0.1), rng = StableRNG(12))
@@ -33,17 +33,17 @@
         add_agent!(model)
     end
 
-    a = model.scheduler(model)
+    a = abmscheduler(model)(model)
     @test length(a) <= N/10
 
     # by property
     model = ABM(Agent2; scheduler = Schedulers.by_property(:weight))
     for i in 1:N
-        add_agent!(model, rand(model.rng) / rand(model.rng))
+        add_agent!(model, rand(abmrng(model)) / rand(abmrng(model)))
     end
 
     Random.seed!(12)
-    a = model.scheduler(model)
+    a = abmscheduler(model)(model)
 
     ids = collect(keys(model.agents))
     properties = [model.agents[id].weight for id in ids]
@@ -93,17 +93,17 @@ end
 @testset "Mixed Scheduler" begin
     # standard scheduler
     model = init_mixed_model()
-    @test sort!(collect(model.scheduler(model))) == 1:12
+    @test sort!(collect(abmscheduler(model)(model))) == 1:12
 
     # shuffling types scheduler
     Random.seed!(12)
     model = init_mixed_model(scheduler = Schedulers.by_type(true, false))
-    s1 = model.scheduler(model)
-    s2 = model.scheduler(model)
+    s1 = abmscheduler(model)(model)
+    s2 = abmscheduler(model)(model)
     @test unique([typeof(model[id]) for id in s1]) != unique([typeof(model[id]) for id in s2])
-    @test count(model[id] isa Agent2 for id in model.scheduler(model)) == 3
+    @test count(model[id] isa Agent2 for id in abmscheduler(model)(model)) == 3
     c = begin
-        x = 0; s = model.scheduler(model)
+        x = 0; s = abmscheduler(model)(model)
         x += count(a -> a == Agent0, typeof(model[id]) for id in s)
         x += count(a -> a == Agent1, typeof(model[id]) for id in s)
         x += count(a -> a == Agent2, typeof(model[id]) for id in s)
@@ -114,15 +114,15 @@ end
     # NOT shuffling types scheduler
     Random.seed!(12)
     model = init_mixed_model(scheduler = Schedulers.by_type(false, false))
-    s1 = model.scheduler(model)
-    s2 = model.scheduler(model)
+    s1 = abmscheduler(model)(model)
+    s2 = abmscheduler(model)(model)
     @test unique([typeof(model[id]) for id in s1]) == unique([typeof(model[id]) for id in s2])
 
     # Not shuffling types, but shuffling agents
     Random.seed!(12)
     model = init_mixed_model(scheduler = Schedulers.by_type(false, true))
-    s1 = model.scheduler(model)
-    s2 = model.scheduler(model)
+    s1 = abmscheduler(model)(model)
+    s2 = abmscheduler(model)(model)
     @test [typeof(model[id]) for id in s1] == [typeof(model[id]) for id in s2]
     # here we actually check whether agents of same type are shuffled
     @test model[s1[1]].id ≠ model[s2[1]] || model[s1[2]].id ≠ model[s2[2]]
@@ -139,7 +139,7 @@ end
         a0 = Agent0(id)
         add_agent!(a0, model)
     end
-    s = model.scheduler(model)
+    s = abmscheduler(model)(model)
     @test [typeof(model[id]) for id in s] ==
           [Agent1, Agent1, Agent1, Agent0, Agent0, Agent0]
     @test all(x -> x < 4, s[1:3])
@@ -171,7 +171,7 @@ end
         add_agent!(model, w)
     end
     for i in 1:10
-        ids = sort!(collect(model.scheduler(model)))
+        ids = sort!(collect(abmscheduler(model)(model)))
         if i < 5
             @test ids == 1:10
         else
@@ -189,7 +189,7 @@ end
         add_agent!(model)
     end
     @test sort!(collect(keys(model.agents))) == 1:N
-    @test model.scheduler(model) == 1:N
+    @test abmscheduler(model)(model) == 1:N
 
     # random
     model = ABM(Agent0; scheduler = Schedulers.Randomly(), rng = StableRNG(12))
@@ -197,7 +197,7 @@ end
         add_agent!(model)
     end
     fastest_order = collect(keys(model.agents))[1:3]
-    @test model.scheduler(model)[1:3] != fastest_order
+    @test abmscheduler(model)(model)[1:3] != fastest_order
 
     # partial
     model = ABM(Agent0; scheduler = Schedulers.Partially(0.1), rng = StableRNG(12))
@@ -205,17 +205,17 @@ end
         add_agent!(model)
     end
 
-    a = model.scheduler(model)
+    a = abmscheduler(model)(model)
     @test length(a) <= N/10
 
     # by property
     model = ABM(Agent2; scheduler = Schedulers.ByProperty(:weight))
     for i in 1:N
-        add_agent!(model, rand(model.rng) / rand(model.rng))
+        add_agent!(model, rand(abmrng(model)) / rand(abmrng(model)))
     end
 
     Random.seed!(12)
-    a = collect(model.scheduler(model))
+    a = collect(abmscheduler(model)(model))
 
     ids = collect(keys(model.agents))
     properties = [model.agents[id].weight for id in ids]
@@ -252,19 +252,19 @@ end
 
     # standard scheduler
     model = init_mixed_model2()
-    @test sort!(collect(model.scheduler(model))) == 1:12
+    @test sort!(collect(abmscheduler(model)(model))) == 1:12
 
     # shuffling types scheduler
     Random.seed!(12)
     model = init_mixed_model2(scheduler = Schedulers.ByType(true, false, Union{Agent0,Agent1,Agent2,Agent3}))
-    s1 = model.scheduler(model)
+    s1 = abmscheduler(model)(model)
     s1_types = unique([typeof(model[x]) for x in s1])
-    s2 = model.scheduler(model)
+    s2 = abmscheduler(model)(model)
     s2_types = unique([typeof(model[x]) for x in s2])
     @test s1_types != s2_types
-    @test count(model[id] isa Agent2 for id in model.scheduler(model)) == 3
+    @test count(model[id] isa Agent2 for id in abmscheduler(model)(model)) == 3
     c = begin
-        x = 0; s = model.scheduler(model)
+        x = 0; s = abmscheduler(model)(model)
         x += count(a -> a == Agent0, typeof(model[id]) for id in s)
         x += count(a -> a == Agent1, typeof(model[id]) for id in s)
         x += count(a -> a == Agent2, typeof(model[id]) for id in s)
@@ -275,15 +275,15 @@ end
     # NOT shuffling types scheduler
     Random.seed!(12)
     model = init_mixed_model2(scheduler = Schedulers.ByType(false, false, Union{Agent0,Agent1,Agent2,Agent3}))
-    s1 = model.scheduler(model)
-    s2 = model.scheduler(model)
+    s1 = abmscheduler(model)(model)
+    s2 = abmscheduler(model)(model)
     @test unique([typeof(model[id]) for id in s1]) == unique([typeof(model[id]) for id in s2])
 
     # Not shuffling types, but shuffling agents
     Random.seed!(12)
     model = init_mixed_model2(scheduler = Schedulers.ByType(false, true, Union{Agent0,Agent1,Agent2,Agent3}))
-    s1 = collect(model.scheduler(model))
-    s2 = collect(model.scheduler(model))
+    s1 = collect(abmscheduler(model)(model))
+    s2 = collect(abmscheduler(model)(model))
     @test [typeof(model[id]) for id in s1] == [typeof(model[id]) for id in s2]
     # here we actually check whether agents of same type are shuffled
     @test model[s1[1]].id ≠ model[s2[1]] || model[s1[2]].id ≠ model[s2[2]]
@@ -300,7 +300,7 @@ end
         a0 = Agent0(id)
         add_agent!(a0, model)
     end
-    s = collect(model.scheduler(model))
+    s = collect(abmscheduler(model)(model))
     @test [typeof(model[id]) for id in s] ==
             [Agent1, Agent1, Agent1, Agent0, Agent0, Agent0]
     @test all(x -> x < 4, s[1:3])

--- a/test/scheduler_tests.jl
+++ b/test/scheduler_tests.jl
@@ -8,7 +8,7 @@
     for i in 1:N
         add_agent!(model)
     end
-    @test sort!(collect(keys(model.agents))) == 1:N
+    @test sort!(collect(allids(model))) == 1:N
     @test abmscheduler(model)(model) == 1:N
 
     # fastest
@@ -24,7 +24,7 @@
     for i in 1:N
         add_agent!(model)
     end
-    fastest_order = collect(keys(model.agents))[1:3]
+    fastest_order = collect(allids(model))[1:3]
     @test abmscheduler(model)(model)[1:3] != fastest_order
 
     # partial
@@ -45,8 +45,8 @@
     Random.seed!(12)
     a = abmscheduler(model)(model)
 
-    ids = collect(keys(model.agents))
-    properties = [model.agents[id].weight for id in ids]
+    ids = collect(allids(model))
+    properties = [model[id].weight for id in ids]
 
     @test ids[sortperm(properties)] == a
 end
@@ -154,7 +154,7 @@ end
     function (ms::MyScheduler)(model::ABM)
         ms.n += 1 # increment internal counter by 1 for each step
         if ms.n < 5
-            return keys(model.agents) # order doesn't matter in this case
+            return allids(model) # order doesn't matter in this case
         else
             ids = collect(allids(model))
             # filter all ids whose agents have `w` less than some amount
@@ -188,7 +188,7 @@ end
     for i in 1:N
         add_agent!(model)
     end
-    @test sort!(collect(keys(model.agents))) == 1:N
+    @test sort!(collect(allids(model))) == 1:N
     @test abmscheduler(model)(model) == 1:N
 
     # random
@@ -196,7 +196,7 @@ end
     for i in 1:N
         add_agent!(model)
     end
-    fastest_order = collect(keys(model.agents))[1:3]
+    fastest_order = collect(allids(model))[1:3]
     @test abmscheduler(model)(model)[1:3] != fastest_order
 
     # partial
@@ -217,8 +217,8 @@ end
     Random.seed!(12)
     a = collect(abmscheduler(model)(model))
 
-    ids = collect(keys(model.agents))
-    properties = [model.agents[id].weight for id in ids]
+    ids = collect(allids(model))
+    properties = [model[id].weight for id in ids]
 
     @test ids[sortperm(properties)] == a
 


### PR DESCRIPTION
This is part of a TODO described in the file `model_abstract.jl`.
This still needs to be done for `:space` and `:agents`. These are a bit more difficult since the methods to access them are not exported and I get some errors substituing `model.space` to `abmspace(model)` in `src`, don't know why at the moment. Also probably we should spare the `changelog` from the change

edit: everything works, I also exported `abmspace`