### PR TITLE
Use Heap instead of PriorityQueue in EventQueueABM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "6.0.5"
+version = "6.0.6"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/examples/event_rock_paper_scissors.jl
+++ b/examples/event_rock_paper_scissors.jl
@@ -308,7 +308,7 @@ fig
 model = initialize_rps()
 abmvideo("rps_eventqueue.mp4", model;
     dt = 0.5, frames = 300,
-    title = "Rock Paper Scissors evolutionary (event based)", plotkw...,
+    title = "Rock Paper Scissors (event based)", plotkw...,
 )
 
 # ```@raw html

--- a/src/core/agents.jl
+++ b/src/core/agents.jl
@@ -375,6 +375,7 @@ function _multiagent(version, struct_repr)
                $expr
                $expr_multiagent
                $expr_multiagent_p
+               nothing
            end
 
     return expr

--- a/src/core/model_event_queue.jl
+++ b/src/core/model_event_queue.jl
@@ -167,7 +167,7 @@ function EventQueueABM(
     agents = C()
     I = events isa Tuple ? Int : keytype(events) # `Tuple` doesn't define `keytype`...
     # the queue stores pairs of (agent ID, event index) mapping them to their trigger time
-    queue = PriorityQueue{Tuple{I, Int}, Float64}()
+    queue = BinaryHeap(Base.By(last), Pair{Tuple{I, Int}, Float64}[])
 
     agent_kinds = allkinds(A)
     kind_to_index = Dict(kind => i for (i, kind) in enumerate(agent_kinds))
@@ -275,7 +275,7 @@ function add_event!(agent, model) # TODO: Study type stability of this function
 end
 
 function add_event!(agent::AbstractAgent, event_idx, t::Real, model::EventQueueABM)
-    enqueue!(abmqueue(model), (agent.id, event_idx) => t + abmtime(model))
+    push!(abmqueue(model), (agent.id, event_idx) => t + abmtime(model))
     return
 end
 

--- a/src/simulations/step_eventqueue.jl
+++ b/src/simulations/step_eventqueue.jl
@@ -33,10 +33,10 @@ function one_step!(queue, model_t, stop_time, model)
         model_t[] = stop_time
         return
     end
-    event_tuple, t_event = dequeue_pair!(queue)
+    event_tuple, t_event = pop!(queue)
     if t_event > stop_time
         model_t[] = stop_time
-        enqueue!(queue, event_tuple => t_event)
+        push!(queue, event_tuple => t_event)
     else
         model_t[] = t_event
         process_event!(event_tuple, model)
@@ -45,7 +45,7 @@ function one_step!(queue, model_t, stop_time, model)
 end
 function one_step!(queue, model_t, model)
     isempty(queue) && return
-    event_tuple, t_event = dequeue_pair!(queue)
+    event_tuple, t_event = pop!(queue)
     model_t[] = t_event
     process_event!(event_tuple, model)
     return


### PR DESCRIPTION
This makes RPS more than 2x faster! in general a `Heap` is more suitable than a `PriorityQueue` for this task, also it actually makes everything better because a `PriorityQueue` denied the use of duplicate times, which is actually something which could happen