### PR TITLE
Enable arrow backend for offline_run! in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@ src/update_*
 agents_visualizations.md
 .vscode
 celllistmap.mp4
-test/adata.arrow
-test/mdata.arrow

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/update_*
 agents_visualizations.md
 .vscode
 celllistmap.mp4
+test/adata.arrow
+test/mdata.arrow

--- a/ext/AgentsArrow/AgentsArrow.jl
+++ b/ext/AgentsArrow/AgentsArrow.jl
@@ -3,12 +3,15 @@ module AgentsArrow
 using Agents, Arrow
 
 function Agents.writer_arrow(filename, data, append)
-    if append
-        Arrow.append(filename, data)
-    else
-        Arrow.write(filename, data; file = false)
+    open(filename, "a+") do io
+        if append
+            Arrow.append(io, data)
+        else
+            Arrow.write(io, data; file = false)
+        end
     end
 end
+
 
 # TODO: Implement populate_from and dump_to functions for Arrow.jl
 

--- a/ext/AgentsArrow/AgentsArrow.jl
+++ b/ext/AgentsArrow/AgentsArrow.jl
@@ -3,15 +3,12 @@ module AgentsArrow
 using Agents, Arrow
 
 function Agents.writer_arrow(filename, data, append)
-    open(filename, "a+") do io
-        if append
-            Arrow.append(io, data)
-        else
-            Arrow.write(io, data; file = false)
-        end
+    if append
+        Arrow.append(io, data)
+    else
+        Arrow.write(io, data; file = false)
     end
 end
-
 
 # TODO: Implement populate_from and dump_to functions for Arrow.jl
 

--- a/ext/AgentsArrow/AgentsArrow.jl
+++ b/ext/AgentsArrow/AgentsArrow.jl
@@ -4,9 +4,9 @@ using Agents, Arrow
 
 function Agents.writer_arrow(filename, data, append)
     if append
-        Arrow.append(io, data)
+        Arrow.append(filename, data)
     else
-        Arrow.write(io, data; file = false)
+        Arrow.write(filename, data; file = false)
     end
 end
 

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -290,11 +290,6 @@ function get_writer(backend)
     if backend == :csv
         return writer_csv
     elseif backend == :arrow
-        if Sys.iswindows()
-            error("""Arrow.jl integration currently does not work on Windows.
-            Please use another backend like `:csv` until the issue has been resolved.
-            Further info: https://github.com/JuliaDynamics/Agents.jl/issues/826""")
-        end
         return writer_arrow
     end
 end

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -230,7 +230,8 @@ end
                 writing_interval = 3
             )
 
-            # IO should be released manually for Windows due to some underlying problems in Arrow.jl
+            # IO should be released manually to be able to remove the .arrow files for Windows 
+            # due to some underlying problems in Arrow.jl
             if !(Sys.iswindows())
                 adata_saved = DataFrame(Arrow.Table("adata.arrow"))
                 @test size(adata_saved) == (11, 2)

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -229,41 +229,40 @@ end
                 adata = [(:weight, mean)],
                 writing_interval = 3
             )
-
-            # IO should be released manually to be able to remove the .arrow files for Windows 
-            # due to some underlying problems in Arrow.jl
-            if !(Sys.iswindows())
-                adata_saved = DataFrame(Arrow.Table("adata.arrow"))
-                @test size(adata_saved) == (11, 2)
-                @test propertynames(adata_saved) == [:step, :mean_weight]
-    
-                mdata_saved = DataFrame(Arrow.Table("mdata.arrow"))
-                @test size(mdata_saved) == (6, 3)
-                @test propertynames(mdata_saved) == [:step, :flag, :year]
-    
-                @test size(vcat(DataFrame.(Arrow.Stream("adata.arrow"))...)) == (11, 2)
-                @test size(vcat(DataFrame.(Arrow.Stream("mdata.arrow"))...)) == (6, 3)
-            else
-                open("adata.arrow") do io
-                    adata_saved = DataFrame(Arrow.Table(io))
-                    close(io)
-                end
-                @test size(adata_saved) == (11, 2)
-                @test propertynames(adata_saved) == [:step, :mean_weight]
-                open("mdata.arrow") do io
-                    mdata_saved = DataFrame(Arrow.Table(io))
-                    close(io)
-                end
-                @test size(mdata_saved) == (6, 3)
-                @test propertynames(mdata_saved) == [:step, :flag, :year]
-                @test size(vcat(DataFrame.(Arrow.Stream("adata.arrow"))...)) == (11, 2)
-                @test size(vcat(DataFrame.(Arrow.Stream("mdata.arrow"))...)) == (6, 3)
-                GC.gc(true)
+            # removing .arrow files after operating on them causes IO errors on Windows
+            # so to make tests on Windows work we need to remove them when a new test
+            # run occurs
+            if Sys.iswindows()
+                isfile("adata.arrow") && rm("adata.arrow")
+                isfile("mdata.arrow") && rm("mdata.arrow")
             end
-            rm("adata.arrow")
-            rm("mdata.arrow")
-            @test !isfile("adata.arrow")
-            @test !isfile("mdata.arrow")
+
+            offline_run!(model, 365 * 5;
+                when_model = each_year,
+                when = six_months,
+                backend = :arrow,
+                mdata = [:flag, :year],
+                adata = [(:weight, mean)],
+                writing_interval = 3
+            )
+
+            adata_saved = DataFrame(Arrow.Table("adata.arrow"))
+            @test size(adata_saved) == (11, 2)
+            @test propertynames(adata_saved) == [:step, :mean_weight]
+
+            mdata_saved = DataFrame(Arrow.Table("mdata.arrow"))
+            @test size(mdata_saved) == (6, 3)
+            @test propertynames(mdata_saved) == [:step, :flag, :year]
+
+            @test size(vcat(DataFrame.(Arrow.Stream("adata.arrow"))...)) == (11, 2)
+            @test size(vcat(DataFrame.(Arrow.Stream("mdata.arrow"))...)) == (6, 3)
+
+            if !(Sys.iswindows())
+                rm("adata.arrow")
+                rm("mdata.arrow")
+                @test !isfile("adata.arrow")
+                @test !isfile("mdata.arrow")
+            end
 
             # Backends
             @test_throws TypeError begin

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -221,33 +221,30 @@ end
             @test !isfile("adata.csv")
             @test !isfile("mdata.csv")
 
-            # Arrow, fails on Windows (see issue #826 (https://github.com/JuliaDynamics/Agents.jl/issues/826))
-            if !(Sys.iswindows())
-                offline_run!(model, 365 * 5;
-                    when_model = each_year,
-                    when = six_months,
-                    backend = :arrow,
-                    mdata = [:flag, :year],
-                    adata = [(:weight, mean)],
-                    writing_interval = 3
-                )
+            offline_run!(model, 365 * 5;
+                when_model = each_year,
+                when = six_months,
+                backend = :arrow,
+                mdata = [:flag, :year],
+                adata = [(:weight, mean)],
+                writing_interval = 3
+            )
 
-                adata_saved = DataFrame(Arrow.Table("adata.arrow"))
-                @test size(adata_saved) == (11, 2)
-                @test propertynames(adata_saved) == [:step, :mean_weight]
+            adata_saved = DataFrame(Arrow.Table("adata.arrow"))
+            @test size(adata_saved) == (11, 2)
+            @test propertynames(adata_saved) == [:step, :mean_weight]
 
-                mdata_saved = DataFrame(Arrow.Table("mdata.arrow"))
-                @test size(mdata_saved) == (6, 3)
-                @test propertynames(mdata_saved) == [:step, :flag, :year]
+            mdata_saved = DataFrame(Arrow.Table("mdata.arrow"))
+            @test size(mdata_saved) == (6, 3)
+            @test propertynames(mdata_saved) == [:step, :flag, :year]
 
-                @test size(vcat(DataFrame.(Arrow.Stream("adata.arrow"))...)) == (11, 2)
-                @test size(vcat(DataFrame.(Arrow.Stream("mdata.arrow"))...)) == (6, 3)
+            @test size(vcat(DataFrame.(Arrow.Stream("adata.arrow"))...)) == (11, 2)
+            @test size(vcat(DataFrame.(Arrow.Stream("mdata.arrow"))...)) == (6, 3)
 
-                rm("adata.arrow")
-                rm("mdata.arrow")
-                @test !isfile("adata.arrow")
-                @test !isfile("mdata.arrow")
-            end
+            rm("adata.arrow")
+            rm("mdata.arrow")
+            @test !isfile("adata.arrow")
+            @test !isfile("mdata.arrow")
 
             # Backends
             @test_throws TypeError begin

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -221,14 +221,6 @@ end
             @test !isfile("adata.csv")
             @test !isfile("mdata.csv")
 
-            # removing .arrow files after operating on them causes IO errors on Windows
-            # so to make tests on Windows work we need to remove them when a new test
-            # run occurs
-            if Sys.iswindows()
-                isfile("adata.arrow") && rm("adata.arrow")
-                isfile("mdata.arrow") && rm("mdata.arrow")
-            end
-
             offline_run!(model, 365 * 5;
                 when_model = each_year,
                 when = six_months,
@@ -238,23 +230,22 @@ end
                 writing_interval = 3
             )
 
-            adata_saved = DataFrame(Arrow.Table("adata.arrow"))
+            adata_saved = DataFrame(Arrow.Table("adata.arrow"), copycols=true)
             @test size(adata_saved) == (11, 2)
             @test propertynames(adata_saved) == [:step, :mean_weight]
 
-            mdata_saved = DataFrame(Arrow.Table("mdata.arrow"))
+            mdata_saved = DataFrame(Arrow.Table("mdata.arrow"), copycols=true)
             @test size(mdata_saved) == (6, 3)
             @test propertynames(mdata_saved) == [:step, :flag, :year]
 
             @test size(vcat(DataFrame.(Arrow.Stream("adata.arrow"))...)) == (11, 2)
             @test size(vcat(DataFrame.(Arrow.Stream("mdata.arrow"))...)) == (6, 3)
-
-            if !(Sys.iswindows())
-                rm("adata.arrow")
-                rm("mdata.arrow")
-                @test !isfile("adata.arrow")
-                @test !isfile("mdata.arrow")
-            end
+            
+            Sys.iswindows() && GC.gc() 
+            rm("adata.arrow")
+            rm("mdata.arrow")
+            @test !isfile("adata.arrow")
+            @test !isfile("mdata.arrow")
 
             # Backends
             @test_throws TypeError begin

--- a/test/collect_tests.jl
+++ b/test/collect_tests.jl
@@ -221,14 +221,6 @@ end
             @test !isfile("adata.csv")
             @test !isfile("mdata.csv")
 
-            offline_run!(model, 365 * 5;
-                when_model = each_year,
-                when = six_months,
-                backend = :arrow,
-                mdata = [:flag, :year],
-                adata = [(:weight, mean)],
-                writing_interval = 3
-            )
             # removing .arrow files after operating on them causes IO errors on Windows
             # so to make tests on Windows work we need to remove them when a new test
             # run occurs


### PR DESCRIPTION
Actually there are current problems with tempfile locking in Windows for Arrow.jl, indeed some tests are not enabled in Arrow.jl for Windows in that repo. I also remembered that offline_run! worked fine for me, there was just a problem in deleting the file during tests but not when using from the external of the package (now I understand that this is due to this locking problem). So I think that we can anyway enable the backend also in Windows so that users can benefit from it.

See https://github.com/apache/arrow-julia/pull/361



