### PR TITLE
Fix model creation with ContinuousAgent{D}

### DIFF
--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -73,6 +73,11 @@ Breaking changes:
 - Agents in `ContinuousSpace` now require `SVector` for their `pos`
   and `vel` fields instead of `NTuple`.
   Using `NTuple`s in `ContinuousSpace` is now deprecated.
+- `ContinuousAgent{D}` is not a concrete type anymore.
+  The new interface requires two parameters `ContinuousAgent{D,T}`
+  where `T` is any `AbstractFloat` type.
+  If you want to use a type different from `Float64`, you will also
+  need to change the type of the `ContinuousSpace` extent accordingly.
 
 See the online documentation for more!
 """

--- a/src/core/model_concrete.jl
+++ b/src/core/model_concrete.jl
@@ -142,6 +142,9 @@ function agent_validator(
         (for example) to this function. You can also create an instance of your agent
         and pass it to this function. If you want to use `Union` types for mixed agent
         models, you can silence this warning.
+        If you are using `ContinuousAgent{D}` as agent type in version 6+, update
+        to the new two-parameter version `ContinuousAgent{D,Float64}` to obtain
+        the same behavior as previous Agents.jl versions.
         """
         for type in union_types(A)
             do_checks(type, space, warn)
@@ -188,7 +191,11 @@ function do_checks(::Type{A}, space::S, warn::Bool) where {A<:AbstractAgent, S<:
                 throw(ArgumentError("`vel` field in agent type must be of type `SVector{<:AbstractFloat}` when using ContinuousSpace."))
             end
             if eltype(space) != eltype(pos_type)
-                throw(ArgumentError("`pos` field in agent type must be of the same type of the `extent` field in ContinuousSpace."))
+                # extra condition for backward compatibility (#855)
+                # we don't want to throw an error if ContinuousAgent{D} is used with a Float64 space
+                if isnothing(match(r"ContinuousAgent{\d}", string(A))) || eltype(space) != Float64
+                    throw(ArgumentError("`pos` field in agent type must be of the same type of the `extent` field in ContinuousSpace."))
+                end
             end
         end
     end

--- a/test/model_creation_tests.jl
+++ b/test/model_creation_tests.jl
@@ -159,7 +159,10 @@ end
         seeing this warning because you gave `Agent` instead of `Agent{Float64}`
         (for example) to this function. You can also create an instance of your agent
         and pass it to this function. If you want to use `Union` types for mixed agent
-        models, you can silence this warning.\n"""
+        models, you can silence this warning.
+        If you are using `ContinuousAgent{D}` as agent type in version 6+, update
+        to the new two-parameter version `ContinuousAgent{D,Float64}` to obtain
+        the same behavior as previous Agents.jl versions.\n"""
     ) ABM(ParametricAgent, GridSpace((1, 1)))
     # Warning is suppressed if flag is set
     @test Agents.agenttype(ABM(ParametricAgent, GridSpace((1, 1)); warn = false)) <:
@@ -182,9 +185,28 @@ end
         seeing this warning because you gave `Agent` instead of `Agent{Float64}`
         (for example) to this function. You can also create an instance of your agent
         and pass it to this function. If you want to use `Union` types for mixed agent
-        models, you can silence this warning.\n"""
+        models, you can silence this warning.
+        If you are using `ContinuousAgent{D}` as agent type in version 6+, update
+        to the new two-parameter version `ContinuousAgent{D,Float64}` to obtain
+        the same behavior as previous Agents.jl versions.\n"""
     ) ABM(Union{NoSpaceAgent,ValidAgent})
     @test_throws ArgumentError ABM(Union{NoSpaceAgent,BadAgent}; warn = false)
+
+    # this should work for backward compatibility but throw warning (#855)
+    @test_logs (
+        :warn,
+        """
+        Agent type is not concrete. If your agent is parametrically typed, you're probably
+        seeing this warning because you gave `Agent` instead of `Agent{Float64}`
+        (for example) to this function. You can also create an instance of your agent
+        and pass it to this function. If you want to use `Union` types for mixed agent
+        models, you can silence this warning.
+        If you are using `ContinuousAgent{D}` as agent type in version 6+, update
+        to the new two-parameter version `ContinuousAgent{D,Float64}` to obtain
+        the same behavior as previous Agents.jl versions.\n"""
+    ) ABM(ContinuousAgent{2}, ContinuousSpace((1,1)))
+    # throws if the old ContinuousAgent{2} form is used with a non-Float64 space
+    @test_throws ArgumentError ABM(ContinuousAgent{2}, ContinuousSpace((1f0,1f0)); warn=false)
 end
 
 


### PR DESCRIPTION
Closes #855.
I added an extra check to the `do_checks` function to allow the creation of models with calls of the form `ABM(ContinuousAgent{D}, ContinuousSpace((1,1))` for backward compatibility, even though this now results in model being not concretely typed.
This change is also mentioned in the welcome message and in the warning for agents with non-concrete types.

I used a regex for the check instead of subtyping because I did not find another easy way to *only* get the case where `ContinuousAgent{D}` is used with a Float64 space.