### PR TITLE
Faster sampling from small iterators

### DIFF
--- a/src/core/model_free_extensions.jl
+++ b/src/core/model_free_extensions.jl
@@ -87,7 +87,7 @@ function fallback_random_agent(model, condition, alloc)
     else
         iter_agents = allagents(model)
         iter_filtered = Iterators.filter(agent -> condition(agent), iter_agents)
-        agent = IteratorSampling.itsample(abmrng(model), iter_filtered)
+        agent = IteratorSampling.itsample(abmrng(model), iter_filtered; method=:alg_L)
         isnothing(agent) && return nothing
         return agent
     end

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -349,13 +349,13 @@ algorithm which doesn't require to collect all elements to just sample one of th
 function random_nearby_id(a, model, r = 1, f = nothing, alloc = false; kwargs...)
     iter = nearby_ids(a, model, r; kwargs...)
     if isnothing(f)
-        return IteratorSampling.itsample(abmrng(model), iter)
+        return IteratorSampling.itsample(abmrng(model), iter; method=:alg_R)
     else
         if alloc
             return sampling_with_condition_single(iter, f, model)
         else
             iter_filtered = Iterators.filter(id -> f(id), iter)
-            return IteratorSampling.itsample(abmrng(model), iter_filtered)
+            return IteratorSampling.itsample(abmrng(model), iter_filtered; method=:alg_R)
         end
     end
 end
@@ -378,13 +378,13 @@ position.
 function random_nearby_agent(a, model, r = 1, f = nothing, alloc = false; kwargs...)
     iter_ids = nearby_ids(a, model, r; kwargs...)
     if isnothing(f)
-        id = IteratorSampling.itsample(abmrng(model), iter_ids)
+        id = IteratorSampling.itsample(abmrng(model), iter_ids; method=:alg_R)
     else
         if alloc
             id = sampling_with_condition_single(iter_ids, f, model, id -> model[id])
         else
             iter_filtered = Iterators.filter(id -> f(model[id]), iter_ids)
-            id = IteratorSampling.itsample(abmrng(model), iter_filtered)
+            id = IteratorSampling.itsample(abmrng(model), iter_filtered; method=:alg_R)
         end
     end
     isnothing(id) && return nothing
@@ -406,13 +406,13 @@ is expensive since in this case the allocating version can be more performant.
 function random_nearby_position(pos, model, r=1, f = nothing, alloc = false; kwargs...)
     iter = nearby_positions(pos, model, r; kwargs...)
     if isnothing(f)
-        return IteratorSampling.itsample(abmrng(model), iter)
+        return IteratorSampling.itsample(abmrng(model), iter; method=:alg_R)
     else
         if alloc
             return sampling_with_condition_single(iter, f, model)
         else
             iter_filtered = Iterators.filter(pos -> f(pos), iter)
-            return IteratorSampling.itsample(abmrng(model), iter_filtered)
+            return IteratorSampling.itsample(abmrng(model), iter_filtered; method=:alg_R)
         end
     end
 end

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -151,7 +151,7 @@ function random_id_in_position(pos, model, f, alloc = false, transform = identit
         return sampling_with_condition_single(iter_ids, f, model, transform)
     else
         iter_filtered = Iterators.filter(id -> f(transform(id)), iter_ids)
-        id = IteratorSampling.itsample(abmrng(model), iter_filtered)
+        id = IteratorSampling.itsample(abmrng(model), iter_filtered; method=:alg_R)
         isnothing(id) && return nothing
         return id
     end

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -109,7 +109,7 @@ function random_empty(model::ABM{<:DiscreteSpace}, cutoff = 0.998)
         end
     else
         empty = empty_positions(model)
-        return IteratorSampling.itsample(abmrng(model), empty)
+        return IteratorSampling.itsample(abmrng(model), empty; method=:alg_L)
     end
 end
 

--- a/src/spaces/walk.jl
+++ b/src/spaces/walk.jl
@@ -206,7 +206,7 @@ function random_empty_pos_in_offsets(offsets, agent, model)
     end
     targets = Iterators.map(β -> normalize_position(agent.pos .+ β, model), offsets)
     empty_targets = Iterators.filter(pos -> isempty(pos, model), targets)
-    return IteratorSampling.itsample(abmrng(model), empty_targets)
+    return IteratorSampling.itsample(abmrng(model), empty_targets; method=:alg_R)
 end
 
 """


### PR DESCRIPTION
`:alg_R` is like 5x faster for small iterators than `:alg_L`, but slower with larger ones. So I applied one or the other depending on the probable scenario