### PR TITLE
Mixed boundary conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Two new functions `random_id_in_position` and `random_agent_in_position` can be used to select a random id/agent in a position in discrete spaces (even with filtering). 
 - A new argument `alloc` can be used to select a more performant version in relation to the expensiveness of the filtering for all random methods selecting ids/agents/positions.
 - The `sample!` function is up to 2x faster than before.
+- All spaces support boundaries with mixed periodicity, specified by tuples with a `Bool` value for each dimension, e.g. `GridSpace((5,5); periodic=(true,false))` is periodic along the first dimension but not along the second.
 
 ## BREAKING
 - `NTuple` in `ContinuousSpace` is officially deprecated, but backward compatibility is *mostly* maintained. Known breakages include the comparison of agent position and/or velocity with user-defined tuples, e.g., doing `agent.pos == (0.5, 0.5)`. This will always be `false` in v6 as `agent.pos` is an `SVector`. The rest of the functionality should all work without problems, such as moving agents to tuple-based positions etc.

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -26,6 +26,14 @@ ValidPos = Union{
     Tuple{Int,Int,Float64} # osm
 } where {N,M}
 
+# Type used to internally represent periodicity of spaces
+struct Periodic{D}
+    isperiodic::SVector{D,Bool}
+    Periodic{D}(p::Bool) where {D} = new{D}(fill(p, SVector{D}))
+    Periodic{D}(p) where {D} = new{D}(SVector{D}(p))
+end
+isperiodic(P::Periodic) = P.isperiodic
+
 
 """
     AgentBasedModel

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -26,14 +26,6 @@ ValidPos = Union{
     Tuple{Int,Int,Float64} # osm
 } where {N,M}
 
-# Type used to internally represent periodicity of spaces
-struct Periodic{D}
-    isperiodic::SVector{D,Bool}
-    Periodic{D}(p::Bool) where {D} = new{D}(fill(p, SVector{D}))
-    Periodic{D}(p) where {D} = new{D}(SVector{D}(p))
-end
-isperiodic(P::Periodic) = P.isperiodic
-
 
 """
     AgentBasedModel

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -12,8 +12,9 @@ end
 Base.eltype(s::ContinuousSpace{D,P,T,F}) where {D,P,T,F} = T
 no_vel_update(a, m) = nothing
 spacesize(space::ContinuousSpace) = space.extent
+isperiodic(::ContinuousSpace{D,P}) where {D,P} = isperiodic(P)
 function Base.show(io::IO, space::ContinuousSpace{D,P}) where {D,P}
-    s = "$(P ? "periodic" : "") continuous space with $(spacesize(space)) extent"*
+    s = "$(isperiodic(P)) continuous space with $(spacesize(space)) extent"*
     " and spacing=$(space.spacing)"
     space.update_vel! ≠ no_vel_update && (s *= " with velocity updates")
     print(io, s)

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -12,13 +12,17 @@ end
 Base.eltype(s::ContinuousSpace{D,P,T,F}) where {D,P,T,F} = T
 no_vel_update(a, m) = nothing
 spacesize(space::ContinuousSpace) = space.extent
-isperiodic(::ContinuousSpace{D,P}) where {D,P} = isperiodic(P)
 function Base.show(io::IO, space::ContinuousSpace{D,P}) where {D,P}
-    s = "$(isperiodic(P)) continuous space with $(spacesize(space)) extent"*
+    periodic = get_periodic_type(space)
+    s = "$(periodic)continuous space with $(spacesize(space)) extent"*
     " and spacing=$(space.spacing)"
     space.update_vel! ≠ no_vel_update && (s *= " with velocity updates")
     print(io, s)
 end
+get_periodic_type(space::ContinuousSpace{D,true}) where {D} = "periodic "
+get_periodic_type(space::ContinuousSpace{D,false}) where {D} = ""
+get_periodic_type(space::ContinuousSpace{D,P}) where {D,P} = "mixed-periodicity "
+
 
 """
     ContinuousAgent{D,T} <: AbstractAgent

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -172,7 +172,7 @@ function nearby_positions(
             checkbounds(Bool, stored_ids, (n .+ pos)...) ?
             n .+ pos : mod1.(n .+ pos, space_size)
             for n in nindices
-            if all(checkbounds(Bool, axes(stored_ids,i), n[i]+pos[i]) || P[i] for i in 1:D)
+            if all(P[i] || checkbounds(Bool, axes(stored_ids,i), n[i]+pos[i]) for i in 1:D)
         )
     end
 end

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -17,8 +17,6 @@ to vector of indices within each radius.
 """
 abstract type AbstractGridSpace{D,P} <: DiscreteSpace end
 
-isperiodic(::AbstractGridSpace{D,P}) where {D,P} = isperiodic(P)
-
 """
     GridAgent{D} <: AbstractAgent
 The minimal agent struct for usage with `D`-dimensional [`GridSpace`](@ref).

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -17,6 +17,8 @@ to vector of indices within each radius.
 """
 abstract type AbstractGridSpace{D,P} <: DiscreteSpace end
 
+isperiodic(::AbstractGridSpace{D,P}) where {D,P} = isperiodic(P)
+
 """
     GridAgent{D} <: AbstractAgent
 The minimal agent struct for usage with `D`-dimensional [`GridSpace`](@ref).

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -64,13 +64,15 @@ example for usage of this advanced specification of dimension-dependent distance
 where one dimension is used as a categorical one.
 """
 function GridSpace(
-        d::NTuple{D,Int}; periodic = true, metric::Symbol = :chebyshev
+        d::NTuple{D,Int};
+        periodic::Union{Bool,SVector{D,Bool},NTuple{D,Bool}} = true,
+        metric::Symbol = :chebyshev
     ) where {D}
     stored_ids = Array{Vector{Int},D}(undef, d)
     for i in eachindex(stored_ids)
         stored_ids[i] = Int[]
     end
-    return GridSpace{D,Periodic{D}(periodic)}(
+    return GridSpace{D,periodic}(
         stored_ids,
         metric,
         Dict{Int,Vector{NTuple{D,Int}}}(),

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -65,7 +65,7 @@ where one dimension is used as a categorical one.
 """
 function GridSpace(
         d::NTuple{D,Int};
-        periodic::Union{Bool,SVector{D,Bool},NTuple{D,Bool}} = true,
+        periodic::Union{Bool,NTuple{D,Bool}} = true,
         metric::Symbol = :chebyshev
     ) where {D}
     stored_ids = Array{Vector{Int},D}(undef, d)
@@ -192,6 +192,17 @@ combine_positions(pos, origin, ::GridSpaceIdIterator{false}) = pos .+ origin
     # checking for bounds is less expensive than calling mod1
     checkbounds(Bool, stored_ids, npos...) ? npos : mod1.(npos, space_size)
 end
+function combine_positions(pos, origin, iter::GridSpaceIdIterator{P,D}) where {P,D}
+    npos = pos .+ origin
+    space_size = iter.space_size
+    stored_ids = iter.stored_ids
+    ntuple(i ->
+        #(P[i] && checkbounds(Bool, stored_ids, npos[i])) ?
+        (!P[i] || checkbounds(Bool, stored_ids, npos[i])) ?
+        npos[i] : mod1(npos[i], space_size[i]),
+        D
+    )
+end
 combine_positions_nocheck(pos, origin, ::GridSpaceIdIterator) = pos .+ origin
 
 # Must return `true` if the access is invalid
@@ -200,6 +211,10 @@ combine_positions_nocheck(pos, origin, ::GridSpaceIdIterator) = pos .+ origin
     return !valid_bounds || @inbounds isempty(iter.stored_ids[pos_index...])
 end
 invalid_access(pos_index, iter::GridSpaceIdIterator{true}) = @inbounds isempty(iter.stored_ids[pos_index...])
+function invalid_access(pos_index, iter::GridSpaceIdIterator{P,D}) where {P,D}
+    valid_bounds = any((!P[i] && checkbounds(Bool, iter.stored_ids, pos_index[i]) for i in 1:D))
+    return !valid_bounds || @inbounds isempty(iter.stored_ids[pos_index...])
+end
 invalid_access_nocheck(pos_index, iter::GridSpaceIdIterator) = @inbounds isempty(iter.stored_ids[pos_index...])
 
 ##########################################################################################

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -64,13 +64,13 @@ example for usage of this advanced specification of dimension-dependent distance
 where one dimension is used as a categorical one.
 """
 function GridSpace(
-        d::NTuple{D,Int}; periodic::Bool = true, metric::Symbol = :chebyshev
+        d::NTuple{D,Int}; periodic = true, metric::Symbol = :chebyshev
     ) where {D}
     stored_ids = Array{Vector{Int},D}(undef, d)
     for i in eachindex(stored_ids)
         stored_ids[i] = Int[]
     end
-    return GridSpace{D,periodic}(
+    return GridSpace{D,Periodic{D}(periodic)}(
         stored_ids,
         metric,
         Dict{Int,Vector{NTuple{D,Int}}}(),

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -28,7 +28,7 @@ with non-zero IDs, either positive or negative. This is not checked internally.
 All arguments and keywords behave exactly as in [`GridSpace`](@ref).
 """
 function GridSpaceSingle(d::NTuple{D,Int};
-        periodic::Union{Bool,SVector{D,Bool},NTuple{D,Bool}} = true,
+        periodic::Union{Bool,NTuple{D,Bool}} = true,
         metric = :chebyshev
     ) where {D}
     s = zeros(Int, d)
@@ -116,6 +116,29 @@ function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,false}},
     else
         ids_iterator = (stored_ids[p...] for p in position_iterator 
                         if checkbounds(Bool, stored_ids, p...) && stored_ids[p...] != 0)
+    end
+    return ids_iterator
+end
+
+function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,P}}, r = 1,
+        get_offset_indices = offsets_within_radius # internal, see last function
+    ) where {D,P}
+    nindices = get_offset_indices(model, r)
+    stored_ids = abmspace(model).stored_ids
+    space_size = size(stored_ids)
+    position_iterator = (pos .+ β for β in nindices)
+    # check if we are far from the wall to skip bounds checks
+    if all(i -> r < pos[i] <= space_size[i] - r, 1:D)
+        ids_iterator = (stored_ids[p...] for p in position_iterator
+                        if stored_ids[p...] != 0)
+    else
+        ids_iterator = (
+            checkbounds(Bool, stored_ids, p...) ?
+            stored_ids[p...] : stored_ids[mod1.(p, space_size)...]
+            for p in position_iterator
+            if stored_ids[mod1.(p, space_size)...] != 0 &&
+            all(checkbounds(Bool, axes(stored_ids, i), p[i]) || P[i] for i in 1:D)
+        )
     end
     return ids_iterator
 end

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -137,7 +137,7 @@ function nearby_ids(pos::NTuple{D, Int}, model::ABM{<:GridSpaceSingle{D,P}}, r =
             stored_ids[p...] : stored_ids[mod1.(p, space_size)...]
             for p in position_iterator
             if stored_ids[mod1.(p, space_size)...] != 0 &&
-            all(checkbounds(Bool, axes(stored_ids, i), p[i]) || P[i] for i in 1:D)
+            all(P[i] || checkbounds(Bool, axes(stored_ids, i), p[i]) for i in 1:D)
         )
     end
     return ids_iterator

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -27,7 +27,10 @@ with non-zero IDs, either positive or negative. This is not checked internally.
 
 All arguments and keywords behave exactly as in [`GridSpace`](@ref).
 """
-function GridSpaceSingle(d::NTuple{D,Int}; periodic = true, metric = :chebyshev) where {D}
+function GridSpaceSingle(d::NTuple{D,Int};
+        periodic::Union{Bool,SVector{D,Bool},NTuple{D,Bool}} = true,
+        metric = :chebyshev
+    ) where {D}
     s = zeros(Int, d)
     return GridSpaceSingle{D,periodic}(s, metric,
         Dict{Int,Vector{NTuple{D,Int}}}(),

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -26,11 +26,10 @@ euclidean_distance(a::A, b::B, model::ABM,
 
 euclidean_distance(p1, p2, model::ABM) = euclidean_distance(p1, p2, abmspace(model))
 
-#==
 function euclidean_distance(
     p1::ValidPos,
     p2::ValidPos,
-    space::Union{ContinuousSpace{D,Periodic{D}(false)},AbstractGridSpace{D,Periodic{D}(false)}},
+    space::Union{ContinuousSpace{D,false},AbstractGridSpace{D,false}},
 ) where {D}
     sqrt(sum(abs2.(p1 .- p2)))
 end
@@ -38,12 +37,11 @@ end
 function euclidean_distance(
     p1::ValidPos,
     p2::ValidPos,
-    space::Union{ContinuousSpace{D,Periodic{D}(true)},AbstractGridSpace{D,Periodic{D}(true)}},
+    space::Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}},
 ) where {D}
     direct = abs.(p1 .- p2)
     sqrt(sum(min.(direct, spacesize(space) .- direct).^2))
 end
-==#
 
 function euclidean_distance(
     p1::ValidPos,
@@ -51,10 +49,9 @@ function euclidean_distance(
     space::Union{ContinuousSpace{D,P},AbstractGridSpace{D,P}}
 ) where {D,P}
     s = spacesize(space)
-    periodic = isperiodic(P)
     distance_squared = 0.0
     for i in eachindex(p1)
-        if periodic[i]
+        if P[i]
             distance_squared += euclidean_distance_periodic(p1[i], p2[i], s[i])^2
         else
             distance_squared += euclidean_distance_direct(p1[i], p2[i])^2
@@ -83,11 +80,10 @@ manhattan_distance(a::A, b::B, model::ABM
 
 manhattan_distance(p1, p2, model::ABM) = manhattan_distance(p1, p2, abmspace(model))
 
-#==
 function manhattan_distance(
     p1::ValidPos,
     p2::ValidPos,
-    space::Union{ContinuousSpace{D,Periodic{D}(false)},AbstractGridSpace{D,Periodic{D}(false)}},
+    space::Union{ContinuousSpace{D,false},AbstractGridSpace{D,false}},
 ) where {D}
     sum(manhattan_distance_direct.(p1, p2))
 end
@@ -95,11 +91,10 @@ end
 function manhattan_distance(
     p1::ValidPos,
     p2::ValidPos,
-    space::Union{ContinuousSpace{D,Periodic{D}(true)},AbstractGridSpace{D,Periodic{D}(true)}}
+    space::Union{ContinuousSpace{D,true},AbstractGridSpace{D,true}}
 ) where {D}
     sum(manhattan_distance_periodic.(p1, p2, spacesize(space)))
 end
-==#
 
 function manhattan_distance(
     p1::ValidPos,
@@ -107,10 +102,9 @@ function manhattan_distance(
     space::Union{ContinuousSpace{D,P},AbstractGridSpace{D,P}}
 ) where {D,P}
     s = spacesize(space)
-    periodic = isperiodic(P)
     distance = zero(eltype(p1))
     for i in eachindex(p1)
-        if periodic[i]
+        if P[i]
             distance += manhattan_distance_periodic(p1[i], p2[i], s[i])
         else
             distance += manhattan_distance_direct(p1[i], p2[i])

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -146,6 +146,21 @@ function get_direction(
     return to .- from
 end
 
+function get_direction(
+    from::ValidPos,
+    to::ValidPos,
+    space::Union{ContinuousSpace{D,P},AbstractGridSpace{D,P}}
+) where {D,P}
+    direct_dir = to .- from
+    inverse_dir = direct_dir .- sign.(direct_dir) .* spacesize(space)
+    return map(
+        i -> P[i] ?
+        (abs(direct_dir[i]) <= abs(inverse_dir[i]) ? direct_dir[i] : inverse_dir[i]) :
+        direct_dir[i],
+        1:D
+    )
+end
+
 #######################################################################################
 # %% Utilities for graph-based spaces (Graph/OpenStreetMap)
 #######################################################################################

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -49,7 +49,7 @@ function euclidean_distance(
     space::Union{ContinuousSpace{D,P},AbstractGridSpace{D,P}}
 ) where {D,P}
     s = spacesize(space)
-    distance_squared = 0.0
+    distance_squared = zero(eltype(p1))
     for i in eachindex(p1)
         if P[i]
             distance_squared += euclidean_distance_periodic(p1[i], p2[i], s[i])^2

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -74,32 +74,53 @@ spaces this clamps the position to the space extent.
 """
 normalize_position(pos, model::ABM) = normalize_position(pos, abmspace(model))
 
+function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,true}) where {D}
+    return mod.(pos, spacesize(space))
+end
+
+function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,false}) where {D}
+    return clamp.(pos, 0.0, prevfloat.(spacesize(space)))
+end
+
 function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,P}) where {D,P}
     s = spacesize(space)
-    periodic = isperiodic(P)
     return SVector{D}(
-        periodic[i] ? mod(pos[i], s[i]) : clamp(pos[i], 0.0, prevfloat(s[i]))
+        P[i] ? mod(pos[i], s[i]) : clamp(pos[i], 0.0, prevfloat(s[i]))
         for i in 1:D
     )
 end
 
 #----
-# for backward compatibility 
+# for backward compatibility
+function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,true}) where {D}
+    return Tuple(mod.(pos, spacesize(space)))
+end
+
+function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,false}) where {D}
+    return Tuple(clamp.(pos, 0.0, prevfloat.(spacesize(space))))
+end
+
 function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,P}) where {D,P}
     s = spacesize(space)
-    periodic = isperiodic(P)
     return ntuple(
-        i -> periodic[i] ? mod(pos[i], s[i]) : clamp(pos[i], 0.0, prevfloat(s[i])),
+        i -> P[i] ? mod(pos[i], s[i]) : clamp(pos[i], 0.0, prevfloat(s[i])),
         D
     )
 end
 #----
 
+function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,true}) where {D}
+    return mod1.(pos, spacesize(space))
+end
+
+function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,false}) where {D}
+    return clamp.(pos, 1, spacesize(space))
+end
+
 function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,P}) where {D,P}
     s = spacesize(space)
-    periodic = isperiodic(P)
     return ntuple(
-        i -> periodic[i] ? mod1(pos[i], s[i]) : clamp(pos[i], 1, s[i]),
+        i -> P[i] ? mod1(pos[i], s[i]) : clamp(pos[i], 1, s[i]),
         D
     )
 end

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -74,31 +74,34 @@ spaces this clamps the position to the space extent.
 """
 normalize_position(pos, model::ABM) = normalize_position(pos, abmspace(model))
 
-function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,true}) where {D}
-    return mod.(pos, spacesize(space))
-end
-
-function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,false}) where {D}
-    return clamp.(pos, 0.0, prevfloat.(spacesize(space)))
+function normalize_position(pos::SVector{D}, space::ContinuousSpace{D,P}) where {D,P}
+    s = spacesize(space)
+    periodic = isperiodic(P)
+    return SVector{D}(
+        periodic[i] ? mod(pos[i], s[i]) : clamp(pos[i], 0.0, prevfloat(s[i]))
+        for i in 1:D
+    )
 end
 
 #----
 # for backward compatibility 
-function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,true}) where {D}
-    return Tuple(mod.(pos, spacesize(space)))
-end
-
-function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,false}) where {D}
-    return Tuple(clamp.(pos, 0.0, prevfloat.(spacesize(space))))
+function normalize_position(pos::NTuple{D}, space::ContinuousSpace{D,P}) where {D,P}
+    s = spacesize(space)
+    periodic = isperiodic(P)
+    return ntuple(
+        i -> periodic[i] ? mod(pos[i], s[i]) : clamp(pos[i], 0.0, prevfloat(s[i])),
+        D
+    )
 end
 #----
 
-function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,true}) where {D}
-    return mod1.(pos, spacesize(space))
-end
-
-function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,false}) where {D}
-    return clamp.(pos, 1, spacesize(space))
+function normalize_position(pos::ValidPos, space::AbstractGridSpace{D,P}) where {D,P}
+    s = spacesize(space)
+    periodic = isperiodic(P)
+    return ntuple(
+        i -> periodic[i] ? mod1(pos[i], s[i]) : clamp(pos[i], 1, s[i]),
+        D
+    )
 end
 
 #######################################################################################

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -63,7 +63,7 @@ Utilization of all features of `AStar` occurs in the
 """
 function AStar(
     dims::NTuple{D,T};
-    periodic::Bool = false,
+    periodic::Union{Bool,SVector{D,Bool},NTuple{D,Bool}} = false,
     diagonal_movement::Bool = true,
     admissibility::Float64 = 0.0,
     walkmap::BitArray{D} = trues(dims),
@@ -115,13 +115,16 @@ function vonneumann_neighborhood(D)
 end
 
 function Base.show(io::IO, pathfinder::AStar{D,P,M}) where {D,P,M}
-    periodic = P ? "periodic, " : ""
+    periodic = get_periodic_type(pathfinder)
     moore = M ? "diagonal, " : "orthogonal, "
     s =
         "A* in $(D) dimensions, $(periodic)$(moore)ϵ=$(pathfinder.admissibility), " *
         "metric=$(pathfinder.cost_metric)"
     print(io, s)
 end
+get_periodic_type(::AStar{D,false,M}) where {D,M} = ""
+get_periodic_type(::AStar{D,true,M}) where {D,M} = "periodic, "
+get_periodic_type(::AStar{D,P,M}) where {D,P,M} = "mixed periodicity, "
 
 struct GridCell
     f::Int

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -63,7 +63,7 @@ Utilization of all features of `AStar` occurs in the
 """
 function AStar(
     dims::NTuple{D,T};
-    periodic::Union{Bool,SVector{D,Bool},NTuple{D,Bool}} = false,
+    periodic::Union{Bool,Tuple{D,Bool}} = false,
     diagonal_movement::Bool = true,
     admissibility::Float64 = 0.0,
     walkmap::BitArray{D} = trues(dims),

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -63,7 +63,7 @@ Utilization of all features of `AStar` occurs in the
 """
 function AStar(
     dims::NTuple{D,T};
-    periodic::Union{Bool,Tuple{D,Bool}} = false,
+    periodic::Union{Bool,NTuple{D,Bool}} = false,
     diagonal_movement::Bool = true,
     admissibility::Float64 = 0.0,
     walkmap::BitArray{D} = trues(dims),
@@ -198,6 +198,13 @@ end
     (mod1.(cur .+ β.I, size(pathfinder.walkmap)) for β in pathfinder.neighborhood)
 @inline get_neighbors(cur, pathfinder::AStar{D,false}) where {D} =
     (cur .+ β.I for β in pathfinder.neighborhood)
+@inline function get_neighbors(cur, pathfinder::AStar{D,P}) where {D,P}
+    s = size(pathfinder.walkmap)
+    (
+        ntuple(i -> P[i] ? mod1(cur[i] + β[i], s[i]) : cur[i] + β[i], D)
+        for β in pathfinder.neighborhood
+    )
+end
 @inline inbounds(n, pathfinder, closed) =
     all(1 .<= n .<= size(pathfinder.walkmap)) && pathfinder.walkmap[n...] && n ∉ closed
 

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -7,6 +7,14 @@ sqr_distance(from, to, pathfinder::AStar{D,true}) where {D} =
     sum(min.(abs.(from .- to), pathfinder.dims .- abs.(from .- to)) .^ 2)
 sqr_distance(from, to, pathfinder::AStar{D,false}) where {D} =
     sum((from .- to) .^ 2)
+@inline function sqr_distance(from, to, pathfinder::AStar{D,P}) where {D,P}
+    s = pathfinder.dims
+    delta = abs.(from .- to)
+    sum(
+        P[i] ? (min(delta[i], s[i] - delta[i]))^2 : delta[i]^2
+        for i in 1:D
+    )
+end
 
 """
     find_continuous_path(pathfinder, from, to)

--- a/src/submodules/pathfinding/pathfinding_utils.jl
+++ b/src/submodules/pathfinding/pathfinding_utils.jl
@@ -9,6 +9,12 @@ position_delta(pathfinder::GridPathfinder{D,true}, from::Dims{D}, to::Dims{D}) w
 position_delta(pathfinder::GridPathfinder{D,false}, from::Dims{D}, to::Dims{D}) where {D} =
     abs.(to .- from)
 
+@inline function position_delta(pathfinder::GridPathfinder{D,P}, from::Dims{D}, to::Dims{D}) where {D,P}
+    s = size(pathfinder.walkmap)
+    delta = abs(to .- from)
+    ntuple(i -> P[i] ? min(abs(delta[i]), s[i] - delta[i]) : delta[i], D)
+end
+
 """
     Pathfinding.delta_cost(pathfinder::GridPathfinder{D}, metric::M, from, to) where {M<:CostMetric}
 Calculate an approximation for the cost of travelling from `from` to `to` (both of

--- a/src/submodules/pathfinding/pathfinding_utils.jl
+++ b/src/submodules/pathfinding/pathfinding_utils.jl
@@ -11,8 +11,8 @@ position_delta(pathfinder::GridPathfinder{D,false}, from::Dims{D}, to::Dims{D}) 
 
 @inline function position_delta(pathfinder::GridPathfinder{D,P}, from::Dims{D}, to::Dims{D}) where {D,P}
     s = size(pathfinder.walkmap)
-    delta = abs(to .- from)
-    ntuple(i -> P[i] ? min(abs(delta[i]), s[i] - delta[i]) : delta[i], D)
+    delta = abs.(to .- from)
+    ntuple(i -> P[i] ? min(delta[i], s[i] - delta[i]) : delta[i], D)
 end
 
 """

--- a/test/astar_tests.jl
+++ b/test/astar_tests.jl
@@ -167,13 +167,12 @@ using Agents.Pathfinding
             space = ContinuousSpace((5., 5.); periodic = (false, true))
             pathfinder = AStar(space; walkmap = trues(10, 10))
             model = ABM(Agent6, space; properties = (pf = pathfinder,))
-            model.pf.walkmap[2,:] .= 0
+            model.pf.walkmap[5,:] .= 0
             a = add_agent!(SVector(0., 0.), model, SVector(0., 0.), 0.)
             @test isnothing(plan_best_route!(a, [SVector(4.0, 0.)], model.pf))
-            @test plan_best_route!(a, [SVector(0., 4.0)], model.pf) == SVector(0., 4.0)
-            move_along_route!(a, model, model.pf, 0.5)
-            # WRONG
-            # @test isapprox(a.pos, SVector(0, 4.5); atol)
+            @test plan_best_route!(a, [SVector(1.0, 1.0)], model.pf) == SVector(1.0, 1.0)
+            move_along_route!(a, model, model.pf, 1.0)
+            @test isapprox(a.pos, SVector(1/sqrt(2), 1/sqrt(2)); atol)
         end
     end
 

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -11,6 +11,17 @@ using StableRNGs
             @test size(poss) == dims
             @test size(space) == dims
         end
+        # mixed boundary conditions
+        if D > 1
+            periodic = ntuple(i -> i==1 ? true : false, D)
+            space = SpaceType(dims; periodic)
+            poss = positions(space)
+            @test spacesize(space) == dims
+            @test size(poss) == dims
+            @test size(space) == dims
+            get_P(::Union{GridSpace{D,P},GridSpaceSingle{D,P}}) where {D,P} = P
+            @test get_P(space) == periodic
+        end
     end
 
     @testset "add/move/remove" begin
@@ -114,6 +125,11 @@ using StableRNGs
         a = add_agent!((1, 6), model)
         b = add_agent!((11, 4), model)
         @test euclidean_distance(a, b, model) ≈ 10.198039
+
+        model = ABM(GridAgent{2}, SpaceType((10, 10); periodic = (false, true)))
+        a = add_agent!((1, 1), model)
+        b = add_agent!((9, 9), model)
+        @test euclidean_distance(a, b, model) ≈ 8.24621125
     end
     @testset "Manhattan Distance" begin
         model = ABM(GridAgent{2}, SpaceType((12, 10); metric = :manhattan, periodic = true))
@@ -125,6 +141,11 @@ using StableRNGs
         a = add_agent!((1, 6), model)
         b = add_agent!((11, 4), model)
         @test manhattan_distance(a, b, model) ≈ 12
+
+        model = ABM(GridAgent{2}, SpaceType((10, 10); periodic = (false, true)))
+        a = add_agent!((1, 1), model)
+        b = add_agent!((9, 9), model)
+        @test manhattan_distance(a, b, model) ≈ 10
     end
     end
 

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -151,7 +151,7 @@ using StableRNGs
 
     @testset "Nearby pos/ids/agents" begin
         metrics = [:euclidean, :manhattan, :chebyshev]
-        periodics = [false, true]
+        periodics = [false, true, (true,false)]
 
         # All following are with r=1
         @testset "periodic=$(periodic)" for periodic in periodics
@@ -162,22 +162,28 @@ using StableRNGs
                 if metric ∈ (:euclidean, :mahnattan) # for r = 1 they give the same
                     @test sort!(collect(nearby_positions((2, 2), model))) ==
                         sort!([(2, 1), (1, 2), (3, 2), (2, 3)])
-                    if !periodic
+                    if periodic == false
                         @test sort!(collect(nearby_positions((1, 1), model))) ==
                         sort!([(1, 2), (2, 1)])
-                    else # in periodic case we still have all nearby 4 positions
+                    elseif periodic == true # in periodic case we still have all nearby 4 positions
                         @test sort!(collect(nearby_positions((1, 1), model))) ==
                         sort!([(1, 2), (2, 1), (1 ,5), (5, 1)])
+                    elseif periodic == (true,false)
+                        @test sort!(collect(nearby_positions((1, 1), model))) ==
+                        sort!([(1, 2), (2, 1), (5, 1)])
                     end
                 elseif metric == :chebyshev
                     @test sort!(collect(nearby_positions((2, 2), model))) ==
                         [(1,1), (1,2), (1,3), (2,1), (2,3), (3,1), (3,2), (3,3)]
-                    if !periodic
+                    if periodic == false
                         @test sort!(collect(nearby_positions((1, 1), model))) ==
                             [(1,2), (2,1), (2,2)]
-                    else
+                    elseif periodic == true
                         @test sort!(collect(nearby_positions((1, 1), model))) ==
                             [(1,2), (1,5), (2,1), (2,2), (2,5), (5,1), (5,2), (5,5)]
+                    elseif periodic == (true,false)
+                        @test sort!(collect(nearby_positions((1, 1), model))) ==
+                            [(1,2), (2,1), (2,2), (5,1), (5,2)]
                     end
                 end
 
@@ -185,7 +191,7 @@ using StableRNGs
                 add_agent!((1, 1), model)
                 a = add_agent!((2, 1), model)
                 add_agent!((3, 2), model) # this is neighbor only in chebyshev
-                add_agent!((5, 1), model)
+                add_agent!((2, 5), model) # this is neighbor in periodic but not in (true,false)
 
                 near_agent = sort!(collect(nearby_ids(a, model)))
                 near_pos = sort!(collect(nearby_ids(a.pos, model)))
@@ -193,14 +199,18 @@ using StableRNGs
                 @test 2 ∉ near_agent
                 @test near_pos == sort!(vcat(near_agent, 2))
 
-                if !periodic && metric ∈ (:euclidean, :mahnattan)
+                if periodic == false && metric ∈ (:euclidean, :mahnattan)
                     near_agent == [1]
-                elseif periodic && metric ∈ (:euclidean, :mahnattan)
+                elseif periodic == true && metric ∈ (:euclidean, :mahnattan)
                     near_agent == [1,4]
-                elseif !periodic && metric == :chebyshev
+                elseif periodic == (true,false) && metric ∈ (:euclidean, :manhattan)
+                    near_agent == [1]
+                elseif periodic == false && metric == :chebyshev
                     near_agent == [1,3]
-                elseif periodic && metric == :chebyshev
+                elseif periodic == true && metric == :chebyshev
                     near_agent == [1,3,4]
+                elseif periodic == (true,false) && metric == :chebyshev
+                    near_agent == [1,3]
                 end
 
             end

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -227,7 +227,7 @@ using StableRNGs
         end
     end
 
-    @testset "$(periodic)" for periodic in (true, false)
+    @testset "$(periodic)" for periodic in (true, false, (true,false))
         @testset "Random nearby" begin
             abm = ABM(GridAgent{2}, SpaceType((10, 10), periodic=periodic); rng = StableRNG(42))
             fill_space!(abm)

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -336,6 +336,21 @@ using StableRNGs
         walk!(a, (-1, -1), model) # Boundary in one direction, not in the other, attempt South west
         @test a.pos == (1, 2)
         @test_throws MethodError walk!(a, (1.0, 1.5), model) # Must use Int for gridspace
+        # mixed boundary
+        model = ABM(GridAgent{2}, GridSpace((3, 3); periodic = (true, false)))
+        a = add_agent!((1, 1), model)
+        walk!(a, (0, 1), model) # North
+        @test a.pos == (1, 2)
+        walk!(a, (1, 1), model) # North east
+        @test a.pos == (2, 3)
+        walk!(a, (1, 0), model) # East
+        @test a.pos == (3, 3)
+        walk!(a, (1, 0), model) # PBC, East
+        @test a.pos == (1, 3)
+        walk!(a, (0, 1), model) # Boundary, attempt North
+        @test a.pos == (1, 3)
+        walk!(a, (-1, -3), model) # PBC West, Boundary South
+        @test a.pos == (3, 1)
 
         # GridSpaceSingle
         model = ABM(GridAgent{2}, GridSpaceSingle((5, 5)))


### PR DESCRIPTION
Closes #828.
WIP, there are still a lot of things to fix.
I tried to represent space periodicity with a new type `Periodic{D}` to only be used internally, which would just wrap a SVector with a Bool value for each spatial dimension. When given a `Bool` e.g. `Periodic{D}(true)` it is internally converted to a SVector as `fill(true, SVector{D})`.
I don't have a smart way to fall back to "full periodic" and "non periodic" via dispatch yet, so as it is now every time distances have to be evaluated, each dimensions needs to be checked for whether or not it is periodic. In low-dimensional systems (which I assume make up the vast majority of use cases) there is no performance difference; in high-dimensional ones it might start to become noticeable (although I don't know to what extent this is really an issue...)

Low-dimensional space:
```julia
julia> # mixed-boundary
       space = GridSpace(ntuple(i->5,2); periodic=true)
       model = ABM(GridAgent{2}, space)
       add_agent!(model)
       add_agent!(model)
       @btime euclidean_distance($(model[1]), $(model[2]), $(model))
  2.374 ns (0 allocations: 0 bytes)

julia> # main
       space = GridSpace(ntuple(i->5,2); periodic=true)
       model = ABM(GridAgent{2}, space)
       add_agent!(model)
       add_agent!(model)
       @btime euclidean_distance($(model[1]), $(model[2]), $(model))
  2.304 ns (0 allocations: 0 bytes)
```


High-dimensional space:
```julia
julia> # mixed-boundary
       space = GridSpace(ntuple(i->5,8); periodic=true)
       model = ABM(GridAgent{8}, space)
       add_agent!(model)
       add_agent!(model)
       @btime euclidean_distance($(model[1]), $(model[2]), $(model))
  8.389 ns (0 allocations: 0 bytes)

julia> # main
       space = GridSpace(ntuple(i->5,8); periodic=true)
       model = ABM(GridAgent{8}, space)
       add_agent!(model)
       add_agent!(model)
       @btime euclidean_distance($(model[1]), $(model[2]), $(model))
  5.168 ns (0 allocations: 0 bytes)
```


An alternative approach (probably better and possibly requiring less work) is to not have a `Periodic` type, just let spaces accept whatever is passed to them (be it a Bool, a tuple an svector etc...). If it's found to be a Bool, then they will just behave as usual, but if they are passed an iterable type they will do the checking.