### PR TITLE
Remove deprecated methods in version 5 rem_node!, add_node!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "6.0.7"
+version = "6.0.8"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -119,38 +119,7 @@ end
 #######################################################################################
 # Mutable graph functions
 #######################################################################################
-export rem_node!, add_node!, rem_vertex!, add_vertex!, add_edge!, rem_edge!
-
-"""
-     rem_node!(model::ABM{<: GraphSpace}, n::Int)
-Remove node (i.e. position) `n` from the model's graph. All agents in that node are removed from the model.
-**Warning:** Graphs.jl (and thus Agents.jl) swaps the index of the last node with
-that of the one to be removed, while every other node remains as is. This means that
- when doing `rem_node!(n, model)` the last node becomes the `n`-th node while the previous
- `n`-th node (and all its edges and agents) are deleted.
- """
- function rem_node!(model::ABM{<:GraphSpace}, n::Int)
-     for id in copy(ids_in_position(n, model))
-         remove_agent!(model[id], model)
-     end
-    V = nv(model)
-    success = Graphs.rem_vertex!(abmspace(model).graph, n)
-    n > V && error("Node number exceeds amount of nodes in graph!")
-    s = abmspace(model).stored_ids
-    s[V], s[n] = s[n], s[V]
-    pop!(s)
-end
-
-"""
-    add_node!(model::ABM{<: GraphSpace})
- Add a new node (i.e. possible position) to the model's graph and return it.
- You can connect this new node with existing ones using [`add_edge!`](@ref).
- """
- function add_node!(model::ABM{<:GraphSpace})
-     add_vertex!(abmspace(model).graph)
-     push!(abmspace(model).stored_ids, Int[])
-     return nv(model)
- end
+export rem_vertex!, add_vertex!, add_edge!, rem_edge!
 
 """
     rem_vertex!(model::ABM{<:GraphSpace}, n::Int)


### PR DESCRIPTION
We forgot to do this during transition to version 6 :( But they were deprecated in v5 so it can be fixed this way