### PR TITLE
Fix heatarray for ContinuousSpace in abmplot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
-version = "7.0.0"
+version = "7.0.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/docs/src/devdocs.md
+++ b/docs/src/devdocs.md
@@ -102,11 +102,12 @@ Agents.spaceplot!
 
 ### Heatmap handling
 
-Heatmaps are extracted and plotted automatically, but your space may require some special handling for that. For example `ContinuousSpace` needs to map the finite heatmap matrix over the continuous space.
+Heatmaps are extracted and plotted automatically, but your space may require some special handling for that. For example `ContinuousSpace` needs to extract a finite heatmap matrix from the continuous space.
 If you require such handling, extend:
 
 ```@docs
 Agents.abmheatmap!
+Agents.abmplot_heatarray
 ```
 
 ## Designing a new Pathfinder Cost Metric

--- a/ext/AgentsVisualizations/src/abmplot.jl
+++ b/ext/AgentsVisualizations/src/abmplot.jl
@@ -82,8 +82,8 @@ function Agents.abmplot!(
     # other plots
     Agents.spaceplot!(ax, abmspace(modelobs[]); spaceplotkwargs...)
     if !isnothing(heatarray)
-        heatobs = @lift(abmplot_heatarray($(modelobs), heatarray))
-        hmap = abmheatmap!(ax, abmobs, abmspace(modelobs[]), heatobs, heatkwargs)
+        heatobs = @lift(Agents.abmplot_heatarray($(modelobs), heatarray))
+        hmap = Agents.abmheatmap!(ax, abmobs, abmspace(modelobs[]), heatobs, heatkwargs)
         add_colorbar && Colorbar(ax.parent[1, 1][1, 2], hmap; width = 20, label = colorbar_label)
         # TODO: Set colorbar to be "glued" to axis
         # Problem with the following code, which comes from the tutorial

--- a/ext/AgentsVisualizations/src/spaces/continuous.jl
+++ b/ext/AgentsVisualizations/src/spaces/continuous.jl
@@ -5,7 +5,7 @@ function Agents.space_axis_limits(space::ContinuousSpace)
     return Tuple(zip(o, e))
 end
 
-function Agents.abmheatmap!(ax, abmobs::ABMObservable, space::ContinuousSpace, heatobs, heatkwargs)
+function abmheatmap!(ax, abmobs::ABMObservable, space::ContinuousSpace, heatobs, heatkwargs)
     nbinx, nbiny = size(heatobs[])
     extx, exty = space.extent
     coordx = range(0, extx; length = nbinx)

--- a/ext/AgentsVisualizations/src/spaces/continuous.jl
+++ b/ext/AgentsVisualizations/src/spaces/continuous.jl
@@ -17,6 +17,8 @@ function Agents.abmheatmap!(ax, abmobs::ABMObservable, space::ContinuousSpace, h
     return hmap
 end
 
+abmplot_heatarray(model::ABM{<:ContinuousSpace}, heatarray) =
+    Agents.get_data(model, heatarray, identity)
 
 ## Inspection
 

--- a/ext/AgentsVisualizations/src/spaces/continuous.jl
+++ b/ext/AgentsVisualizations/src/spaces/continuous.jl
@@ -5,7 +5,7 @@ function Agents.space_axis_limits(space::ContinuousSpace)
     return Tuple(zip(o, e))
 end
 
-function abmheatmap!(ax, abmobs::ABMObservable, space::ContinuousSpace, heatobs, heatkwargs)
+function Agents.abmheatmap!(ax, abmobs::ABMObservable, space::ContinuousSpace, heatobs, heatkwargs)
     nbinx, nbiny = size(heatobs[])
     extx, exty = space.extent
     coordx = range(0, extx; length = nbinx)
@@ -17,7 +17,7 @@ function abmheatmap!(ax, abmobs::ABMObservable, space::ContinuousSpace, heatobs,
     return hmap
 end
 
-abmplot_heatarray(model::ABM{<:ContinuousSpace}, heatarray) =
+Agents.abmplot_heatarray(model::ABM{<:ContinuousSpace}, heatarray) =
     Agents.get_data(model, heatarray, identity)
 
 ## Inspection

--- a/ext/AgentsVisualizations/src/spaces/grid.jl
+++ b/ext/AgentsVisualizations/src/spaces/grid.jl
@@ -5,7 +5,7 @@ function Agents.space_axis_limits(space::Agents.AbstractGridSpace)
     return Tuple(zip(o, e))
 end
 
-function abmheatmap!(ax, abmobs::ABMObservable, space::Agents.AbstractGridSpace, heatobs, heatkwargs)
+function Agents.abmheatmap!(ax, abmobs::ABMObservable, space::Agents.AbstractGridSpace, heatobs, heatkwargs)
     hmap = Makie.heatmap!(
         ax, heatobs;
         colormap = JULIADYNAMICS_CMAP, heatkwargs...
@@ -13,7 +13,7 @@ function abmheatmap!(ax, abmobs::ABMObservable, space::Agents.AbstractGridSpace,
     return hmap
 end
 
-function abmplot_heatarray(model::ABM{<:Agents.AbstractGridSpace}, heatarray)
+function Agents.abmplot_heatarray(model::ABM{<:Agents.AbstractGridSpace}, heatarray)
     matrix = Agents.get_data(model, heatarray, identity)
     if !(matrix isa AbstractMatrix) || size(matrix) ≠ size(abmspace(model))
         error("The heat array property must yield a matrix of same size as the grid!")

--- a/src/visualizations.jl
+++ b/src/visualizations.jl
@@ -273,6 +273,14 @@ Return the heatmap (or otherwise) plot object so that a Colorbar can be assigned
 function abmheatmap! end
 
 """
+    abmplot_heatarray(model::ABM{<:S}, heatarray) where {S<:AbstractSpace} end
+
+Return a 2D matrix that will be plotted as a heatmap using the `heatarray`
+keyword of `abmplot`.
+"""
+function abmplot_heatarray end
+
+"""
     spaceplot!(ax, space::AbstractSpace; spaceplotkwargs...)
 
 Add a space-dependent plot to `ax`. `spaceplotkwargs` is propagated


### PR DESCRIPTION
Fixes #1203

It seems that whilst abmplot_heatarray exists for GridSpace, the same is not present for ContinuousSpace. 

This PR is a minimal change which introduces the function to fix the issue. 