### PR TITLE
Fix dispatch for `remove_all_from_space!`

### DIFF
--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -61,7 +61,7 @@ In principle, the following should be done:
 6. Extend `nearby_ids(pos, model, r)`.
 7. Create a new "minimal" agent type to be used with [`@agent`](@ref) (see the source code of [`GraphAgent`](@ref) for an example).
 
-And that's it! Every function of the main API will now work. In some situations you might want to explicitly extend other functions such as `move_agent!` for performance reasons.
+And that's it! Every function of the main API will now work. In some situations you might want to explicitly extend other functions such as `move_agent!` or `remove_all_from_space!` for performance reasons.
 
 ### Visualization of a custom space
 

--- a/src/core/model_standard.jl
+++ b/src/core/model_standard.jl
@@ -175,6 +175,12 @@ function remove_all_from_model!(model::StandardABM)
     empty!(agent_container(model))
 end
 
+function remove_all_from_space!(model)
+    for a in allagents(model)
+        remove_agent_from_space!(a, model)
+    end
+end
+
 
 """
     dummystep(model)

--- a/src/spaces/discrete.jl
+++ b/src/spaces/discrete.jl
@@ -301,7 +301,7 @@ function swap_agents!(agent1, agent2, model::ABM{<:DiscreteSpace})
     return nothing
 end
 
-function remove_all_from_space!(model)
+function remove_all_from_space!(model::ABM{<:DiscreteSpace})
     for p in positions(model)
         empty!(ids_in_position(p, model))
     end

--- a/test/new_space_tests.jl
+++ b/test/new_space_tests.jl
@@ -1,0 +1,38 @@
+using Test, Agents
+
+@testset "create new space" begin
+    struct DummySpace <: Agents.AbstractSpace
+        ids::Set{Int}
+    end
+
+    DummySpace() = DummySpace(Set{Int}())
+
+    Agents.random_position(::ABM{<:DummySpace}) = nothing
+
+    function Agents.add_agent_to_space!(agent::Agents.AbstractAgent, model::ABM{<:DummySpace})
+        space = Agents.abmspace(model)
+        push!(space.ids, agent.id)
+        return agent
+    end
+
+    function Agents.remove_agent_from_space!(agent::Agents.AbstractAgent, model::ABM{<:DummySpace})
+        space = Agents.abmspace(model)
+        delete!(space.ids, agent.id)
+        return agent
+    end
+
+
+    @agent struct DummyAgent(NoSpaceAgent)
+        pos::Nothing
+    end
+
+    model = StandardABM(DummyAgent, DummySpace(); agent_step! = (a, m) -> a)
+
+    for i in 1:3
+        add_agent!(DummyAgent, model)
+        @test nagents(model) == i
+    end
+
+    remove_all!(model)
+    @test iszero(nagents(model))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,4 +169,5 @@ end
     include("csv_tests.jl")
     include("jld2_tests.jl")
     include("visualization_tests.jl")
+    include("new_space_tests.jl")
 end


### PR DESCRIPTION
This fixes #1104.
- Restrict the method in discrete.jl to discrete spaces
- Add a test that defines a new space as described in the dev docs and checks that adding and removing agents works. The test fails without the next step
- Add a generic fallback that makes the new test pass
- Add a note in the dev docs that this is a candidate to be overloaded for performance