### PR TITLE
Revert "Remove outdated warning about kwargs"

### DIFF
--- a/examples/agents_visualizations.jl
+++ b/examples/agents_visualizations.jl
@@ -48,6 +48,13 @@ fig, ax, abmobs = abmplot(model;
 )
 fig # returning the figure displays it
 
+# !!! note "Supported keyword arguments"
+#     We do not check internally, if the keyword arguments passed to `abmplot` are
+#     supported. Please make sure that there are no typos and that the used kwargs are
+#     supported by the [`abmplot`](@ref) function. Otherwise they will be ignored.
+#     This is an unfortunate consequence of how Makie.jl recipes work, and we believe
+#     that in the future this problem will be addressed in Makie.jl.
+
 # Besides agents, we can also plot spatial properties as a heatmap.
 # Here we plot the temperature of the planet by providing the name
 # of the property as the "heat array":


### PR DESCRIPTION
Reverts JuliaDynamics/Agents.jl#1084

Actually I'm wrong @Datseris, the warning is outdated _if_ it refers to typos inside `agentsplotkwargs` or `spaceplotkwargs`, but not if there are typos for kwargs to `abmplot` itself (e.g. `agentplotkwargs` instead of `agentsplotkwargs` won't warn...) I guess just keep it for now.