### PR TITLE
Fix broken link in documentation

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,7 +65,7 @@ abmtime
 abmevents
 ```
 
-## [Available spaces](@ref available_spaces)
+## [Available spaces](@id available_spaces)
 
 Here we list the spaces that are available "out of the box" from Agents.jl. To create your own, see the developer documentation on [creating a new space type](@ref make_new_space).
 


### PR DESCRIPTION
In Step 1 of https://juliadynamics.github.io/Agents.jl/stable/tutorial/, it links to https://juliadynamics.github.io/Agents.jl/stable/tutorial/@ref%20available_spaces in the sentence "Agents.jl offers multiple spaces one can utilize to perform simulations, all of which are listed in the [available spaces section](https://juliadynamics.github.io/Agents.jl/stable/tutorial/@ref%20available_spaces).". This link is broken since the intended reference is using `@ref` instead of `@id`.