### PR TITLE
Fix iter_agent_groups for `fastest` scheduler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Agents"
 uuid = "46ada45e-f475-11e8-01d0-f70cc89e6671"
-version = "7.0.2"
+version = "7.0.4"
 authors = ["George Datseris", "Tim DuBois", "Aayush Sabharwal", "Ali Vahdati", "Adriano Meligrana"]
 
 [deps]

--- a/src/core/higher_order_iteration.jl
+++ b/src/core/higher_order_iteration.jl
@@ -9,11 +9,14 @@ e.g. `(agent1, agent7, agent8)`. `order` must be larger than `1` but has no uppe
 
 Index order is provided by the `scheduler` input which is a scheduler.
 """
-function iter_agent_groups(order::Int, model::ABM; scheduler=abmscheduler(model))
-    tuples = (map(i -> model[i], collect(scheduler(model))) for _ in 1:order)
-    @info "tuple type" typeof(tuples)
-    Iterators.product(tuples)
+function iter_agent_groups(::Val{N}, model::ABM; scheduler=abmscheduler(model)) where {N}
+    base_iter = Iterators.map(i -> model[i], scheduler(model))
+    iters = ntuple(_ -> base_iter, Val(N))
+    return Iterators.product(iters...)
 end
+
+iter_agent_groups(order::Int, model::ABM; scheduler=abmscheduler(model)) = iter_agent_groups(Val(order), model; scheduler)
+
 """
     map_agent_groups(order::Int, f::Function, model::ABM; kwargs...)
     map_agent_groups(order::Int, f::Function, model::ABM, filter::Function; kwargs...)

--- a/src/core/higher_order_iteration.jl
+++ b/src/core/higher_order_iteration.jl
@@ -9,9 +9,11 @@ e.g. `(agent1, agent7, agent8)`. `order` must be larger than `1` but has no uppe
 
 Index order is provided by the `scheduler` input which is a scheduler.
 """
-iter_agent_groups(order::Int, model::ABM; scheduler = abmscheduler(model)) =
-    Iterators.product((map(i -> model[i], scheduler(model)) for _ in 1:order)...)
-
+function iter_agent_groups(order::Int, model::ABM; scheduler=abmscheduler(model))
+    tuples = (map(i -> model[i], collect(scheduler(model))) for _ in 1:order)
+    @info "tuple type" typeof(tuples)
+    Iterators.product(tuples)
+end
 """
     map_agent_groups(order::Int, f::Function, model::ABM; kwargs...)
     map_agent_groups(order::Int, f::Function, model::ABM, filter::Function; kwargs...)
@@ -36,7 +38,7 @@ map_agent_groups(order::Int, f::Function, model::ABM, filter::Function; kwargs..
     index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler = Schedulers.ByID)
 Return an iterable of agent ids in the model, meeting the `filter` criteria if used.
 """
-index_mapped_groups(order::Int, model::ABM; scheduler = Schedulers.ByID()) =
+index_mapped_groups(order::Int, model::ABM; scheduler=Schedulers.ByID()) =
     Iterators.product((schedule(model, scheduler) for _ in 1:order)...)
-index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler = Schedulers.ByID()) =
+index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler=Schedulers.ByID()) =
     Iterators.filter(filter, Iterators.product((scheduler(model) for _ in 1:order)...))

--- a/src/core/higher_order_iteration.jl
+++ b/src/core/higher_order_iteration.jl
@@ -9,13 +9,13 @@ e.g. `(agent1, agent7, agent8)`. `order` must be larger than `1` but has no uppe
 
 Index order is provided by the `scheduler` input which is a scheduler.
 """
-function iter_agent_groups(::Val{N}, model::ABM; scheduler=abmscheduler(model)) where {N}
+function iter_agent_groups(::Val{N}, model::ABM; scheduler = abmscheduler(model)) where {N}
     base_iter = Iterators.map(i -> model[i], scheduler(model))
     iters = ntuple(_ -> base_iter, Val(N))
     return Iterators.product(iters...)
 end
 
-iter_agent_groups(order::Int, model::ABM; scheduler=abmscheduler(model)) = iter_agent_groups(Val(order), model; scheduler)
+iter_agent_groups(order::Int, model::ABM; scheduler = abmscheduler(model)) = iter_agent_groups(Val(order), model; scheduler)
 
 """
     map_agent_groups(order::Int, f::Function, model::ABM; kwargs...)
@@ -41,7 +41,7 @@ map_agent_groups(order::Int, f::Function, model::ABM, filter::Function; kwargs..
     index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler = Schedulers.ByID)
 Return an iterable of agent ids in the model, meeting the `filter` criteria if used.
 """
-index_mapped_groups(order::Int, model::ABM; scheduler=Schedulers.ByID()) =
+index_mapped_groups(order::Int, model::ABM; scheduler = Schedulers.ByID()) =
     Iterators.product((schedule(model, scheduler) for _ in 1:order)...)
-index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler=Schedulers.ByID()) =
+index_mapped_groups(order::Int, model::ABM, filter::Function; scheduler = Schedulers.ByID()) =
     Iterators.filter(filter, Iterators.product((scheduler(model) for _ in 1:order)...))

--- a/test/iterable_tests.jl
+++ b/test/iterable_tests.jl
@@ -1,4 +1,5 @@
 using Agents
+import Agents.Schedulers: fastest, Randomly, ByID, Partially, ByProperty, ByType
 @testset "Iterate over Agents" begin
     TESTSYSTEMSIZE = 10.
 
@@ -10,19 +11,18 @@ using Agents
 
     test_space = ContinuousSpace((TESTSYSTEMSIZE, TESTSYSTEMSIZE))
     model_step!(model) = nothing
-    test_model = StandardABM(TestAgent, test_space; model_step!)
+    test_model = StandardABM(Agent6, test_space; model_step!)
 
     #direct adding leads to correct position
-    add_agent!(SVector(0.5, 0.5), TestAgent, test_model)
-    add_agent!(SVector(0.5, 0.1), TestAgent, test_model)
-
-    #Debug Schedulker:
-    scheduler = abmscheduler(test_model)
-    @info "info: scheduler returns:" scheduler(test_model)
+    add_agent!(SVector(0.5, 0.5), Agent6, test_model; vel=SVector(0.0, 0.0), weight=0)
+    add_agent!(SVector(0.5, 0.1), Agent6, test_model; vel=SVector(0.0, 0.0), weight=0)
 
     #iter agent groups should return an iterable
-    result = iter_agent_groups(2, test_model)
-    @test Base.isiterable(typeof(result))
-
-
+    for scheduler in [fastest, Randomly(), ByID(), Partially(1), ByProperty(:weight)]
+        @testset "Itermap with Scheduler: $scheduler" begin
+            result = iter_agent_groups(2, test_model; scheduler)
+            @test Base.isiterable(typeof(result))
+            @test map_agent_groups(2, _ -> true, test_model; scheduler) |> all
+        end
+    end
 end

--- a/test/iterable_tests.jl
+++ b/test/iterable_tests.jl
@@ -1,0 +1,28 @@
+using Agents
+@testset "Iterate over Agents" begin
+    TESTSYSTEMSIZE = 10.
+
+    @kwdef mutable struct TestAgent <: AbstractAgent
+        id::Int
+        pos::SVector{2,Float64}
+        vel::SVector{2,Float64} = SVector(0., 0.)
+    end
+
+    test_space = ContinuousSpace((TESTSYSTEMSIZE, TESTSYSTEMSIZE))
+    model_step!(model) = nothing
+    test_model = StandardABM(TestAgent, test_space; model_step!)
+
+    #direct adding leads to correct position
+    add_agent!(SVector(0.5, 0.5), TestAgent, test_model)
+    add_agent!(SVector(0.5, 0.1), TestAgent, test_model)
+
+    #Debug Schedulker:
+    scheduler = abmscheduler(test_model)
+    @info "info: scheduler returns:" scheduler(test_model)
+
+    #iter agent groups should return an iterable
+    result = iter_agent_groups(2, test_model)
+    @test Base.isiterable(typeof(result))
+
+
+end

--- a/test/iterable_tests.jl
+++ b/test/iterable_tests.jl
@@ -1,12 +1,12 @@
 using Agents
 import Agents.Schedulers: fastest, Randomly, ByID, Partially, ByProperty, ByType
 @testset "Iterate over Agents" begin
-    TESTSYSTEMSIZE = 10.
+    TESTSYSTEMSIZE = 10.0
 
     @kwdef mutable struct TestAgent <: AbstractAgent
         id::Int
-        pos::SVector{2,Float64}
-        vel::SVector{2,Float64} = SVector(0., 0.)
+        pos::SVector{2, Float64}
+        vel::SVector{2, Float64} = SVector(0.0, 0.0)
     end
 
     test_space = ContinuousSpace((TESTSYSTEMSIZE, TESTSYSTEMSIZE))
@@ -14,8 +14,8 @@ import Agents.Schedulers: fastest, Randomly, ByID, Partially, ByProperty, ByType
     test_model = StandardABM(Agent6, test_space; model_step!)
 
     #direct adding leads to correct position
-    add_agent!(SVector(0.5, 0.5), Agent6, test_model; vel=SVector(0.0, 0.0), weight=0)
-    add_agent!(SVector(0.5, 0.1), Agent6, test_model; vel=SVector(0.0, 0.0), weight=0)
+    add_agent!(SVector(0.5, 0.5), Agent6, test_model; vel = SVector(0.0, 0.0), weight = 0)
+    add_agent!(SVector(0.5, 0.1), Agent6, test_model; vel = SVector(0.0, 0.0), weight = 0)
 
     #iter agent groups should return an iterable
     for scheduler in [fastest, Randomly(), ByID(), Partially(1), ByProperty(:weight)]

--- a/test/iterable_tests.jl
+++ b/test/iterable_tests.jl
@@ -1,4 +1,4 @@
-using Agents
+using Agents, Test
 import Agents.Schedulers: fastest, Randomly, ByID, Partially, ByProperty, ByType
 @testset "Iterate over Agents" begin
     TESTSYSTEMSIZE = 10.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ end
     weight::Float64
 end
 
-@agent struct Agent6(ContinuousAgent{2, Float64})
+@agent struct Agent6(ContinuousAgent{2,Float64})
     weight::Float64
 end
 
@@ -49,7 +49,7 @@ end
     f2::Int
 end
 
-@agent struct Agent8(ContinuousAgent{2, Float64})
+@agent struct Agent8(ContinuousAgent{2,Float64})
     f1::Bool
     f2::Int
 end
@@ -61,7 +61,7 @@ Agent8(id, pos; f1, f2) = Agent8(id, pos, f1, f2)
     group::Int
 end
 
-@agent struct Bird(ContinuousAgent{2, Float64})
+@agent struct Bird(ContinuousAgent{2,Float64})
     speed::Float64
     cohere_factor::Float64
     separation::Float64
@@ -70,14 +70,14 @@ end
     visual_distance::Float64
 end
 
-function schelling_model(ModelType, SpaceType, ContainerType; numagents = 30, griddims = (8, 8), min_to_be_happy = 3)
+function schelling_model(ModelType, SpaceType, ContainerType; numagents=30, griddims=(8, 8), min_to_be_happy=3)
     @assert numagents < prod(griddims)
-    space = SpaceType(griddims, periodic = false)
+    space = SpaceType(griddims, periodic=false)
     properties = Dict(:min_to_be_happy => min_to_be_happy)
     model = ModelType(
-        SchellingAgent2, space, agent_step! = schelling_model_agent_step!,
-        properties = properties, scheduler = Schedulers.Randomly(),
-        container = ContainerType, rng = StableRNG(10)
+        SchellingAgent2, space, (agent_step!)=schelling_model_agent_step!,
+        properties=properties, scheduler=Schedulers.Randomly(),
+        container=ContainerType, rng=StableRNG(10)
     )
     for n in 1:numagents
         add_agent_single!(SchellingAgent2, model, false, n < numagents / 2 ? 1 : 2)
@@ -101,22 +101,22 @@ function schelling_model_agent_step!(agent, model)
 end
 
 function flocking_model(
-        ModelType, ContainerType;
-        n_birds = 10,
-        speed = 1.0,
-        cohere_factor = 0.25,
-        separation = 4.0,
-        separate_factor = 0.25,
-        match_factor = 0.01,
-        visual_distance = 2.0,
-        extent = (10, 10),
-        spacing = visual_distance,
-    )
+    ModelType, ContainerType;
+    n_birds=10,
+    speed=1.0,
+    cohere_factor=0.25,
+    separation=4.0,
+    separate_factor=0.25,
+    match_factor=0.01,
+    visual_distance=2.0,
+    extent=(10, 10),
+    spacing=visual_distance,
+)
     space2d = ContinuousSpace(extent; spacing)
     model = ModelType(
-        Bird, space2d, agent_step! = flocking_model_agent_step!,
-        scheduler = Schedulers.Randomly(), rng = StableRNG(10),
-        container = ContainerType
+        Bird, space2d, (agent_step!)=flocking_model_agent_step!,
+        scheduler=Schedulers.Randomly(), rng=StableRNG(10),
+        container=ContainerType
     )
     for _ in 1:n_birds
         vel = rand(abmrng(model), SVector{2}) .* 2 .- 1
@@ -158,6 +158,8 @@ function flocking_model_agent_step!(bird, model)
 end
 
 @testset "Agents.jl Tests" begin
+    include("iterable_tests.jl")
+    #=
     include("package_sanity_tests.jl")
     include("model_creation_tests.jl")
     include("api_tests.jl")
@@ -177,4 +179,5 @@ end
     include("new_space_tests.jl")
     include("reinforcement_learning_tests.jl")
     include("rl_extension_tests.jl")
+    =#
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ end
     weight::Float64
 end
 
-@agent struct Agent6(ContinuousAgent{2,Float64})
+@agent struct Agent6(ContinuousAgent{2, Float64})
     weight::Float64
 end
 
@@ -49,7 +49,7 @@ end
     f2::Int
 end
 
-@agent struct Agent8(ContinuousAgent{2,Float64})
+@agent struct Agent8(ContinuousAgent{2, Float64})
     f1::Bool
     f2::Int
 end
@@ -61,7 +61,7 @@ Agent8(id, pos; f1, f2) = Agent8(id, pos, f1, f2)
     group::Int
 end
 
-@agent struct Bird(ContinuousAgent{2,Float64})
+@agent struct Bird(ContinuousAgent{2, Float64})
     speed::Float64
     cohere_factor::Float64
     separation::Float64
@@ -70,14 +70,14 @@ end
     visual_distance::Float64
 end
 
-function schelling_model(ModelType, SpaceType, ContainerType; numagents=30, griddims=(8, 8), min_to_be_happy=3)
+function schelling_model(ModelType, SpaceType, ContainerType; numagents = 30, griddims = (8, 8), min_to_be_happy = 3)
     @assert numagents < prod(griddims)
-    space = SpaceType(griddims, periodic=false)
+    space = SpaceType(griddims, periodic = false)
     properties = Dict(:min_to_be_happy => min_to_be_happy)
     model = ModelType(
-        SchellingAgent2, space, (agent_step!)=schelling_model_agent_step!,
-        properties=properties, scheduler=Schedulers.Randomly(),
-        container=ContainerType, rng=StableRNG(10)
+        SchellingAgent2, space, (agent_step!) = schelling_model_agent_step!,
+        properties = properties, scheduler = Schedulers.Randomly(),
+        container = ContainerType, rng = StableRNG(10)
     )
     for n in 1:numagents
         add_agent_single!(SchellingAgent2, model, false, n < numagents / 2 ? 1 : 2)
@@ -101,22 +101,22 @@ function schelling_model_agent_step!(agent, model)
 end
 
 function flocking_model(
-    ModelType, ContainerType;
-    n_birds=10,
-    speed=1.0,
-    cohere_factor=0.25,
-    separation=4.0,
-    separate_factor=0.25,
-    match_factor=0.01,
-    visual_distance=2.0,
-    extent=(10, 10),
-    spacing=visual_distance,
-)
+        ModelType, ContainerType;
+        n_birds = 10,
+        speed = 1.0,
+        cohere_factor = 0.25,
+        separation = 4.0,
+        separate_factor = 0.25,
+        match_factor = 0.01,
+        visual_distance = 2.0,
+        extent = (10, 10),
+        spacing = visual_distance,
+    )
     space2d = ContinuousSpace(extent; spacing)
     model = ModelType(
-        Bird, space2d, (agent_step!)=flocking_model_agent_step!,
-        scheduler=Schedulers.Randomly(), rng=StableRNG(10),
-        container=ContainerType
+        Bird, space2d, (agent_step!) = flocking_model_agent_step!,
+        scheduler = Schedulers.Randomly(), rng = StableRNG(10),
+        container = ContainerType
     )
     for _ in 1:n_birds
         vel = rand(abmrng(model), SVector{2}) .* 2 .- 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,7 +159,6 @@ end
 
 @testset "Agents.jl Tests" begin
     include("iterable_tests.jl")
-    #=
     include("package_sanity_tests.jl")
     include("model_creation_tests.jl")
     include("api_tests.jl")
@@ -179,5 +178,4 @@ end
     include("new_space_tests.jl")
     include("reinforcement_learning_tests.jl")
     include("rl_extension_tests.jl")
-    =#
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ function schelling_model(ModelType, SpaceType, ContainerType; numagents = 30, gr
     space = SpaceType(griddims, periodic = false)
     properties = Dict(:min_to_be_happy => min_to_be_happy)
     model = ModelType(
-        SchellingAgent2, space, (agent_step!) = schelling_model_agent_step!,
+        SchellingAgent2, space, agent_step! = schelling_model_agent_step!,
         properties = properties, scheduler = Schedulers.Randomly(),
         container = ContainerType, rng = StableRNG(10)
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,7 +114,7 @@ function flocking_model(
     )
     space2d = ContinuousSpace(extent; spacing)
     model = ModelType(
-        Bird, space2d, (agent_step!) = flocking_model_agent_step!,
+        Bird, space2d, agent_step! = flocking_model_agent_step!,
         scheduler = Schedulers.Randomly(), rng = StableRNG(10),
         container = ContainerType
     )


### PR DESCRIPTION
tackles #1210 by moving `Base.map` to `Iterators.map` and Ntuples.

Includes tests with schedulers `fastest, Randomly(), ByID(), Partially(1), ByProperty(:weight)`, but any scheduler returning either a Vector or a KeySet should be fine.

```
Test Summary:   | Pass  Total     Time
Agents.jl Tests | 2514   2514  2m36.3s
     Testing Agents tests passed 
```