### PR TITLE
Remove unnecessary check in add_agent_pos!

### DIFF
--- a/src/Agents.jl
+++ b/src/Agents.jl
@@ -20,7 +20,7 @@ import LinearAlgebra
 # Core structures of Agents.jl
 include("core/agents.jl")
 include("core/model_abstract.jl")
-include("core/for_free_extensions.jl")
+include("core/model_free_extensions.jl")
 include("core/model_single_container.jl")
 include("core/space_interaction_API.jl")
 include("core/higher_order_iteration.jl")

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -195,9 +195,6 @@ end
 Add the agent to the `model` at the agent's own position.
 """
 function add_agent_pos!(agent::A, model::ABM) where {A<:AbstractAgent}
-    if !(A <: agenttype(model))
-        error("Agent type $(A) is not a subtype of the model specified agent type!")
-    end
     add_agent_to_model!(agent, model)
     add_agent_to_space!(agent, model)
     return agent


### PR DESCRIPTION
This will fail with an easy to bisect error anyway since adding to the model will fail since the agent type will not be accepted. Forgot to do it when merging #900 