### PR TITLE
Error if deletion of agent fails

### DIFF
--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -139,6 +139,7 @@ function remove_agent_from_space!(
 )
     prev = abmspace(model).grid.stored_ids[cell_index...]
     ai = findfirst(i -> i == a.id, prev)
+    isnothing(ai) && error(lazy"Tried to remove $(a) from the space, but that agent is not on the space")
     deleteat!(prev, ai)
     return a
 end


### PR DESCRIPTION
This seems the only thing to improve in `remove_agent_from_space!` which could have been seen as a bug (but it is not), related to the issue in https://github.com/JuliaDynamics/Agents.jl/issues/841