### PR TITLE
Add chebyshev_distance utility function

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -168,6 +168,7 @@ get_spatial_property
 get_spatial_index
 interacting_pairs
 elastic_collision!
+chebyshev_distance
 euclidean_distance
 manhattan_distance
 ```

--- a/test/grid_space_tests.jl
+++ b/test/grid_space_tests.jl
@@ -115,6 +115,22 @@ using StableRNGs
     end
 
     @testset "Distances" begin
+    @testset "Chebyshev Distance" begin
+        model = StandardABM(GridAgent{2}, SpaceType((12, 10); metric = :chebyshev, periodic = true), warn_deprecation = false)
+        a = add_agent!((1, 6), model)
+        b = add_agent!((11, 4), model)
+        @test chebyshev_distance(a, b, model) ≈ 2
+
+        model = StandardABM(GridAgent{2}, SpaceType((12, 10); metric = :chebyshev, periodic = false), warn_deprecation = false)
+        a = add_agent!((1, 6), model)
+        b = add_agent!((11, 4), model)
+        @test chebyshev_distance(a, b, model) ≈ 10
+
+        model = StandardABM(GridAgent{2}, SpaceType((10, 10); periodic = (false, true)), warn_deprecation = false)
+        a = add_agent!((1, 1), model)
+        b = add_agent!((9, 9), model)
+        @test chebyshev_distance(a, b, model) ≈ 8
+    end
     @testset "Euclidean distance" begin
         model = StandardABM(GridAgent{2}, SpaceType((12, 10); periodic = true), warn_deprecation = false)
         a = add_agent!((1, 6), model)


### PR DESCRIPTION
From a recent online discussion ([Computing distances in Agents.jl](https://discourse.julialang.org/t/computing-distances-in-agents-jl/134375)), it seems that while `:euclidean` and `:manhattan` metrics have their own distance functions, the function is missing for `metric = :chebyshev`.

This pull request introduces the `chebyshev_distance` function and tests, implemented consistently with the existing distance functions.