### PR TITLE
Add OSM destination check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "6.0.8"
+version = "6.0.9"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -230,8 +230,10 @@ keywords are passed to
 [`LightOSM.shortest_path`](https://deloittedigitalapac.github.io/LightOSM.jl/docs/shortest_path/#LightOSM.shortest_path).
 
 Return `true` if a path to `dest` exists, and hence the route planning was successful.
-Otherwise return `false`. Specifying `return_trip = true` also requires the existence
-of a return path for a route to be planned.
+Otherwise return `false`. When `dest` is an invalid position, i.e. contains node indices
+that are not in the graph, or if the distance along the road is not between zero and the
+length of the road, return `false` as well. Specifying `return_trip = true` also requires
+the existence of a return path for a route to be planned.
 """
 function Agents.plan_route!(
         agent::AbstractAgent,

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -230,10 +230,12 @@ keywords are passed to
 [`LightOSM.shortest_path`](https://deloittedigitalapac.github.io/LightOSM.jl/docs/shortest_path/#LightOSM.shortest_path).
 
 Return `true` if a path to `dest` exists, and hence the route planning was successful.
-Otherwise return `false`. When `dest` is an invalid position, i.e. contains node indices
-that are not in the graph, or if the distance along the road is not between zero and the
-length of the road, return `false` as well. Specifying `return_trip = true` also requires
-the existence of a return path for a route to be planned.
+Otherwise return `false`. When `dest` is an invalid position, i.e. if it contains node
+indices that are not in the graph, or if the distance along the road is not between zero an
+the length of the road, return `false` as well. 
+
+Specifying `return_trip = true` also requires the existence of a return path for a route to
+be planned.
 """
 function Agents.plan_route!(
         agent::AbstractAgent,

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -509,16 +509,14 @@ function lonlat(pos::Tuple{Int,Int,Float64}, model::ABM{<:OpenStreetMapSpace})
     # extra checks to ensure consistency between both versions of `lonlat`
     if pos[3] == 0.0 || pos[1] == pos[2]
         return lonlat(pos[1], model)
-    elseif pos[3] == 1.0
+    elseif pos[3] == road_length(pos, model)
         return lonlat(pos[2], model)
     else
-        # find the geolocation that is a fraction `pos[3]` along the straight
-        # line between `pos[1]` and `pos[2]`
         gloc1 = get_geoloc(pos[1], model)
         gloc2 = get_geoloc(pos[2], model)
         dist = norm(LightOSM.to_cartesian(gloc1) .- LightOSM.to_cartesian(gloc2))
         dir = heading(gloc1, gloc2)
-        geoloc = calculate_location(gloc1, dir, pos[3] * dist)
+        geoloc = calculate_location(gloc1, dir, pos[3] / road_length(pos, model) * dist)
         return (geoloc.lon, geoloc.lat)
     end
 end

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -502,14 +502,16 @@ function lonlat(pos::Tuple{Int,Int,Float64}, model::ABM{<:OpenStreetMapSpace})
     # extra checks to ensure consistency between both versions of `lonlat`
     if pos[3] == 0.0 || pos[1] == pos[2]
         return lonlat(pos[1], model)
-    elseif pos[3] == road_length(pos, model)
+    elseif pos[3] == 1.0
         return lonlat(pos[2], model)
     else
+        # find the geolocation that is a fraction `pos[3]` along the straight
+        # line between `pos[1]` and `pos[2]`
         gloc1 = get_geoloc(pos[1], model)
         gloc2 = get_geoloc(pos[2], model)
         dist = norm(LightOSM.to_cartesian(gloc1) .- LightOSM.to_cartesian(gloc2))
         dir = heading(gloc1, gloc2)
-        geoloc = calculate_location(gloc1, dir, pos[3] / road_length(pos, model) * dist)
+        geoloc = calculate_location(gloc1, dir, pos[3] * dist)
         return (geoloc.lon, geoloc.lat)
     end
 end

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -231,7 +231,7 @@ keywords are passed to
 
 Return `true` if a path to `dest` exists, and hence the route planning was successful.
 Otherwise return `false`. When `dest` is an invalid position, i.e. if it contains node
-indices that are not in the graph, or if the distance along the road is not between zero an
+indices that are not in the graph, or if the distance along the road is not between zero and
 the length of the road, return `false` as well. 
 
 Specifying `return_trip = true` also requires the existence of a return path for a route to

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -241,6 +241,7 @@ function Agents.plan_route!(
         kwargs...
     )
 
+    isa_valid_position(dest, model) || return false
     delete!(abmspace(model).routes, agent.id) # clear old route
     same_position(agent.pos, dest, model) && return true
 
@@ -366,6 +367,12 @@ function Agents.plan_route!(
         return_trip,
     )
     return true
+end
+
+function isa_valid_position(pos::Tuple{Int,Int,Float64}, model::ABM{<:OpenStreetMapSpace})
+    index_to_node = abmspace(model).map.index_to_node
+    return haskey(index_to_node, pos[1]) && haskey(index_to_node, pos[2]) &&
+        0.0 ≤ pos[3] ≤ road_length(pos, model)
 end
 
 # Allows passing destination as a node number

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -65,6 +65,18 @@ end
 
         @test OSM.road_length(model[1].pos, model) ≈ 0.0002591692620559716
         @test OSM.road_length(finish_road[1], finish_road[2], model) ≈ 0.00030269737299400725
+
+        # Test that if the destination is invalid, route planning fails (returns `false``)
+        @testset "test invalid destination: $dest" for dest in (
+            # Distance along road is greater than the length of the road:
+            (finish_road[1], finish_road[2], 1.2 * OSM.road_length(finish_road, model)),
+            # Distance along road is negative:
+            (finish_road[1], finish_road[2], -1.0),
+            # Road does not exist:
+            (finish_road[1], Graphs.nv(abmspace(model).map.graph) + 1, 0.5)
+        )
+            @test !plan_route!(model[1], dest, model)
+        end
     end
 
     @testset "Moving along routes" begin

--- a/test/osm_tests.jl
+++ b/test/osm_tests.jl
@@ -66,7 +66,7 @@ end
         @test OSM.road_length(model[1].pos, model) ≈ 0.0002591692620559716
         @test OSM.road_length(finish_road[1], finish_road[2], model) ≈ 0.00030269737299400725
 
-        # Test that if the destination is invalid, route planning fails (returns `false``)
+        # Test that if the destination is invalid, route planning fails (returns `false`)
         @testset "test invalid destination: $dest" for dest in (
             # Distance along road is greater than the length of the road:
             (finish_road[1], finish_road[2], 1.2 * OSM.road_length(finish_road, model)),


### PR DESCRIPTION
It is possible to plan a route to a destination `dest` for which `dest[3]` is not between zero and `road_length(dest[1], dest[2], model)`, which is not caught by the subsequent shortest path algorithm. When such a route is executed, the agent will snap to a position that is not on the graph after completing the route.

With this PR, we check that the destination is valid and if it is not, we exit the `plan_route!` function early and return `false`.

Discovered in #1023.