### PR TITLE
Improve performance of nearby_positions for GridSpaces

### DIFF
--- a/src/spaces/grid_general.jl
+++ b/src/spaces/grid_general.jl
@@ -239,9 +239,8 @@ end
     @inbounds offset = iter.nindices[state]
     nearby_pos = iter.pos .+ offset
     # check if we are far from the wall to skip bounds checks
-    if iter.do_bounds
-        nearby_pos = checkbounds(Bool, iter.stored_ids, nearby_pos...) ? 
-            nearby_pos : mod1.(nearby_pos, iter.space_size)
+    if iter.do_bounds && !checkbounds(Bool, iter.stored_ids, nearby_pos...)
+        nearby_pos = mod1.(nearby_pos, iter.space_size)
     end
     return (nearby_pos, state + 1)
 end


### PR DESCRIPTION
I was a bit upset by the fact that our game of life at https://juliadynamics.github.io/AgentsExampleZoo.jl/dev/examples/game_of_life_2D_CA/#Conway's-game-of-life allocated, with this allocations disappear completely and the model is 2x faster