### PR TITLE
3d inspection fix

### DIFF
--- a/ext/AgentsVisualizations/src/spaces/abstract.jl
+++ b/ext/AgentsVisualizations/src/spaces/abstract.jl
@@ -124,35 +124,6 @@ function Makie.show_data(inspector::DataInspector,
     return true
 end
 
-# 3D space
-# function Makie.show_data(inspector::DataInspector,
-#     p::ABMP{<:Agents.AbstractSpace}, idx, source::MeshScatter)
-#     @info "show_data called for MeshScatter! idx=$idx"
-
-#     pos = Makie.position_on_plot(source, idx)
-#     @info "Position on plot: $pos"
-
-#     proj_pos = Makie.shift_project(Makie.parent_scene(p), pos)
-#     @info "Projected position: $proj_pos"
-
-#     Makie.update_tooltip_alignment!(inspector, proj_pos)
-
-#     model = p.abmobs[].model[]
-#     converted_pos = convert_element_pos(abmspace(model), pos)
-#     @info "Converted position: $converted_pos"
-
-#     agent_string = Agents.agent2string(model, converted_pos)
-#     @info "Agent string: $agent_string"
-
-#     a = inspector.plot.attributes
-#     a.text[] = agent_string
-#     a.visible[] = true
-
-#     @info "Tooltip visible: $(a.visible[]), Text: $(a.text[])"
-
-#     return true
-# end
-
 function Makie.show_data(inspector::DataInspector,
     p::Plot{AgentsVisualizations._abmplot, <:Tuple},
     idx::UInt32, source::MeshScatter)
@@ -165,7 +136,7 @@ function Makie.show_data(inspector::DataInspector,
         agent_id = agent_ids[agent_idx]
         agent = model[agent_id]
         
-        # Use existing Agents.jl functionality to handle multiple agents
+        # Use existing functionality to handle multiple agents
         a = inspector.plot.attributes
         a.text[] = Agents.agent2string(model, agent.pos)
         a.visible[] = true
@@ -182,13 +153,8 @@ function Makie.show_data(inspector::DataInspector,
 end
 
 function Agents.agent2string(model::ABM, pos)
-    @info "agent2string called with pos: $pos"
     ids = Agents.ids_to_inspect(model, pos)
-    
-    # Convert the iterator to an array
     ids_array = collect(ids)
-    @info "Found agent IDs: $ids_array"
-    
     s = ""
     for (i, id) in enumerate(ids_array)
         if i > 1
@@ -197,12 +163,10 @@ function Agents.agent2string(model::ABM, pos)
         s *= Agents.agent2string(model[id])
     end
 
-    @info "Final string: '$s'"
     return s
 end
 
 function Agents.agent2string(agent::A) where {A<:AbstractAgent}
-
     agentstring = "▶ $(nameof(A))\n"
 
     agentstring *= "id: $(getproperty(agent, :id))\n"

--- a/ext/AgentsVisualizations/src/spaces/abstract.jl
+++ b/ext/AgentsVisualizations/src/spaces/abstract.jl
@@ -154,9 +154,8 @@ end
 
 function Agents.agent2string(model::ABM, pos)
     ids = Agents.ids_to_inspect(model, pos)
-    ids_array = collect(ids)
     s = ""
-    for (i, id) in enumerate(ids_array)
+    for (i, id) in enumerate(ids)
         if i > 1
             s *= "\n"
         end

--- a/ext/AgentsVisualizations/src/spaces/abstract.jl
+++ b/ext/AgentsVisualizations/src/spaces/abstract.jl
@@ -124,6 +124,7 @@ function Makie.show_data(inspector::DataInspector,
     return true
 end
 
+# 3D space
 function Makie.show_data(inspector::DataInspector,
         p::ABMP{<:Agents.AbstractSpace}, idx, source::MeshScatter)
     pos = Makie.position_on_plot(source, idx)
@@ -164,6 +165,7 @@ end
 function Agents.agent2string(model::ABM, pos)
     ids = Agents.ids_to_inspect(model, pos)
     s = ""
+    
     for (i, id) in enumerate(ids)
         if i > 1
             s *= "\n"

--- a/ext/AgentsVisualizations/src/spaces/abstract.jl
+++ b/ext/AgentsVisualizations/src/spaces/abstract.jl
@@ -183,6 +183,6 @@ function Agents.agent2string(agent::A) where {A<:AbstractAgent}
     return agentstring
 end
 
-Agents.convert_element_pos(s::S, pos) where {S<:Agents.AbstractSpace} = Tuple(pos[1:length(s.dims)])
+Agents.convert_element_pos(s::S, pos) where {S<:Agents.AbstractSpace} = Tuple(pos[1:length(spacesize(s))])
 
 Agents.ids_to_inspect(model::ABM, pos) = ids_in_position(pos, model)

--- a/ext/AgentsVisualizations/src/spaces/abstract.jl
+++ b/ext/AgentsVisualizations/src/spaces/abstract.jl
@@ -183,6 +183,6 @@ function Agents.agent2string(agent::A) where {A<:AbstractAgent}
     return agentstring
 end
 
-Agents.convert_element_pos(::S, pos) where {S<:Agents.AbstractSpace} = Tuple(pos)
+Agents.convert_element_pos(s::S, pos) where {S<:Agents.AbstractSpace} = Tuple(pos[1:length(s.dims)])
 
 Agents.ids_to_inspect(model::ABM, pos) = ids_in_position(pos, model)

--- a/ext/AgentsVisualizations/src/spaces/abstract.jl
+++ b/ext/AgentsVisualizations/src/spaces/abstract.jl
@@ -158,28 +158,19 @@ function Makie.show_data(inspector::DataInspector,
     idx::UInt32, source::MeshScatter)
 
     model = p.abmobs[].model[]
-
-    # For meshscatter, each agent is represented by one marker instance
-    # The idx directly corresponds to the agent index in most cases
-    # But we should verify this with the actual data
-
-    # Get all agent IDs in the order they appear in the plot
     agent_ids = collect(allids(model))
-
-    # In Agents.jl, the meshscatter should have one marker per agent
-    # So idx should directly correspond to the agent index
     agent_idx = Int(idx)
 
     if agent_idx <= length(agent_ids)
         agent_id = agent_ids[agent_idx]
         agent = model[agent_id]
         
-        # Generate tooltip
+        # Use existing Agents.jl functionality to handle multiple agents
         a = inspector.plot.attributes
-        a.text[] = Agents.agent2string(agent)
+        a.text[] = Agents.agent2string(model, agent.pos)
         a.visible[] = true
         
-        # Position tooltip at the clicked point
+        # Position tooltip
         pos = Makie.position_on_plot(source, idx)
         proj_pos = Makie.shift_project(Makie.parent_scene(p), pos)
         Makie.update_tooltip_alignment!(inspector, proj_pos)

--- a/ext/AgentsVisualizations/src/spaces/continuous.jl
+++ b/ext/AgentsVisualizations/src/spaces/continuous.jl
@@ -40,22 +40,22 @@ end
 
 ## Inspection
 
-# Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos) =
-#     nearby_ids_exact(pos, model, 0.00001)
+Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos) =
+    nearby_ids_exact(pos, model, 0.00001)
 
 
-# Fixed implementation for 3D
-function Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos)
-    space = abmspace(model)
-    D = length(spacesize(space))
+# # Fixed implementation for 3D
+# function Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos)
+#     space = abmspace(model)
+#     D = length(spacesize(space))
 
-    if D == 3
-        # 3D plots in Makie use normalized coordinates
-        extent = space.extent
-        transformed_pos = ntuple(i -> (pos[i] + 1) * extent[i] / 2, D)
-        nearby_ids_exact(transformed_pos, model, 0.00001)
-    else
-        # 2D plots don't have this issue
-        nearby_ids_exact(pos, model, 0.00001)
-    end
-end
+#     if D == 3
+#         # 3D plots in Makie use normalized coordinates
+#         extent = space.extent
+#         transformed_pos = ntuple(i -> (pos[i] + 1) * extent[i] / 2, D)
+#         nearby_ids_exact(transformed_pos, model, 0.00001)
+#     else
+#         # 2D plots don't have this issue
+#         nearby_ids_exact(pos, model, 0.00001)
+#     end
+# end

--- a/ext/AgentsVisualizations/src/spaces/continuous.jl
+++ b/ext/AgentsVisualizations/src/spaces/continuous.jl
@@ -42,20 +42,3 @@ end
 
 Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos) =
     nearby_ids_exact(pos, model, 0.00001)
-
-
-# # Fixed implementation for 3D
-# function Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos)
-#     space = abmspace(model)
-#     D = length(spacesize(space))
-
-#     if D == 3
-#         # 3D plots in Makie use normalized coordinates
-#         extent = space.extent
-#         transformed_pos = ntuple(i -> (pos[i] + 1) * extent[i] / 2, D)
-#         nearby_ids_exact(transformed_pos, model, 0.00001)
-#     else
-#         # 2D plots don't have this issue
-#         nearby_ids_exact(pos, model, 0.00001)
-#     end
-# end

--- a/ext/AgentsVisualizations/src/spaces/continuous.jl
+++ b/ext/AgentsVisualizations/src/spaces/continuous.jl
@@ -40,5 +40,22 @@ end
 
 ## Inspection
 
-Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos) =
-    nearby_ids_exact(pos, model, 0.00001)
+# Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos) =
+#     nearby_ids_exact(pos, model, 0.00001)
+
+
+# Fixed implementation for 3D
+function Agents.ids_to_inspect(model::ABM{<:ContinuousSpace}, pos)
+    space = abmspace(model)
+    D = length(spacesize(space))
+
+    if D == 3
+        # 3D plots in Makie use normalized coordinates
+        extent = space.extent
+        transformed_pos = ntuple(i -> (pos[i] + 1) * extent[i] / 2, D)
+        nearby_ids_exact(transformed_pos, model, 0.00001)
+    else
+        # 2D plots don't have this issue
+        nearby_ids_exact(pos, model, 0.00001)
+    end
+end


### PR DESCRIPTION
Currently 3D hover inspection is broken.

Minimal non working example:
```
using Agents, Plots, Random, GLMakie

@agent struct Dummy(ContinuousAgent{3,Float64}) 
     speed::Float64
end

function setup(;
    n_agents = 100,
    extent = (100, 100, 100),
)
    space3d = ContinuousSpace(extent)
    model = StandardABM(Dummy, space3d; agent_step! = agent_step,
                        container = Vector, scheduler = Schedulers.Randomly(), rng = Xoshiro(314))
    for _ in 1:n_agents
        add_agent!(model,(1.,1.,1.),1.)
    end
    return model
end

function agent_step(dummy, model)
    move_agent!(dummy, model, dummy.speed)
end

model=setup()

fig, abmobs = abmexploration(model; agent_size=3)

fig
```
<img width="1312" alt="Screenshot 2025-05-20 at 11 56 11" src="https://github.com/user-attachments/assets/d6fc960c-8682-4219-a889-d3582490c6e7" />

Note that there's a visible arrow but none of the default inspection information.

I don't have a great understanding of Makie, but it seems like the issue had something to do with the way the position was being translated, and thus never recognizing any Agents in the position of the mouse. The changes I made fix this as minimally as I was able to, such that it avoids Bounds errors, and displays information of multiple agents if they're in the same position.

With the fix:
<img width="1312" alt="Screenshot 2025-05-20 at 11 55 26" src="https://github.com/user-attachments/assets/cb9a7904-0052-44dc-b55f-531309430617" />

If someone thinks there's a better way to do this, be my guest, but at least it works nows.

Note that this should be merged after #1159 
