### PR TITLE
Fix links (second round)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "6.2.6"
+version = "6.2.7"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -308,7 +308,7 @@ Schedulers.ByType
 Schedulers.ByKind
 ```
 
-### Advanced scheduling
+### [Advanced scheduling](@id advanced_scheduling)
 You can use [Function-like objects](https://docs.julialang.org/en/v1/manual/methods/#Function-like-objects) to make your scheduling possible of arbitrary events.
 For example, imagine that after the `n`-th step of your simulation you want to fundamentally change the order of agents. To achieve this you can define
 ```julia

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -132,7 +132,7 @@ normalize_position
 spacesize
 ```
 
-## Discrete space exclusives
+## [`DiscreteSpace` exclusives](@id DiscreteSpace_exclusives)
 ```@docs
 positions
 npositions

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -149,7 +149,7 @@ random_empty
 add_agent_single!
 move_agent_single!
 swap_agents!
-isempty(::Integer, ::ABM)
+isempty(::Int, ::ABM)
 ```
 
 ## `GraphSpace` exclusives
@@ -291,7 +291,7 @@ return df_agent, df_model
 
 ```@docs
 Schedulers
-schedule
+schedule(::ABM)
 ```
 
 ### Predefined schedulers

--- a/src/core/model_standard.jl
+++ b/src/core/model_standard.jl
@@ -93,7 +93,7 @@ The evolution rules are functions given to the keywords `agent_step!`, `model_st
 - `warn=true`: some type tests for `AgentType(s)` are done, and by default
   warnings are thrown when appropriate.
 
-## Advanced stepping
+## [Advanced stepping](@id advanced_stepping)
 
 Some advanced models may require special handling for scheduling, or may need to
 schedule agents several times and act on different subsets of agents with different

--- a/src/simulations/step.jl
+++ b/src/simulations/step.jl
@@ -22,7 +22,7 @@ Step the model forwards until `f(model, t)` returns `true`,
 where `t` is the current amount of time the model has been evolved
 for, starting from the model's initial time.
 
-See also [Advanced stepping](@ref).
+See also [Advanced stepping](@ref advanced_stepping).
 """
 function CommonSolve.step!(model::AgentBasedModel, args...)
     error(lazy"`step!` not implemented yet for model of type $(typeof(model)).")

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -17,8 +17,9 @@ Create a `GraphSpace` instance that is underlined by an arbitrary graph from
 arbitrary amount of agents, and each agent can move between the nodes of the graph.
 The position type for this space is `Int`, use [`GraphAgent`](@ref) for convenience.
 
-`Graphs.nv` and `Graphs.ne` can be used in a model with a `GraphSpace` to obtain
-the number of nodes or edges in the graph.
+`GraphSpace` inherits from `DiscreteSpace` and all functions for [`DiscreteSpace`](@ref DiscreteSpace_exclusives)
+are available. On top of that, `Graphs.nv` and `Graphs.ne` can be used in a model
+with a `GraphSpace` to obtain the number of nodes or edges in the graph.
 The underlying graph can be altered using [`add_vertex!`](@ref) and [`rem_vertex!`](@ref).
 
 An example using `GraphSpace` is [SIR model for the spread of COVID-19](@ref).

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -2,7 +2,7 @@ export OpenStreetMapSpace, OSMSpace, OSM, OSMAgent
 
 """
     OSM
-Submodule for functionality related to `OpenStreetMapSpace`.
+Submodule for functionality related to [`OpenStreetMapSpace`](@ref).
 See the docstring of the space for more info.
 """
 module OSM # OpenStreetMap

--- a/src/spaces/utilities.jl
+++ b/src/spaces/utilities.jl
@@ -4,8 +4,8 @@ export euclidean_distance, manhattan_distance, get_direction, spacesize
 """
     spacesize(model::ABM)
 
-Return the size of the model's space. Works for [`AbstractGridSpace`](@ref) and
-[`ContinuousSpace`](@ref).
+Return the size of the model's space. Works for [`GridSpace`](@ref),
+[`GridSpaceSingle`](@ref) and [`ContinuousSpace`](@ref).
 """
 spacesize(model::ABM) = spacesize(abmspace(model))
 

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -25,13 +25,13 @@ Schedulers have many purposes:
 1. Can be given in [`StandardABM`](@ref) as a default scheduler.
    This functionality is only meaningful when the `agent_step!` has been configured.
    The function `schedule(model)` will return the scheduled IDs.
-2. Can be used by a user when performing [manual scheduling](@ref Advanced_scheduling)
+2. Can be used by a user when performing [manual scheduling](@ref advanced_scheduling)
    in case `agent_step!` has not been configured.
 3. Can be used to globally filter agents by type/property/whatever. For example,
    one can use the [`ByProperty`](@ref) scheduler to simply obtain
    the list of all agent IDs that satisfy a particular property.
 
-See also [Advanced scheduling](@ref) for making more advanced schedulers.
+See also [Advanced scheduling](@ref advanced_scheduling) for making more advanced schedulers.
 """
 module Schedulers
 using Agents


### PR DESCRIPTION
Partially fix #1142

Don't know how to fix:
```
 89:6664: gent &lt;: AbstractAgent</code></pre><p>The minimal agent struct for usage with <a href="@ref OSM.OpenStreetMapSpace"><code>OpenStreetMapSpace</code></a>. It has an additional field <code>pos::
 95:697: , as an agent can truly be at any possible point on an existing road.</p><p>Use <a href="@ref OSM.OSMAgent"><code>OSMAgent</code></a> for convenience.</p><p><strong>Obtaining map files</strong>
131:4193: his map requires <code>network_type = :none</code> to be passed as a keyword to <a href="@ref OSM.OpenStreetMapSpace"><code>OpenStreetMapSpace</code></a>. The unit of distance used for this map
```

Not sure about the missing docstring for `isempty` and the resulting broken link:
`125:1191: position</code></a>, but specialized for <code>GridSpaceSingle</code>. See also <a href="@ref"><code>isempty</code></a>.</p></div><a class="docs-sourcelink" target="_blank" href="https://github`