### PR TITLE
Improve `Schedulers` docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ model is used automatically.
 - Two new functions `random_id_in_position` and `random_agent_in_position` can be used to select a random id/agent in a position in discrete spaces (even with filtering).
 - A new function `swap_agents` can be used to swap an agents couple in a discrete space.
 - The model time/step is tracked automatically, accessible through `abmtime(model)`.
+- New function `hasid`
 
 ## Performance Improvements
 
@@ -30,6 +31,10 @@ model is used automatically.
 - The `random_agent` function is now much faster than before. The functions `random_nearby_position`, `random_nearby_id` and `random_nearby_agent` are up to 2 times faster thanks to a faster sampling function.
 - The `nearby_agents` function for `ContinuousSpace` and `GridSpace` is now 1.5x faster than before.
 - The `sample!` function is much faster than before.
+
+## Deprecations
+
+- `schedule(model, scheduler)` is deprecated. Use `scheduler(model)` directly.
 
 
 # v5.17

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -276,12 +276,15 @@ return df_agent, df_model
 (here `until` and `should_we_collect` are internal functions)
 
 ## [Schedulers](@id Schedulers)
+
 ```@docs
 Schedulers
 ```
 
 ### Predefined schedulers
+
 Some useful schedulers are available below as part of the Agents.jl API:
+
 ```@docs
 Schedulers.fastest
 Schedulers.ByID

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,6 +46,7 @@ random_agent
 nagents
 allagents
 allids
+hasid
 abmproperties
 abmrng
 abmscheduler

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -279,6 +279,7 @@ return df_agent, df_model
 
 ```@docs
 Schedulers
+schedule
 ```
 
 ### Predefined schedulers

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -3,7 +3,7 @@
 # All methods, whose defaults won't apply, must be extended
 # during the definition of a new ABM type.
 export AgentBasedModel, ABM
-export abmrng, abmscheduler, abmspace, abmtime, abmproperties
+export abmrng, abmscheduler, abmspace, abmtime, abmproperties, hasid
 
 ###########################################################################################
 # %% Fundamental type definitions
@@ -52,6 +52,7 @@ interface (see below). `ABM` is an alias to `AgentBasedModel`.
   It is strongly recommended to give `abmrng(model)` to all calls to `rand` and similar
   functions, so that reproducibility can be established in your modelling workflow.
 - `allids(model)/allagents(model)` returns an iterator over all IDs/agents in the model.
+- `hasid(model, id)` returns `true` if the model has an agent with given `id`.
 
 `AgentBasedModel` defines an extendable interface composed of the above syntax as well
 as a few more additional functions described in the Developer's Docs.
@@ -144,6 +145,15 @@ function Base.setproperty!(m::ABM, s::Symbol, x)
         throw(exception)
     end
 end
+
+"""
+    hasid(model, id::Int) → true/false
+    hasid(model, agent::AbstractAgent) → true/false
+
+Return `true` if the `model` has an agent with given `id` or has the given `agent`.
+"""
+hasid(model, id) = haskey(agent_container(model), id)
+hasid(model, a::AbstractAgent) = hasid(model, a.id)
 
 ###########################################################################################
 # %% Mandatory methods - internal

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -152,7 +152,8 @@ end
 
 Return `true` if the `model` has an agent with given `id` or has the given `agent`.
 """
-hasid(model, id) = haskey(agent_container(model), id)
+hasid(model, id::Int) = haskey(agent_container(model), id)
+hasid(model::VecABM, id::Int) = id ≤ nagents(model)
 hasid(model, a::AbstractAgent) = hasid(model, a.id)
 
 ###########################################################################################

--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -153,7 +153,7 @@ end
 Return `true` if the `model` has an agent with given `id` or has the given `agent`.
 """
 hasid(model, id::Int) = haskey(agent_container(model), id)
-hasid(model::VecABM, id::Int) = id ≤ nagents(model)
+# vector version is extended in the model_accessing_API.jl
 hasid(model, a::AbstractAgent) = hasid(model, a.id)
 
 ###########################################################################################

--- a/src/core/model_accessing_API.jl
+++ b/src/core/model_accessing_API.jl
@@ -1,4 +1,3 @@
-
 const DictABM = Union{StandardABM{S,A,Dict{Int,A}} where {S,A},
                       EventQueueABM{S,A,Dict{Int,A}} where {S,A}}
 const VecABM = Union{StandardABM{S,A,Vector{A}} where {S,A},
@@ -6,6 +5,7 @@ const VecABM = Union{StandardABM{S,A,Vector{A}} where {S,A},
 
 nextid(model::DictABM) = getfield(model, :maxid)[] + 1
 nextid(model::VecABM) = nagents(model) + 1
+hasid(model::VecABM, id::Int) = id ≤ nagents(model)
 
 function add_agent_to_model!(agent::AbstractAgent, model::DictABM)
     if haskey(agent_container(model), agent.id)

--- a/src/core/model_standard.jl
+++ b/src/core/model_standard.jl
@@ -100,6 +100,9 @@ functions during a single simulation step.
 In such a scenario, it is more sensible to provide only a model stepping function,
 where all the dynamics is contained within.
 
+Note that if you do not use the automated `agent_step!` option, you need to manually
+check for removed agents during evolution, using the [`hasid`](@ref) function.
+
 Here is an example:
 
 ```julia
@@ -112,6 +115,8 @@ function complex_model_step!(model)
     end
     intermediate_model_action!(model)
     for id in scheduler2(model)
+        # here `_step2!` may delete agents, so we check for it manually
+        hasid(model, id) || continue
         agent_step2!(model[id], model)
     end
     if model.step_counter % 100 == 0

--- a/src/core/model_standard.jl
+++ b/src/core/model_standard.jl
@@ -107,11 +107,11 @@ function complex_model_step!(model)
     # tip: these schedulers should be defined as properties of the model
     scheduler1 = Schedulers.Randomly()
     scheduler2 = user_defined_function_with_model_as_input
-    for id in schedule(model, scheduler1)
+    for id in scheduler1(model)
         agent_step1!(model[id], model)
     end
     intermediate_model_action!(model)
-    for id in schedule(model, scheduler2)
+    for id in scheduler2(model)
         agent_step2!(model[id], model)
     end
     if model.step_counter % 100 == 0

--- a/src/core/model_standard.jl
+++ b/src/core/model_standard.jl
@@ -115,7 +115,7 @@ function complex_model_step!(model)
     end
     intermediate_model_action!(model)
     for id in scheduler2(model)
-        # here `_step2!` may delete agents, so we check for it manually
+        # here `agent_step2!` may delete agents, so we check for it manually
         hasid(model, id) || continue
         agent_step2!(model[id], model)
     end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -375,6 +375,3 @@ end
 
 until(s, n::Int, model) = s < n
 until(s, f, model) = !f(model, s)
-
-schedule(model::ABM, scheduler) = Iterators.filter(id -> id in allids(model), scheduler(model))
-schedule(model::Agents.VecABM, scheduler) = scheduler(model)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,4 +1,3 @@
-
 # v6 deprecations
 
 # From before the move to an interface for ABMs and making `ABM` abstract.
@@ -85,7 +84,7 @@ end
 
 export add_agent_pos!
 function add_agent_pos!(agent::AbstractAgent, model::ABM)
-    @warn "`add_agent_pos(agent, model)` is deprecated in favor of `add_agent_own_pos(agent, model)`" 
+    @warn "`add_agent_pos(agent, model)` is deprecated in favor of `add_agent_own_pos(agent, model)`"
     add_agent_own_pos!(agent, model)
 end
 
@@ -369,7 +368,7 @@ end
 agent_step_field(model::ABM) = getfield(model, :agent_step)
 model_step_field(model::ABM) = getfield(model, :model_step)
 
-function UnremovableABM(args::Vararg{Any, N}; kwargs...) where {N} 
+function UnremovableABM(args::Vararg{Any, N}; kwargs...) where {N}
     @warn "UnremovableABM is deprecated. Use StandardABM(...; container = Vector, ...) instead."
     StandardABM(args...; kwargs..., container=Vector)
 end
@@ -377,3 +376,5 @@ end
 until(s, n::Int, model) = s < n
 until(s, f, model) = !f(model, s)
 
+schedule(model::ABM, scheduler) = Iterators.filter(id -> id in allids(model), scheduler(model))
+schedule(model::Agents.VecABM, scheduler) = scheduler(model)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -376,4 +376,7 @@ end
 until(s, n::Int, model) = s < n
 until(s, f, model) = !f(model, s)
 
-schedule(model::ABM, scheduler) = scheduler(model)
+function schedule(model::ABM, scheduler)
+    @warn "`schedule(model::ABM, scheduler)` deprecated in favor of `scheduler(model)`."
+    Iterators.filter(id -> id in allids(model), scheduler(model))
+end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -375,3 +375,5 @@ end
 
 until(s, n::Int, model) = s < n
 until(s, f, model) = !f(model, s)
+
+schedule(model::ABM, scheduler) = scheduler(model)

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -38,7 +38,7 @@ function step_ahead!(model::ABM, agent_step!, model_step!, n, t)
         !agents_first && model_step!(model)
         for id in schedule(model)
             # ensure we don't act on agent that doesn't exist
-            haskey(agent_container(model), id) || continue
+            hasid(model, id) || continue
             agent_step!(model[id], model)
         end
         agents_first && model_step!(model)
@@ -119,7 +119,7 @@ function process_event!(event_tuple, model)
     return
 end
 
-agent_was_removed(id, model::DictABM) = !haskey(agent_container(model), id)
+agent_was_removed(id, model::DictABM) = !hasid(model, id)
 agent_was_removed(::Int, ::VecABM) = false
 
 until(t1, t0, n::Real, ::ABM) = t1 < t0+n

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -23,7 +23,7 @@ for, starting from the model's initial time.
 
 See also [Advanced stepping](@ref).
 """
-function CommonSolve.step!(model::ABM, n::Union{Real, Function} = 1)
+function CommonSolve.step!(model::StandardABM, n::Union{Real, Function} = 1)
     agent_step! = agent_step_field(model)
     model_step! = model_step_field(model)
     t = getfield(model, :time)
@@ -31,21 +31,22 @@ function CommonSolve.step!(model::ABM, n::Union{Real, Function} = 1)
     return model
 end
 
-function step_ahead!(model::ABM, agent_step!, model_step!, n, t)
+function step_ahead!(model::StandardABM, agent_step!, model_step!, n, t)
     agents_first = getfield(model, :agents_first)
     t0 = t[]
     while until(t[], t0, n, model)
         !agents_first && model_step!(model)
         for id in schedule(model)
             # ensure we don't act on agent that doesn't exist
-            hasid(model, id) || continue
+            # (this condition can be skipped for `VecABM`)
+            model isa VecABM && (hasid(model, id) || continue)
             agent_step!(model[id], model)
         end
         agents_first && model_step!(model)
         t[] += 1
     end
 end
-function step_ahead!(model::ABM, agent_step!::typeof(dummystep), model_step!, n, t)
+function step_ahead!(model::StandardABM, agent_step!::typeof(dummystep), model_step!, n, t)
     t0 = t[]
     while until(t[], t0, n, model)
         model_step!(model)

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -37,6 +37,8 @@ function step_ahead!(model::ABM, agent_step!, model_step!, n, t)
     while until(t[], t0, n, model)
         !agents_first && model_step!(model)
         for id in schedule(model)
+            # ensure we don't act on agent that doesn't exist
+            haskey(agent_container(model), id) || continue
             agent_step!(model[id], model)
         end
         agents_first && model_step!(model)
@@ -71,14 +73,14 @@ function step_ahead!(queue, model_t, t::Real, model::EventQueueABM)
     while until(model_t[], t0, t, model)
         one_step!(queue, model_t, stop_time, model)
     end
-    return 
+    return
 end
 function step_ahead!(queue, model_t, f::Function, model::EventQueueABM)
     t0 = model_t[]
     while until(model_t[], t0, f, model)
         one_step!(queue, model_t, model)
     end
-    return 
+    return
 end
 
 function one_step!(queue, model_t, stop_time, model)

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -19,7 +19,7 @@ For discrete time models such as [`StandardABM`](@ref),
 
 Step the model forwards until `f(model, t)` returns `true`,
 where `t` is the current amount of time the model has been evolved
-for, starting from 0.
+for, starting from the model's initial time.
 
 See also [Advanced stepping](@ref).
 """

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -1,16 +1,14 @@
 export schedule, Schedulers
 
 """
-    schedule(model [, scheduler]) → ids
+    schedule(model::StandardABM) → ids
 
-If no `scheduler` is given, it returns an iterator over the scheduled IDs using the model's
-scheduler, otherwise it uses the given custom scheduler, which can be either a function which
-accepts `model` as argument or one of the already defined schedulers inside Agents.jl. See
-the [manual scheduling](@ref manual_scheduling) section for usage examples.
+Return an iterator over the scheduled IDs using the model's default scheduler.
 """
-schedule(model::ABM) = schedule(model, abmscheduler(model))
+schedule(model::ABM) = abmscheduler(model)(model)
+
+# Deprecated:
 schedule(model::ABM, scheduler) = Iterators.filter(id -> id in allids(model), scheduler(model))
-schedule(model::Agents.VecABM) = abmscheduler(model)(model)
 schedule(model::Agents.VecABM, scheduler) = scheduler(model)
 
 # Notice how the above lines are *outside* the submodule

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -7,10 +7,6 @@ Return an iterator over the scheduled IDs using the model's default scheduler.
 """
 schedule(model::ABM) = abmscheduler(model)(model)
 
-# Deprecated:
-schedule(model::ABM, scheduler) = Iterators.filter(id -> id in allids(model), scheduler(model))
-schedule(model::Agents.VecABM, scheduler) = scheduler(model)
-
 # Notice how the above lines are *outside* the submodule
 
 """

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -7,9 +7,6 @@ Return an iterator over the scheduled IDs using the model's default scheduler.
 """
 schedule(model::ABM) = abmscheduler(model)(model)
 
-schedule(model::ABM, scheduler) = Iterators.filter(id -> id in allids(model), scheduler(model))
-schedule(model::Agents.VecABM, scheduler) = scheduler(model)
-
 # Notice how the above lines are *outside* the submodule
 
 """

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -60,7 +60,7 @@ end
 """
     Schedulers.fastest
 
-A scheduler that orders all agent IDs once per step in the fastest way possible,
+A scheduler that orders all agent IDs in the fastest way possible,
 which is the default order dictaed by the agent container.
 """
 fastest(model::ABM) = allids(model)

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -16,7 +16,8 @@ Submodule containing all predefined schedulers of Agents.jl that can be used wit
 [`StandardABM`](@ref).
 
 Schedulers have a very simple interface. They are functions that take as an input the ABM and
-return an iterator over agent IDs. Notice that this iterator can be non-allocated specialized
+return an iterator over agent IDs: `f(model) -> iterator`.
+Notice that this iterator can be non-allocated specialized
 type or just a standard vector of IDs.
 
 Schedulers have many purposes:

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -7,6 +7,9 @@ Return an iterator over the scheduled IDs using the model's default scheduler.
 """
 schedule(model::ABM) = abmscheduler(model)(model)
 
+schedule(model::ABM, scheduler) = Iterators.filter(id -> id in allids(model), scheduler(model))
+schedule(model::Agents.VecABM, scheduler) = scheduler(model)
+
 # Notice how the above lines are *outside* the submodule
 
 """

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -61,7 +61,7 @@ end
     Schedulers.fastest
 
 A scheduler that orders all agent IDs in the fastest way possible,
-which is the default order dictaed by the agent container.
+which is the default order dictated by the agent container.
 """
 fastest(model::ABM) = allids(model)
 

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -19,13 +19,16 @@ Schedulers have a very simple interface. They are functions that take as an inpu
 return an iterator over agent IDs. Notice that this iterator can be non-allocated specialized
 type or just a standard vector of IDs.
 
-Schedulers have two purposes:
+Schedulers have many purposes:
 
 1. Can be given in [`StandardABM`](@ref) as a default scheduler.
    This functionality is only meaningful when the `agent_step!` has been configured.
    The function `abmscheduler(model)` will return the default scheduler of the model.
 2. Can be used by a user when performing [manual scheduling](@ref manual_scheduling)
    in case `agent_step!` has not been configured.
+3. Can be used to globally filter agents by type/property/whatever. For example,
+   one can use the [`ByProperty`](@ref) scheduler to simply obtain
+   the list of all agent IDs that satisfy a particular property.
 
 See also [Advanced scheduling](@ref) for making more advanced schedulers.
 """

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -58,15 +58,16 @@ end
 
 """
     Schedulers.fastest
-A scheduler that activates all agents once per step in the order dictated by the
-agent's container, which is arbitrary (the keys sequence of a dictionary).
-This is the fastest way to activate all agents once per step.
+
+A scheduler that orders all agent IDs once per step in the fastest way possible,
+which is the default order dictaed by the agent container.
 """
 fastest(model::ABM) = allids(model)
 
 """
     Schedulers.ByID()
-A scheduler that activates all agents at each step according to their id.
+
+A scheduler that orders all agent IDs by their integer value.
 """
 struct ByID
     ids::Vector{Int}
@@ -83,7 +84,8 @@ end
 
 """
     Schedulers.Randomly()
-A scheduler that activates all agents once per step in a random order.
+
+A scheduler that randomly orders all agent IDs.
 Different random ordering is used at each different step.
 """
 struct Randomly
@@ -98,8 +100,8 @@ end
 
 """
     Schedulers.Partially(p)
-A scheduler that at each step activates only `p` percentage of randomly
-chosen agents.
+
+A scheduler that orders only `p` percentage of randomly chosen agent IDs.
 """
 struct Partially{R<:Real}
     p::R
@@ -116,8 +118,9 @@ end
 
 """
     Schedulers.ByProperty(property)
-A scheduler that at each step activates the agents in an order dictated by
-their `property`, with agents with greater `property` acting first. `property` can be a
+
+A scheduler that orders agent IDs by their `property`, with agents with greater `property`
+being ordered first. `property` can be a
 `Symbol`, which just dictates which field of the agents to compare, or a function which
 inputs an agent and outputs a real number.
 """
@@ -149,16 +152,15 @@ end
 
 A scheduler useful only for mixed agent models using `Union` types.
 - Setting `shuffle_types = true` groups by agent type, but randomizes the type order.
-Otherwise returns agents grouped in order of appearance in the `Union`.
+  Otherwise returns agent IDs grouped in order of appearance in the `Union`.
 - `shuffle_agents = true` randomizes the order of agents within each group, `false` returns
-the default order of the container (equivalent to [`Schedulers.fastest`](@ref)).
+  the default order of the container (equivalent to [`Schedulers.fastest`](@ref)).
 - `agent_union` is a `Union` of all valid agent types (as passed to [`ABM`](@ref))
 
----
 
     Schedulers.ByType((C, B, A), shuffle_agents::Bool)
 
-A scheduler that activates agents by type in specified order (since
+A scheduler that orders agent IDs by type in specified order (since
 `Union`s are not order preserving). `shuffle_agents = true` randomizes the order of
 agents within each group.
 """

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -24,7 +24,7 @@ Schedulers have many purposes:
 
 1. Can be given in [`StandardABM`](@ref) as a default scheduler.
    This functionality is only meaningful when the `agent_step!` has been configured.
-   The function `abmscheduler(model)` will return the default scheduler of the model.
+   The function `schedule(model)` will return the scheduled IDs.
 2. Can be used by a user when performing [manual scheduling](@ref manual_scheduling)
    in case `agent_step!` has not been configured.
 3. Can be used to globally filter agents by type/property/whatever. For example,

--- a/test/api_tests.jl
+++ b/test/api_tests.jl
@@ -34,6 +34,10 @@ using StableRNGs
     @test add_agent!((7, 8), Agent1, model).pos == (7, 8)
     a = Agent1(model; pos = (9, 8))
     @test add_agent_own_pos!(a, model).pos == (9, 8)
+
+    @test hasid(model, 1)
+    @test hasid(model, a)
+    @test !hasid(model, 5)
 end
 
 @testset "add_agent! (nothing space)" begin
@@ -465,7 +469,7 @@ end
     @test nagents(model) == 3
     sample!(model, 2)
     @test nagents(model) == 2
-    
+
     f = F(1, 1)
     g = G(2, 2)
 
@@ -480,7 +484,7 @@ end
     @test E <: AbstractE && E <: AbstractE
     @test f isa E && g isa E
 
-    
+
     civ = Civilian1(; id = 2, pos = (2, 2), group = 2)
     gov = Governor1(; id = 3 , pos = (2, 2), group = 2, influence = 0.5)
     civ = Civilian2(; id = 2, pos = (2, 2), group = 2)


### PR DESCRIPTION
- All docstrings have been made "correct": they refer to ordering, and not scheduling, and they refer to the IDs, not the agents
- Deprecated using `schedule` with the non-default scheduler, as all schedulers are anyways functions of the model, there is no need to pipe them through `schedule`.
- Highlighted another usage for the schedulers
- Remove wording "once per step" from schedulers: this is clear from the `StandardABM` docstring. Furthermore, how many times scheduling happens in custom scheduling is unknown.