### PR TITLE
Remove ismultiagenttype checks

### DIFF
--- a/src/core/model_event_queue.jl
+++ b/src/core/model_event_queue.jl
@@ -153,12 +153,6 @@ function EventQueueABM(
         autogenerate_on_add = true,
         autogenerate_after_action = true,
     ) where {A<:AbstractAgent,S<:SpaceType,P,R<:AbstractRNG}
-    if warn
-        @warn "This model type is still experimental which means that it is subject to breaking changes in the
-        future. Also, while all the core functionalities have been implemented, this model type
-        has some more limited features than `StandardABM`: in particular, visualizations and
-        IO functionalities are incomplete." maxlog=1
-    end
     C = construct_agent_container(container, A)
     agents = C()
     events = SizedVector{length(events), Union{typeof.(events)...}}(events...)

--- a/src/core/model_standard.jl
+++ b/src/core/model_standard.jl
@@ -152,7 +152,7 @@ function StandardABM(
         ABMObservable.
         """ maxlog=1
     end
-    !(ismultiagenttype(A)) && !(is_sumtype(A)) && agent_validator(A, space, warn)
+    !(is_sumtype(A)) && agent_validator(A, space, warn)
     C = construct_agent_container(container, A)
     agents = C()
     agents_types = union_types(A)

--- a/src/simulations/sample.jl
+++ b/src/simulations/sample.jl
@@ -104,11 +104,7 @@ function replicate!(agent::AbstractAgent, model; kwargs...)
 end
 
 function copy_agent(agent::A, model, id_new; kwargs...) where {A<:AbstractAgent}
-    # TODO: this first if statement should be removed as soon as @multiagent is removed
-    if ismultiagenttype(A)
-        args = ismultiagentsumtype(A) ? new_args_sum_t(agent, model; kwargs...) : new_args_t(agent, model; kwargs...)
-        newagent = variant_constructor(agent)(id_new, args...)
-    elseif is_sumtype(A)
+    if is_sumtype(A)
         args = new_args_sum_t(agent, model; kwargs...)
         newagent = A(variantof(agent)(id_new, args...))
     else

--- a/test/scheduler_tests.jl
+++ b/test/scheduler_tests.jl
@@ -229,31 +229,6 @@ end
           [Agent1, Agent1, Agent1, Agent0, Agent0, Agent0]
     @test all(x -> x < 4, s[1:3])
     @test all(x -> x > 3, s[4:6])
-
-    scheduler = Schedulers.ByKind((:G, :F); shuffle_kinds = false, shuffle_agents = false)
-    model = init_mixed_multiagent_model(scheduler)
-    s1 = collect(abmscheduler(model)(model))
-    s2 = collect(abmscheduler(model)(model))
-    @test length(s1) == length(s2) == 20
-    @test s1 == s2
-
-    scheduler = Schedulers.ByKind((:G, :F); shuffle_kinds = false, shuffle_agents = true)
-    model = init_mixed_multiagent_model(scheduler)
-    s1 = collect(abmscheduler(model)(model))
-    s2 = collect(abmscheduler(model)(model))
-    @test length(s1) == length(s2) == 20
-    @test s1 != s2
-    @test Set(s1) == Set(s2)
-    @test filter(id -> kindof(model[id]) == :F, s1) != filter(id -> kindof(model[id]) == :F, s2)
-
-    scheduler = Schedulers.ByKind((:G, :F); shuffle_kinds = true, shuffle_agents = true)
-    model = init_mixed_multiagent_model(scheduler)
-    s1 = collect(abmscheduler(model)(model))
-    s2 = collect(abmscheduler(model)(model))
-    @test length(s1) == length(s2) == 20
-    @test s1 != s2
-    @test Set(s1) == Set(s2)
-    @test filter(id -> kindof(model[id]) == :F, s1) != filter(id -> kindof(model[id]) == :F, s2)
 end
 
 @testset "Scheduler as struct" begin


### PR DESCRIPTION
Not needed anymore since we are abandoning the previous methodology for multiagent systems