### PR TITLE
Deprecate `as, am, ac` in favor of  `agent_size, agent_marker, agent_color`

### DIFF
--- a/examples/agents_visualizations.jl
+++ b/examples/agents_visualizations.jl
@@ -48,8 +48,8 @@ model
 # for the agents that depend on the agent properties, and
 # a size and marker style that are constants,
 daisycolor(a) = a.breed # agent color
-agent_size = 20    # agent size
-agent_marker = '✿'  # agent marker
+agent_size = 20
+agent_marker = '✿'
 agentsplotkwargs = (strokewidth = 1.0,) # add stroke around each agent
 fig, ax, abmobs = abmplot(model; ac = daisycolor, as, am, agentsplotkwargs)
 fig

--- a/examples/agents_visualizations.jl
+++ b/examples/agents_visualizations.jl
@@ -48,8 +48,8 @@ model
 # for the agents that depend on the agent properties, and
 # a size and marker style that are constants,
 daisycolor(a) = a.breed # agent color
-as = 20    # agent size
-am = '✿'  # agent marker
+agent_size = 20    # agent size
+agent_marker = '✿'  # agent marker
 agentsplotkwargs = (strokewidth = 1.0,) # add stroke around each agent
 fig, ax, abmobs = abmplot(model; ac = daisycolor, as, am, agentsplotkwargs)
 fig
@@ -65,7 +65,7 @@ fig
 heatarray = :temperature
 heatkwargs = (colorrange = (-20, 60), colormap = :thermal)
 plotkwargs = (;
-    ac = daisycolor, as, am,
+    agent_color = daisycolor, agent_size, agent_marker,
     agentsplotkwargs = (strokewidth = 1.0,),
     heatarray, heatkwargs
 )
@@ -283,5 +283,5 @@ agentsplotkwargs = (
     edge_plottype = :linesegments # needed for tapered edge widths
 )
 
-fig, ax, abmobs = abmplot(sir_model; as = city_size, ac = city_color, agentsplotkwargs)
+fig, ax, abmobs = abmplot(sir_model; agent_size = city_size, ac = city_color, agentsplotkwargs)
 fig

--- a/examples/celllistmap.jl
+++ b/examples/celllistmap.jl
@@ -214,8 +214,8 @@ abmvideo(
     "celllistmap.mp4", model;
     framerate=20, frames=200, spf=5,
     title="Softly bouncing particles with CellListMap.jl",
-    as=p -> p.r, # marker size
-    ac=p -> p.k # marker color
+    agent_size=p -> p.r,
+    agent_color=p -> p.k
 )
 
 # ```@raw html

--- a/examples/flock.jl
+++ b/examples/flock.jl
@@ -116,7 +116,7 @@ using CairoMakie
 CairoMakie.activate!() # hide
 
 # The great thing about [`abmplot`](@ref) is its flexibility. We can incorporate the
-# direction of the birds when plotting them, by making the "marker" function `am`
+# direction of the birds when plotting them, by making the "marker" function `agent_marker`
 # create a `Polygon`: a triangle with same orientation as the bird's velocity.
 # It is as simple as defining the following function:
 
@@ -129,16 +129,16 @@ end
 # Where we have used the utility functions `scale_polygon` and `rotate_polygon` to act on a
 # predefined polygon. `translate_polygon` is also available.
 # We now give `bird_marker` to `abmplot`, and notice how
-# the `as` keyword is meaningless when using polygons as markers.
+# the `agent_size` keyword is meaningless when using polygons as markers.
 
 model = initialize_model()
-figure, = abmplot(model; am = bird_marker)
+figure, = abmplot(model; agent_marker = bird_marker)
 figure
 
 # And let's also do a nice little video for it:
 abmvideo(
     "flocking.mp4", model;
-    am = bird_marker,
+    agent_marker = bird_marker,
     framerate = 20, frames = 150,
     title = "Flocking"
 )

--- a/examples/predator_prey.jl
+++ b/examples/predator_prey.jl
@@ -210,9 +210,9 @@ heatkwargs = (colormap = [:brown, :green], colorrange = (0, 1))
 
 # and put everything together and give it to [`abmplot`](@ref)
 plotkwargs = (;
-    ac = acolor,
-    as = 25,
-    am = ashape,
+    agent_color = acolor,
+    agent_size = 25,
+    agent_marker = ashape,
     offset,
     agentsplotkwargs = (strokewidth = 1.0, strokecolor = :black),
     heatarray = grasscolor,

--- a/examples/rabbit_fox_hawk.jl
+++ b/examples/rabbit_fox_hawk.jl
@@ -400,8 +400,8 @@ end
 #     figure = (size = (800, 700),),
 #     frames = 300,
 #     framerate = 15,
-#     ac = animalcolor,
-#     as = 1.0,
+#     agent_color = animalcolor,
+#     agent_size = 1.0,
 #     static_preplot!,
 #     title = "Rabbit Fox Hawk with pathfinding"
 # )

--- a/examples/schoolyard.jl
+++ b/examples/schoolyard.jl
@@ -145,7 +145,8 @@ model = schoolyard()
 using CairoMakie
 CairoMakie.activate!() # hide
 
-function static_preplot!(ax, p)
+const ABMPlot = Agents.get_ABMPlot_type()
+function Agents.static_preplot!(ax::Axis, p::ABMPlot)
     obj = CairoMakie.scatter!([50 50]; color = :red) # Show position of teacher
     CairoMakie.hidedecorations!(ax) # hide tick labels etc.
     CairoMakie.translate!(obj, 0, 0, 5) # be sure that the teacher will be above students
@@ -155,7 +156,6 @@ abmvideo(
     "schoolyard.mp4", model;
     framerate = 15, frames = 40,
     title = "Playgound dynamics",
-    static_preplot!,
 )
 
 # ```@raw html

--- a/examples/zombies.jl
+++ b/examples/zombies.jl
@@ -101,7 +101,7 @@ zombies = initialise_zombies()
 
 abmvideo("outbreak.mp4", zombies;
     title = "Zombie outbreak", framerate = 15, frames = 200,
-    ac = zombie_color, as = zombie_size
+    agent_color = zombie_color, agent_size = zombie_size
 )
 
 # ```@raw html

--- a/ext/AgentsVisualizations/src/abmplot.jl
+++ b/ext/AgentsVisualizations/src/abmplot.jl
@@ -72,6 +72,7 @@ function Agents.abmplot!(ax, abmobs::ABMObservable;
     if any(x -> x in keys(kwargs), [:as, :am, :ac])
         @warn "Keywords `as, am, ac` has been deprecated in favor of 
           `agent_size, agent_marker, agent_color`" maxlog=1
+    end
     if enable_space_checks
         if has_custom_space(abmobs.model[])
             Agents.check_space_visualization_API(abmobs.model[])

--- a/ext/AgentsVisualizations/src/abmplot.jl
+++ b/ext/AgentsVisualizations/src/abmplot.jl
@@ -69,6 +69,9 @@ function Agents.abmplot!(ax, abmobs::ABMObservable;
         enable_space_checks = true,
         kwargs...
     )
+    if any(x -> x in keys(kwargs), [:as, :am, :ac])
+        @warn "Keywords `as, am, ac` has been deprecated in favor of 
+          `agent_size, agent_marker, agent_color`" maxlog=1
     if enable_space_checks
         if has_custom_space(abmobs.model[])
             Agents.check_space_visualization_API(abmobs.model[])

--- a/ext/AgentsVisualizations/src/abmplot.jl
+++ b/ext/AgentsVisualizations/src/abmplot.jl
@@ -72,12 +72,14 @@ function Agents.abmplot!(ax, abmobs::ABMObservable;
     if any(x -> x in keys(kwargs), [:as, :am, :ac])
         @warn "Keywords `as, am, ac` has been deprecated in favor of 
           `agent_size, agent_marker, agent_color`" maxlog=1
+        kwargs = deprecate_asamac(kwargs)
     end
     if enable_space_checks
         if has_custom_space(abmobs.model[])
             Agents.check_space_visualization_API(abmobs.model[])
         end
     end
+
     _abmplot!(ax, abmobs; ax, add_controls, kwargs...)
 
     # Model inspection on mouse hover
@@ -108,9 +110,9 @@ This is the internal recipe for creating an `_ABMPlot`.
         ax=nothing,
 
         # Agent
-        ac=JULIADYNAMICS_COLORS[1],
-        as=15,
-        am=:circle,
+        agent_color=JULIADYNAMICS_COLORS[1],
+        agent_size=15,
+        agent_marker=:circle,
         offset=nothing,
         spaceplotkwargs = NamedTuple(),
         agentsplotkwargs = NamedTuple(),
@@ -140,7 +142,7 @@ function Makie.plot!(p::_ABMPlot)
     set_axis_limits!(ax, model)
 
     p.pos, p.color, p.marker, p.markersize = 
-        lift_attributes(p.abmobs[].model, p.ac, p.as, p.am, p.offset)
+        lift_attributes(p.abmobs[].model, p.agent_color, p.agent_size, p.agent_marker, p.offset)
 
     # gracefully handle deprecations of old plot kwargs
     merge_spaceplotkwargs!(p)

--- a/ext/AgentsVisualizations/src/deprecations.jl
+++ b/ext/AgentsVisualizations/src/deprecations.jl
@@ -29,3 +29,12 @@ function Agents.abmvideo(file, model, agent_step!, model_step! = Agents.dummyste
     end
     return nothing
 end
+
+function deprecate_asamac(kwargs)
+    kwargs = NamedTuple(kwargs)
+    new_kw = Dict(:as => :agent_size, :am => :agent_marker, :ac => :agent_color)
+    subs = filter(x -> x in keys(kwargs), [:as, :am, :ac])
+    kwargs_no_deprs = NamedTuple(p for p in pairs(kwargs) if !in(p[1], subs))
+    kwargs_no_deprs = (; kwargs_no_deprs..., (new_kw[x] => getfield(kwargs, x) for x in subs)...)
+    return kwargs_no_deprs
+end

--- a/ext/AgentsVisualizations/src/utils.jl
+++ b/ext/AgentsVisualizations/src/utils.jl
@@ -10,8 +10,8 @@ function Agents.check_space_visualization_API(::ABM{S}) where {S}
         hasmethod(agentsplot!, (Axis, ABMP{S})) ||
             hasmethod(agentsplot!, (Axis3, ABMP{S})),
         # Preplots (Optional)
-        hasmethod(spaceplot!, (Axis, ABMP{S}), (:ac, :am, :as)) ||
-            hasmethod(spaceplot!, (Axis3, ABMP{S}), (:ac, :am, :as)),
+        hasmethod(spaceplot!, (Axis, ABMP{S}), (:agent_color, :agent_marker, :agent_size)) ||
+            hasmethod(spaceplot!, (Axis3, ABMP{S}), (:agent_color, :agent_marker, :agent_size)),
         hasmethod(static_preplot!, (Axis, ABMP{S})) ||
             hasmethod(static_preplot!, (Axis3, ABMP{S})),
         # Lifting (optional)

--- a/src/visualizations.jl
+++ b/src/visualizations.jl
@@ -13,26 +13,26 @@ See also [`abmvideo`](@ref) and [`abmexploration`](@ref).
 ## Keyword arguments
 
 ### Agent related
-* `ac, as, am` : These three keywords decide the color, size, and marker, that
+* `agent_color, agent_size, agent_marker` : These three keywords decide the color, size, and marker, that
   each agent will be plotted as. They can each be either a constant or a *function*,
   which takes as an input a single agent and outputs the corresponding value. If the model
-  uses a `GraphSpace`, `ac, as, am` functions instead take an *iterable of agents* in each
+  uses a `GraphSpace`, `agent_color, agent_size, agent_marker` functions instead take an *iterable of agents* in each
   position (i.e. node of the graph).
 
-  Using constants: `ac = "#338c54", as = 15, am = :diamond`
+  Using constants: `agent_color = "#338c54", agent_size = 15, agent_marker = :diamond`
 
   Using functions:
   ```julia
-  ac(a) = a.status == :S ? "#2b2b33" : a.status == :I ? "#bf2642" : "#338c54"
-  as(a) = 10rand()
-  am(a) = a.status == :S ? :circle : a.status == :I ? :diamond : :rect
+  agent_color(a) = a.status == :S ? "#2b2b33" : a.status == :I ? "#bf2642" : "#338c54"
+  agent_size(a) = 10rand()
+  agent_marker(a) = a.status == :S ? :circle : a.status == :I ? :diamond : :rect
   ```
-  Notice that for 2D models, `am` can be/return a `Makie.Polygon` instance, which plots each agent
+  Notice that for 2D models, `agent_marker` can be/return a `Makie.Polygon` instance, which plots each agent
   as an arbitrary polygon. It is assumed that the origin (0, 0) is the agent's position when
   creating the polygon. In this case, the keyword `as` is meaningless, as each polygon has
   its own size. Use the functions `scale, rotate_polygon` to transform this polygon.
 
-  3D models currently do not support having different markers. As a result, `am` cannot be
+  3D models currently do not support having different markers. As a result, `agent_marker` cannot be
   a function. It should be a `Mesh` or 3D primitive (such as `Sphere` or `Rect3D`).
 * `offset = nothing` : If not `nothing`, it must be a function taking as an input an
   agent and outputting an offset position tuple to be added to the agent's position
@@ -320,18 +320,18 @@ function abmplot_heatobs end
 """
 function abmplot_pos end
 """
-  abmplot_colors(model::ABM{S}, ac)
-  abmplot_colors(model::ABM{S}, ac::Function)
+  abmplot_colors(model::ABM{S}, agent_color)
+  abmplot_colors(model::ABM{S}, agent_color::Function)
 """
 function abmplot_colors end
 """
-    abmplot_markers(model::ABM{S}, am, pos)
-    abmplot_markers(model::ABM{S}, am::Function, pos)
+    abmplot_markers(model::ABM{S}, agent_marker, pos)
+    abmplot_markers(model::ABM{S}, agent_marker::Function, pos)
 """
 function abmplot_markers end
 """
-    abmplot_markersizes(model::ABM{S}, as)
-    abmplot_markersizes(model::ABM{S}, as::Function)
+    abmplot_markersizes(model::ABM{S}, agent_size)
+    abmplot_markersizes(model::ABM{S}, agent_size::Function)
 """
 function abmplot_markersizes end
 


### PR DESCRIPTION
Closes #964 