### PR TITLE
Use Vectors instead of a Dict for nearby offsets

### DIFF
--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -97,7 +97,8 @@ function offsets_within_radius(space::AbstractGridSpace{D}, r::Real) where {D}
     else
         r₀ = i - 1
         βs = calculate_offsets(space, r₀)
-        append_offsets!(offsets, i, βs, D)
+        resize_offsets!(offsets, i)
+        offsets[i] = βs
     end
     return βs
 end
@@ -122,7 +123,8 @@ function offsets_at_radius(space::AbstractGridSpace{D}, r::Real) where {D}
         elseif space.metric == :chebyshev
             filter!(β -> maximum(abs.(β)) == r₀, βs)
         end
-        append_offsets!(offsets, i, βs, D)
+        resize_offsets!(offsets, i)
+        offsets[i] = βs
     end
     return βs
 end
@@ -142,12 +144,11 @@ function calculate_offsets(space::AbstractGridSpace{D}, r::Int) where {D}
     return βs
 end
 
-function append_offsets!(offsets, i, βs, D)
+function resize_offsets!(offsets, i)
     incr = i - length(offsets)
     if incr > 0
         resize!(offsets, i)
     end
-    offsets[i] = βs
 end
 
 function random_position(model::ABM{<:AbstractGridSpace})
@@ -165,7 +166,8 @@ function offsets_within_radius_no_0(space::AbstractGridSpace{D}, r::Real) where 
         βs = calculate_offsets(space, r₀)
         z = ntuple(i -> 0, D)
         filter!(x -> x ≠ z, βs)
-        append_offsets!(offsets, i, βs, D)
+        resize_offsets!(offsets, i)
+        offsets[i] = βs
     end
     return βs
 end

--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -92,7 +92,7 @@ offsets_within_radius(model::ABM, r::Real) = offsets_within_radius(abmspace(mode
 function offsets_within_radius(space::AbstractGridSpace{D}, r::Real) where {D}
     i = floor(Int, r + 1)
     offsets = space.offsets_within_radius
-    if i <= length(offsets) && !isempty(offsets[i])
+    if isassigned(offsets, i)
         βs = offsets[i]
     else
         r₀ = i - 1
@@ -112,7 +112,7 @@ offsets_at_radius(model::ABM, r::Real) = offsets_at_radius(abmspace(model), r)
 function offsets_at_radius(space::AbstractGridSpace{D}, r::Real) where {D}
     i = floor(Int, r + 1)
     offsets = space.offsets_at_radius
-    if i <= length(offsets) && !isempty(offsets[i])
+    if isassigned(offsets, i)
         βs = offsets[i]
     else
         r₀ = i - 1
@@ -146,11 +146,8 @@ function append_offsets!(offsets, i, βs, D)
     incr = i - length(offsets)
     if incr > 0
         resize!(offsets, i)
-        @inbounds for j in i-incr+1:i
-            offsets[j] = Vector{NTuple{D,Int}}()
-        end
     end
-    append!(offsets[i], βs)
+    offsets[i] = βs
 end
 
 function random_position(model::ABM{<:AbstractGridSpace})
@@ -161,7 +158,7 @@ offsets_within_radius_no_0(model::ABM, r::Real) = offsets_within_radius_no_0(abm
 function offsets_within_radius_no_0(space::AbstractGridSpace{D}, r::Real) where {D}
     i = floor(Int, r + 1)
     offsets = space.offsets_within_radius_no_0
-    if i <= length(offsets) && !isempty(offsets[i])
+    if isassigned(offsets, i)
         βs = offsets[i]
     else
         r₀ = i - 1

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -5,9 +5,9 @@ struct GridSpace{D,P} <: AbstractGridSpace{D,P}
     stored_ids::Array{Vector{Int},D}
     extent::NTuple{D,Int}
     metric::Symbol
-    offsets_at_radius::Dict{Int,Vector{NTuple{D,Int}}}
-    offsets_within_radius::Dict{Int,Vector{NTuple{D,Int}}}
-    offsets_within_radius_no_0::Dict{Int,Vector{NTuple{D,Int}}}
+    offsets_at_radius::Vector{Vector{NTuple{D,Int}}}
+    offsets_within_radius::Vector{Vector{NTuple{D,Int}}}
+    offsets_within_radius_no_0::Vector{Vector{NTuple{D,Int}}}
     indices_within_radius_tuple::Dict{NTuple{D,Int},Vector{NTuple{D,Int}}}
 end
 spacesize(space::GridSpace) = space.extent
@@ -78,9 +78,9 @@ function GridSpace(
         stored_ids,
         d,
         metric,
-        Dict{Int,Vector{NTuple{D,Int}}}(),
-        Dict{Int,Vector{NTuple{D,Int}}}(),
-        Dict{Int,Vector{NTuple{D,Int}}}(),
+        Vector{Vector{NTuple{D,Int}}}(),
+        Vector{Vector{NTuple{D,Int}}}(),
+        Vector{Vector{NTuple{D,Int}}}(),
         Dict{NTuple{D,Int},Vector{NTuple{D,Int}}}(),
     )
 end

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -12,9 +12,9 @@ struct GridSpaceSingle{D,P} <: AbstractGridSpace{D,P}
     stored_ids::Array{Int,D}
     extent::NTuple{D,Int}
     metric::Symbol
-    offsets_at_radius::Dict{Int,Vector{NTuple{D,Int}}}
-    offsets_within_radius::Dict{Int,Vector{NTuple{D,Int}}}
-    offsets_within_radius_no_0::Dict{Int,Vector{NTuple{D,Int}}}
+    offsets_at_radius::Vector{Vector{NTuple{D,Int}}}
+    offsets_within_radius::Vector{Vector{NTuple{D,Int}}}
+    offsets_within_radius_no_0::Vector{Vector{NTuple{D,Int}}}
 end
 spacesize(space::GridSpaceSingle) = space.extent
 
@@ -35,9 +35,9 @@ function GridSpaceSingle(d::NTuple{D,Int};
     ) where {D}
     s = zeros(Int, d)
     return GridSpaceSingle{D,periodic}(s, d, metric,
-        Dict{Int,Vector{NTuple{D,Int}}}(),
-        Dict{Int,Vector{NTuple{D,Int}}}(),
-        Dict{Int,Vector{NTuple{D,Int}}}(),
+        Vector{Vector{NTuple{D,Int}}}(),
+        Vector{Vector{NTuple{D,Int}}}(),
+        Vector{Vector{NTuple{D,Int}}}(),
     )
 end
 # Implementation of space API

--- a/src/submodules/io/jld2_integration.jl
+++ b/src/submodules/io/jld2_integration.jl
@@ -142,11 +142,11 @@ function from_serializable(t::SerializableGridSpace{D,P}; kwargs...) where {D,P}
     for i in eachindex(s)
         s[i] = Int[]
     end
-    return GridSpace{D,P}(s, t.dims, t.metric, Dict(), Dict(), Dict(), Dict())
+    return GridSpace{D,P}(s, t.dims, t.metric, Vector(), Vector(), Vector(), Dict())
 end
 function from_serializable(t::SerializableGridSpaceSingle{D,P}; kwargs...) where {D,P}
     s = zeros(Int, t.dims)
-    return GridSpaceSingle{D,P}(s, t.dims, t.metric, Dict(), Dict(), Dict())
+    return GridSpaceSingle{D,P}(s, t.dims, t.metric, Vector(), Vector(), Vector())
 end
 
 function from_serializable(t::SerializableContinuousSpace{D,P,T}; kwargs...) where {D,P,T}


### PR DESCRIPTION
This should make the retrieval of the offsets faster.....

The PR removes the dictionaries used to hold the offsets for calculating nearby stuff and substitute them with vectors. The access to a vector should be faster, and so this should help performance

Still needs benchmarks