### PR TITLE
Faster reservoir sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ _We tried to deprecate every major change, resulting in practically no breakage 
 - Two new functions `random_id_in_position` and `random_agent_in_position` can be used to select a random id/agent in a position in discrete spaces (even with filtering).
 - A new function `swap_agents` can be used to swap an agents couple in a discrete space.
 - A new argument `alloc` can be used to select a more performant version in relation to the expensiveness of the filtering for all random methods selecting ids/agents/positions.
-- The `random_agent` function is now much faster than before.
+- The `random_agent` function is now much faster than before. The functions `random_nearby_position`, `random_nearby_id` and `random_nearby_agent` are up to 2 times faster thanks to a faster sampling function.
 - The `sample!` function is up to 2x faster than before.
 - Grid and continuous spaces support boundaries with mixed periodicity, specified by tuples with a `Bool` value for each dimension, e.g. `GridSpace((5,5); periodic=(true,false))` is periodic along the first dimension but not along the second.
 

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -430,20 +430,21 @@ end
 # Reservoir sampling function (https://en.wikipedia.org/wiki/Reservoir_sampling)
 function resorvoir_sampling_single(iter, model)
     res = iterate(iter)
-    isnothing(res) && return nothing                       # `iterate` returns `nothing` when it ends
+    isnothing(res) && return nothing
     rng = abmrng(model)
+    el, state = res
     w = rand(rng)
     while true
-        choice, state = res                                # random position to return, and the state of the iterator
-        skip_counter = floor(log(rand(rng)) / log(1 - w))  # skip entries in the iterator
+        skip_counter = ceil(Int, randexp(rng)/log(1-w))
         while skip_counter != 0
             skip_res = iterate(iter, state)
-            isnothing(skip_res) && return choice
+            isnothing(skip_res) && return el
             state = skip_res[2]
-            skip_counter -= 1
+            skip_counter += 1
         end
         res = iterate(iter, state)
-        isnothing(res) && return choice
+        isnothing(res) && return el
+        el, state = res
         w *= rand(rng)
     end
 end

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -401,9 +401,8 @@ function sampling_with_condition_single(iter, condition, model)
     population = collect(iter)
     n = length(population)
     rng = abmrng(model)
-    indices = 1:n
     @inbounds while n != 0
-        index_id = rand(rng, indices)
+        index_id = rand(rng, 1:n)
         el = population[index_id]
         condition(el) && return el
         population[index_id], population[n] = population[n], population[index_id]
@@ -418,9 +417,8 @@ function sampling_with_condition_agents_single(iter, condition, model)
     population = collect(iter)
     n = length(population)
     rng = abmrng(model)
-    indices = 1:n
     @inbounds while n != 0
-        index_id = rand(rng, indices)
+        index_id = rand(rng, 1:n)
         el = population[index_id]
         condition(model[el]) && return model[el]
         population[index_id], population[n] = population[n], population[index_id]

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -401,8 +401,9 @@ function sampling_with_condition_single(iter, condition, model)
     population = collect(iter)
     n = length(population)
     rng = abmrng(model)
+    indices = 1:n
     @inbounds while n != 0
-        index_id = rand(rng, 1:n)
+        index_id = rand(rng, indices)
         el = population[index_id]
         condition(el) && return el
         population[index_id], population[n] = population[n], population[index_id]
@@ -417,8 +418,9 @@ function sampling_with_condition_agents_single(iter, condition, model)
     population = collect(iter)
     n = length(population)
     rng = abmrng(model)
+    indices = 1:n
     @inbounds while n != 0
-        index_id = rand(rng, 1:n)
+        index_id = rand(rng, indices)
         el = population[index_id]
         condition(model[el]) && return model[el]
         population[index_id], population[n] = population[n], population[index_id]


### PR DESCRIPTION
This is faster, as some benchmark show, same code and metodology of #788 

before

```julia
julia> @benchmark random_nearby_position($(50,50), $model, $1)
BenchmarkTools.Trial: 10000 samples with 958 evaluations.
 Range (min … max):   94.749 ns …  1.410 μs  ┊ GC (min … max): 0.00% … 90.62%
 Time  (median):     100.439 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   102.630 ns ± 32.078 ns  ┊ GC (mean ± σ):  0.74% ±  2.21%

             ▁▄▇▇██▆▃▁                                          
  ▁▁▁▁▁▁▂▂▃▅▇█████████▇▅▄▃▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▃▃▂▂▂▂▂▂▂▁▂▁ ▃
  94.7 ns         Histogram: frequency by time          115 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.

julia> @benchmark random_nearby_position($(50,50), $model, $10)
BenchmarkTools.Trial: 10000 samples with 182 evaluations.
 Range (min … max):  594.137 ns … 823.137 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     639.610 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   640.772 ns ±  18.826 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                 ▃▃▄▆▅▆▆▅▆▇▆█▇▆▆▆▆▅▅▃▃▁▁                         
  ▁▁▁▁▂▂▂▃▃▄▅▇▇███████████████████████████▇▆▅▄▄▃▃▃▂▂▂▂▂▂▂▁▂▁▁▁▁ ▅
  594 ns           Histogram: frequency by time          698 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.
```


after

```julia
julia> @benchmark random_nearby_position($(50,50), $model, $1)
BenchmarkTools.Trial: 10000 samples with 962 evaluations.
 Range (min … max):  89.899 ns …  2.274 μs  ┊ GC (min … max): 0.00% … 93.24%
 Time  (median):     96.220 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   98.950 ns ± 34.391 ns  ┊ GC (mean ± σ):  0.79% ±  2.22%

           ▂▅███▄▁                                             
  ▂▂▁▂▂▂▃▅▇████████▆▅▄▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂ ▃
  89.9 ns         Histogram: frequency by time         118 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.

julia> @benchmark random_nearby_position($(50,50), $model, $10)
BenchmarkTools.Trial: 10000 samples with 359 evaluations.
 Range (min … max):  265.178 ns …  3.143 μs  ┊ GC (min … max): 0.00% … 87.86%
 Time  (median):     286.585 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   288.582 ns ± 40.748 ns  ┊ GC (mean ± σ):  0.19% ±  1.24%

                 ▁▁▃▃▆▇█▇▇▇▇▇▅▆▅▂▃▃▂▃▁▁▁ ▁▁                     
  ▂▁▁▂▂▂▂▂▃▃▃▄▅▆▇█████████████████████████████▆▆▅▅▅▄▄▃▃▃▃▃▃▃▂▃ ▅
  265 ns          Histogram: frequency by time          312 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.
```

This is based on the relationship between an exponential rv and the logarithm of a uniform rv

