### PR TITLE
Add getid function to retrieve the id of the agent

### DIFF
--- a/src/core/model_abstract.jl
+++ b/src/core/model_abstract.jl
@@ -147,7 +147,7 @@ Return `true` if the `model` has an agent with given `id` or has the given `agen
 """
 hasid(model, id::Int) = haskey(agent_container(model), id)
 # vector version is extended in the model_accessing_API.jl
-hasid(model, a::AbstractAgent) = hasid(model, a.id)
+hasid(model, a::AbstractAgent) = hasid(model, getid(a))
 
 ###########################################################################################
 # %% Mandatory methods - internal

--- a/src/core/model_accessing_API.jl
+++ b/src/core/model_accessing_API.jl
@@ -10,15 +10,15 @@ nextid(model::Union{VecABM, StructVecABM}) = nagents(model) + 1
 hasid(model::Union{VecABM, StructVecABM}, id::Int) = id ≤ nagents(model)
 
 function add_agent_to_container!(agent::AbstractAgent, container::AbstractDict)
-    if haskey(container, agent.id)
-        error(lazy"Can't add agent to container. There is already an agent with id=$(agent.id)")
+    if haskey(container, getid(agent))
+        error(lazy"Can't add agent to container. There is already an agent with id=$(getid(agent))")
     else
-        container[agent.id] = agent
+        container[getid(agent)] = agent
     end
 end
 
 function add_agent_to_container!(agent::AbstractAgent, container::AbstractVector)
-    agent.id != length(container) + 1 && error(lazy"Cannot add agent of ID $(agent.id) in a vector container of $(length(container)) agents. Expected ID == $(length(container)+1).")
+    getid(agent) != length(container) + 1 && error(lazy"Cannot add agent of ID $(getid(agent)) in a vector container of $(length(container)) agents. Expected ID == $(length(container)+1).")
     push!(container, agent)
 end
 
@@ -27,8 +27,8 @@ function add_agent_to_container!(agent::AbstractAgent, model::ABM)
     # Update maxid for DictABM
     if model isa DictABM
         maxid = getfield(model, :maxid)
-        if maxid[] < agent.id
-            maxid[] = agent.id
+        if maxid[] < getid(agent)
+            maxid[] = getid(agent)
         end
     end
     return
@@ -40,11 +40,11 @@ function extra_actions_after_add!(agent, model::EventQueueABM{S,A,<:Union{Abstra
     getfield(model, :autogenerate_on_add) && add_event!(agent, model)
 end
 function extra_actions_after_add!(agent, model::EventQueueABM{S,A,<:StructVector} where {S,A})
-    getfield(model, :autogenerate_on_add) && add_event!(model[agent.id], model)
+    getfield(model, :autogenerate_on_add) && add_event!(model[getid(agent)], model)
 end
 
 function remove_agent_from_container!(agent::AbstractAgent, model::DictABM)
-    delete!(agent_container(model), agent.id)
+    delete!(agent_container(model), getid(agent))
     return
 end
 function remove_agent_from_container!(agent::AbstractAgent, model::Union{VecABM, StructVecABM})
@@ -57,3 +57,5 @@ retrieve_agent(container, id::Int, ::Type) = container[id]
 
 random_id(model::DictABM) = rand(abmrng(model), agent_container(model)).first
 random_agent(model::DictABM) = rand(abmrng(model), agent_container(model)).second
+
+getid(agent) = agent.id

--- a/src/core/model_event_queue.jl
+++ b/src/core/model_event_queue.jl
@@ -264,7 +264,7 @@ function add_event!(agent, model) # TODO: Study type stability of this function
 end
 
 function add_event!(agent::AbstractAgent, event_idx, t::Real, model::EventQueueABM)
-    push!(abmqueue(model), (agent.id, event_idx) => t + abmtime(model))
+    push!(abmqueue(model), (getid(agent), event_idx) => t + abmtime(model))
     return
 end
 

--- a/src/core/space_interaction_API.jl
+++ b/src/core/space_interaction_API.jl
@@ -306,7 +306,7 @@ Same as `nearby_ids(agent.pos, model, r)` but the iterable *excludes* the given
 """
 function nearby_ids(agent::AbstractAgent, model::ABM, r = 1; kwargs...)
     all = nearby_ids(agent.pos, model, r; kwargs...)
-    Iterators.filter(i -> i ≠ agent.id, all)
+    Iterators.filter(i -> i ≠ getid(agent), all)
 end
 
 """

--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -460,10 +460,10 @@ function collect_agent_data!(df, model, properties::Vector, step::Int = 0; kwarg
         @warn "Passing the `step` argument to `collect_agent_data!` is deprecated,
              now `abmtime(model)` is used automatically" maxlog=1
     end
-    alla = sort!(collect(allagents(model)), by = a -> a.id)
+    alla = sort!(collect(allagents(model)), by = a -> getid(a))
     dd = DataFrame()
     dd[!, :time] = fill(abmtime(model), length(alla))
-    dd[!, :id] = map(a -> a.id, alla)
+    dd[!, :id] = map(a -> getid(a), alla)
     if :agent_type ∈ propertynames(df)
         dd[!, :agent_type] = map(a -> Symbol(typeof(a)), alla)
     end

--- a/src/spaces/continuous.jl
+++ b/src/spaces/continuous.jl
@@ -129,7 +129,7 @@ end
 
 function add_agent_to_space!(
     a::AbstractAgent, model::ABM{<:ContinuousSpace}, cell_index = pos2cell(a, model))
-    push!(abmspace(model).grid.stored_ids[cell_index...], a.id)
+    push!(abmspace(model).grid.stored_ids[cell_index...], getid(a))
     return a
 end
 
@@ -139,8 +139,8 @@ function remove_agent_from_space!(
     cell_index = pos2cell(a, model),
 )
     prev = abmspace(model).grid.stored_ids[cell_index...]
-    ai = findfirst(i -> i == a.id, prev)
-    isnothing(ai) && error(lazy"Tried to remove agent with ID $(a.id) from the space, but that agent is not on the space")
+    ai = findfirst(i -> i == getid(a), prev)
+    isnothing(ai) && error(lazy"Tried to remove agent with ID $(getid(a)) from the space, but that agent is not on the space")
     # we change the order, but this doesn't matter because we don't guarantee any
     # particular ordering for agents in a certain position
     prev[ai], prev[end] = prev[end], prev[ai]
@@ -439,7 +439,7 @@ function all_pairs!(
     for a in allagents(model)
         for nid in nearby_ids(a, model, r; search)
             # Sort the pair to overcome any uniqueness issues
-            new_pair = isless(a.id, nid) ? (a.id, nid) : (nid, a.id)
+            new_pair = isless(getid(a), nid) ? (getid(a), nid) : (nid, getid(a))
             new_pair ∉ pairs && push!(pairs, new_pair)
         end
     end
@@ -451,7 +451,7 @@ function true_pairs!(pairs::Vector{Tuple{Int,Int}}, model::ABM{<:ContinuousSpace
         nn = nearest_neighbor(a, model, r)
         nn === nothing && continue
         # Sort the pair to overcome any uniqueness issues
-        new_pair = isless(a.id, nn.id) ? (a.id, nn.id) : (nn.id, a.id)
+        new_pair = isless(getid(a), getid(nn)) ? (getid(a), getid(nn)) : (getid(nn), getid(a))
         if new_pair ∉ pairs
             # We also need to check if our current pair is closer to each
             # other than any pair using our first id already in the list,

--- a/src/spaces/graph.jl
+++ b/src/spaces/graph.jl
@@ -77,14 +77,14 @@ random_position(model::ABM{<:GraphSpace}) = rand(abmrng(model), 1:nv(model))
 function remove_agent_from_space!(a::AbstractAgent, model::ABM{<:GraphSpace})
     agentpos = a.pos
     ids = ids_in_position(agentpos, model)
-    ai = findfirst(id -> id == a.id, ids)
-    isnothing(ai) && error(lazy"Tried to remove agent with ID $(a.id) from the space, but that agent is not on the space")
+    ai = findfirst(id -> id == getid(a), ids)
+    isnothing(ai) && error(lazy"Tried to remove agent with ID $(getid(a)) from the space, but that agent is not on the space")
     deleteat!(ids, ai)
     return a
 end
 
 function add_agent_to_space!(agent::AbstractAgent, model::ABM{<:GraphSpace})
-    push!(ids_in_position(agent.pos, model), agent.id)
+    push!(ids_in_position(agent.pos, model), getid(agent))
     return agent
 end
 
@@ -107,7 +107,7 @@ end
 # This function is here purely because of performance reasons
 function nearby_ids(agent::AbstractAgent, model::ABM{<:GraphSpace}, r = 1; kwargs...)
     all = nearby_ids(agent.pos, model, r; kwargs...)
-    filter!(i -> i ≠ agent.id, all)
+    filter!(i -> i ≠ getid(agent), all)
 end
 
 function nearby_positions(

--- a/src/spaces/grid_multi.jl
+++ b/src/spaces/grid_multi.jl
@@ -89,13 +89,13 @@ end
 # %% Implementation of space API
 #######################################################################################
 function add_agent_to_space!(a::AbstractAgent, model::ABM{<:GridSpace})
-    push!(abmspace(model).stored_ids[a.pos...], a.id)
+    push!(abmspace(model).stored_ids[a.pos...], getid(a))
     return a
 end
 
 function remove_agent_from_space!(a::AbstractAgent, model::ABM{<:GridSpace})
     prev = abmspace(model).stored_ids[a.pos...]
-    ai = findfirst(i -> i == a.id, prev)
+    ai = findfirst(i -> i == getid(a), prev)
     isnothing(ai) && error(lazy"Tried to remove $(a) from the space, but that agent is not on the space")
     # we change the order, but this doesn't matter because we don't guarantee any
     # particular ordering for agents in a certain position

--- a/src/spaces/grid_single.jl
+++ b/src/spaces/grid_single.jl
@@ -45,7 +45,7 @@ end
 function add_agent_to_space!(a::AbstractAgent, model::ABM{<:GridSpaceSingle})
     pos = a.pos
     !isempty(pos, model) && error(lazy"Cannot add agent $(a) to occupied position $(pos)")
-    abmspace(model).stored_ids[pos...] = a.id
+    abmspace(model).stored_ids[pos...] = getid(a)
     return a
 end
 

--- a/src/spaces/openstreetmap.jl
+++ b/src/spaces/openstreetmap.jl
@@ -246,7 +246,7 @@ function Agents.plan_route!(
     )
 
     isa_valid_position(dest, model) || return false
-    delete!(abmspace(model).routes, agent.id) # clear old route
+    delete!(abmspace(model).routes, getid(agent)) # clear old route
     same_position(agent.pos, dest, model) && return true
 
     if same_road(agent.pos, dest)
@@ -257,7 +257,7 @@ function Agents.plan_route!(
             move_agent!(agent, get_reverse_direction(agent.pos, model), model)
             dest = get_reverse_direction(dest, model)
         end
-        abmspace(model).routes[agent.id] = OpenStreetMapPath(
+        abmspace(model).routes[getid(agent)] = OpenStreetMapPath(
             Int[],
             agent.pos,
             dest,
@@ -275,7 +275,7 @@ function Agents.plan_route!(
         if agent.pos[1] == agent.pos[2] # start at node
             end_node == dest[2] && (dest = get_reverse_direction(dest, model))
             move_agent!(agent, (dest[1], dest[2], 0.0), model)
-            abmspace(model).routes[agent.id] = OpenStreetMapPath(
+            abmspace(model).routes[getid(agent)] = OpenStreetMapPath(
                 Int[],
                 agent.pos,
                 dest,
@@ -287,7 +287,7 @@ function Agents.plan_route!(
         if dest[1] == dest[2] # end at node
             start_node == agent.pos[1] && move_agent!(agent, get_reverse_direction(agent.pos, model), model)
             dest = (agent.pos[1], agent.pos[2], road_length(agent.pos, model))
-            abmspace(model).routes[agent.id] = OpenStreetMapPath(
+            abmspace(model).routes[getid(agent)] = OpenStreetMapPath(
                 Int[],
                 agent.pos,
                 dest,
@@ -301,7 +301,7 @@ function Agents.plan_route!(
             move_agent!(agent, get_reverse_direction(agent.pos, model), model)
         end_node == dest[2] &&
             (dest = get_reverse_direction(dest, model))
-        abmspace(model).routes[agent.id] = OpenStreetMapPath(
+        abmspace(model).routes[getid(agent)] = OpenStreetMapPath(
             Int[start_node],
             agent.pos,
             dest,
@@ -363,7 +363,7 @@ function Agents.plan_route!(
         end
     end
 
-    abmspace(model).routes[agent.id] = OpenStreetMapPath(
+    abmspace(model).routes[getid(agent)] = OpenStreetMapPath(
         route,
         agent.pos,
         dest,
@@ -592,7 +592,7 @@ function road_length(p1::Int, p2::Int, model::ABM{<:OpenStreetMapSpace})
 end
 
 function Agents.is_stationary(agent::AbstractAgent, model::ABM{<:OpenStreetMapSpace})
-    return !haskey(abmspace(model).routes, agent.id)
+    return !haskey(abmspace(model).routes, getid(agent))
 end
 
 """
@@ -605,7 +605,7 @@ function route_length(agent::AbstractAgent, model::ABM{<:OpenStreetMapSpace})
     is_stationary(agent, model) && return 0.0
     prev_node, next_node = agent.pos
     length = road_length(prev_node, next_node, model)
-    for node in reverse(abmspace(model).routes[agent.id].route)
+    for node in reverse(abmspace(model).routes[getid(agent)].route)
         prev_node = next_node
         next_node = node
         length += road_length(prev_node, next_node, model)
@@ -731,7 +731,7 @@ function Agents.add_agent_to_space!(
         agent::AbstractAgent,
         model::ABM{<:OpenStreetMapSpace},
     )
-    push!(abmspace(model).s[agent.pos[1]], agent.id)
+    push!(abmspace(model).s[agent.pos[1]], getid(agent))
     return agent
 end
 
@@ -740,7 +740,7 @@ function Agents.remove_agent_from_space!(
         model::ABM{<:OpenStreetMapSpace},
     )
     prev = abmspace(model).s[agent.pos[1]]
-    ai = findfirst(i -> i == agent.id, prev)
+    ai = findfirst(i -> i == getid(agent), prev)
     deleteat!(prev, ai)
     return agent
 end
@@ -790,7 +790,7 @@ function Agents.move_along_route!(
     # It might be easier to formulate this as a recursive structure, so recursive calls are annotated where necessary
     # instead of the loop this currently runs in. These annotations are marked with `##` just to make it clear.
 
-    osmpath = abmspace(model).routes[agent.id]
+    osmpath = abmspace(model).routes[getid(agent)]
     while distance > 0.0
         # check if reached end
         if same_position(agent.pos, osmpath.dest, model)
@@ -802,7 +802,7 @@ function Agents.move_along_route!(
                 elseif osmpath.return_route[end] == agent.pos[1]
                     move_agent!(agent, get_reverse_direction(agent.pos, model), model)
                 end
-                osmpath = abmspace(model).routes[agent.id] = OpenStreetMapPath(
+                osmpath = abmspace(model).routes[getid(agent)] = OpenStreetMapPath(
                     osmpath.return_route,
                     agent.pos,
                     osmpath.start,
@@ -812,7 +812,7 @@ function Agents.move_along_route!(
                 continue
             end
 
-            delete!(abmspace(model).routes, agent.id)
+            delete!(abmspace(model).routes, getid(agent))
             break
         end
 

--- a/src/submodules/pathfinding/astar.jl
+++ b/src/submodules/pathfinding/astar.jl
@@ -219,7 +219,7 @@ Same, but for pathfinding with A*.
 Agents.is_stationary(
     agent::AbstractAgent,
     pathfinder::AStar,
-) = isempty(agent.id, pathfinder)
+) = isempty(getid(agent), pathfinder)
 
 """
     Pathfinding.penaltymap(pathfinder)
@@ -246,7 +246,7 @@ The same as `remove_agent!(agent, model)`, but also removes the agent's path dat
 from `pathfinder`.
 """
 function Agents.remove_agent!(agent::AbstractAgent, model::ABM, pathfinder::AStar)
-    delete!(pathfinder.agent_paths, agent.id)
+    delete!(pathfinder.agent_paths, getid(agent))
     Agents.remove_agent_from_container!(agent, model)
     Agents.remove_agent_from_space!(agent, model)
 end

--- a/src/submodules/pathfinding/astar_continuous.jl
+++ b/src/submodules/pathfinding/astar_continuous.jl
@@ -69,7 +69,7 @@ function Agents.plan_route!(
 ) where {D,P,M}
     path = find_continuous_path(pathfinder, agent.pos, dest)
     isnothing(path) && return
-    pathfinder.agent_paths[agent.id] = path
+    pathfinder.agent_paths[getid(agent)] = path
 end
 
 function Agents.plan_best_route!(
@@ -92,7 +92,7 @@ function Agents.plan_best_route!(
     end
 
     isnothing(best_target) && return
-    pathfinder.agent_paths[agent.id] = best_path
+    pathfinder.agent_paths[getid(agent)] = best_path
     return best_target
 end
 
@@ -112,19 +112,19 @@ function Agents.move_along_route!(
     speed::Float64,
     dt::Real = 1.0,
 ) where {D}
-    isempty(agent.id, pathfinder) && return
+    isempty(getid(agent), pathfinder) && return
     from = agent.pos
     next_pos = agent.pos
     T = typeof(agent.pos)
     while true
-        next_waypoint = T(first(pathfinder.agent_paths[agent.id]))
+        next_waypoint = T(first(pathfinder.agent_paths[getid(agent)]))
         dir = get_direction(from, next_waypoint, model)
         dist_to_target = norm(dir)
         # edge case
         if dist_to_target ≈ 0.
             from = next_waypoint
-            popfirst!(pathfinder.agent_paths[agent.id])
-            if isempty(agent.id, pathfinder)
+            popfirst!(pathfinder.agent_paths[getid(agent)])
+            if isempty(getid(agent), pathfinder)
                 next_pos = next_waypoint
                 break
             end
@@ -145,9 +145,9 @@ function Agents.move_along_route!(
             # without this, agent would end up at (0.85, 0.85) instead of (1, 0.2)
             from = next_waypoint
             dt -= dist_to_target / speed
-            popfirst!(pathfinder.agent_paths[agent.id])
+            popfirst!(pathfinder.agent_paths[getid(agent)])
             # if the path is now empty, go directly to the end
-            if isempty(agent.id, pathfinder)
+            if isempty(getid(agent), pathfinder)
                 next_pos = next_waypoint
                 break
             end

--- a/src/submodules/pathfinding/astar_grid.jl
+++ b/src/submodules/pathfinding/astar_grid.jl
@@ -12,7 +12,7 @@ function Agents.plan_route!(
 ) where {D}
     path = find_path(pathfinder, agent.pos, dest)
     isnothing(path) && return
-    pathfinder.agent_paths[agent.id] = path
+    pathfinder.agent_paths[getid(agent)] = path
 end
 
 """
@@ -46,7 +46,7 @@ function Agents.plan_best_route!(
     end
 
     isnothing(best_target) && return
-    pathfinder.agent_paths[agent.id] = best_path
+    pathfinder.agent_paths[getid(agent)] = best_path
     return best_target
 end
 
@@ -63,9 +63,9 @@ function Agents.move_along_route!(
     model::ABM{<:GridSpace{D}},
     pathfinder::AStar{D}
 ) where {D}
-    isempty(agent.id, pathfinder) && return
-    move_agent!(agent, first(pathfinder.agent_paths[agent.id]), model)
-    popfirst!(pathfinder.agent_paths[agent.id])
+    isempty(getid(agent), pathfinder) && return
+    move_agent!(agent, first(pathfinder.agent_paths[getid(agent)]), model)
+    popfirst!(pathfinder.agent_paths[getid(agent)])
 end
 
 """

--- a/src/submodules/schedulers.jl
+++ b/src/submodules/schedulers.jl
@@ -248,9 +248,9 @@ function (sched::ByKind)(model::ABM)
         curr_idx = n_agents[cont_idx]
         ids_kind = sched.ids[cont_idx]
         if curr_idx <= length(ids_kind)
-            ids_kind[curr_idx] = agent.id
+            ids_kind[curr_idx] = getid(agent)
         else
-            push!(ids_kind, agent.id)
+            push!(ids_kind, getid(agent))
         end
     end
 


### PR DESCRIPTION
I'd like to create a custom function which retrieves the id of a type of agent where the `id` can't be retrieved with `getproperty`. I could specialize `getproperty` but I'd like not to have branches in it, so having a specialize function to retrieve the id is better. Even if we forget in the future to use it, no big deal, it's just to facilitate some internal testing