### PR TITLE
Specify versions for Integration Libraries in Docs Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "6.0.6"
+version = "6.0.7"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -32,4 +32,9 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+BlackBoxOptim = "0.6"
+CellListMap = "0.8"
+DifferentialEquations = "7"
 Documenter = "1"
+Graphs = "1"
+Measurements = "2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -34,7 +34,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 BlackBoxOptim = "0.6"
 CellListMap = "0.8"
-DifferentialEquations = "7"
 Documenter = "1"
 Graphs = "1"
 Measurements = "2"
+OrdinaryDiffEq = "6"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -140,6 +140,26 @@ Any contribution to Agents.jl is welcome! For example you can:
 
 Have a look at [contributor's guide](https://github.com/SciML/ColPrac) of the SciML organization for some good information on contributing to Julia packages!
 
+## Citation
+
+If you use this package in work that leads to a publication, then please cite the paper below:
+
+```
+@article{Agents.jl,
+  doi = {10.1177/00375497211068820},
+  url = {https://doi.org/10.1177/00375497211068820},
+  year = {2022},
+  month = jan,
+  publisher = {{SAGE} Publications},
+  pages = {003754972110688},
+  author = {George Datseris and Ali R. Vahdati and Timothy C. DuBois},
+  title = {Agents.jl: a performant and feature-full agent-based modeling software of minimal code complexity},
+  journal = {{SIMULATION}},
+  volume = {0},
+  number = {0},
+}
+```
+
 ## Reproducibility
 
 ```@raw html
@@ -198,22 +218,3 @@ file.
 """)
 ```
 
-## Citation
-
-If you use this package in work that leads to a publication, then please cite the paper below:
-
-```
-@article{Agents.jl,
-  doi = {10.1177/00375497211068820},
-  url = {https://doi.org/10.1177/00375497211068820},
-  year = {2022},
-  month = jan,
-  publisher = {{SAGE} Publications},
-  pages = {003754972110688},
-  author = {George Datseris and Ali R. Vahdati and Timothy C. DuBois},
-  title = {Agents.jl: a performant and feature-full agent-based modeling software of minimal code complexity},
-  journal = {{SIMULATION}},
-  volume = {0},
-  number = {0},
-}
-```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -140,6 +140,64 @@ Any contribution to Agents.jl is welcome! For example you can:
 
 Have a look at [contributor's guide](https://github.com/SciML/ColPrac) of the SciML organization for some good information on contributing to Julia packages!
 
+## Reproducibility
+
+```@raw html
+<details><summary>The documentation of Agents.jl was built using these direct dependencies,</summary>
+```
+
+```@example
+using Pkg # hide
+Pkg.status() # hide
+```
+
+```@raw html
+</details>
+```
+
+```@raw html
+<details><summary>and using this machine and Julia version.</summary>
+```
+
+```@example
+using InteractiveUtils # hide
+versioninfo() # hide
+```
+
+```@raw html
+</details>
+```
+
+```@raw html
+<details><summary>A more complete overview of all dependencies and their versions is also provided.</summary>
+```
+
+```@example
+using Pkg # hide
+Pkg.status(; mode = PKGMODE_MANIFEST) # hide
+```
+
+```@raw html
+</details>
+```
+
+```@eval
+using TOML
+using Markdown
+version = TOML.parse(read("../../Project.toml", String))["version"]
+name = TOML.parse(read("../../Project.toml", String))["name"]
+link_manifest = "https://github.com/Agents/" * name * ".jl/tree/gh-pages/v" * version *
+                "/assets/Manifest.toml"
+link_project = "https://github.com/Agents/" * name * ".jl/tree/gh-pages/v" * version *
+               "/assets/Project.toml"
+Markdown.parse("""You can also download the
+[manifest]($link_manifest)
+file and the
+[project]($link_project)
+file.
+""")
+```
+
 ## Citation
 
 If you use this package in work that leads to a publication, then please cite the paper below:


### PR DESCRIPTION
This way we signal (a bit) the version with which the integration surely works for users, because if a major version is made could be problematic if the docs are not updated